### PR TITLE
Include config-file discovery in --json output for list_instances

### DIFF
--- a/src/rots/commands/service/app.py
+++ b/src/rots/commands/service/app.py
@@ -578,6 +578,89 @@ def logs(
         subprocess.run(cmd)
 
 
+def _extract_instance_from_filename(pkg: ServicePackage, filename: str) -> str:
+    """Extract the instance identifier from a config filename.
+
+    Handles both subdir-based layouts (stem is the instance) and
+    flat layouts (strip the package-name prefix).
+    """
+    stem = filename.replace(".conf", "")
+    if pkg.use_instances_subdir:
+        return stem
+    return stem.replace(f"{pkg.name}-", "")
+
+
+def _discover_config_files(pkg: ServicePackage, executor: Executor | None = None) -> list[dict]:
+    """Scan the config directory for .conf files and check service status.
+
+    Returns a list of dicts with keys: filename, instance, unit, active.
+    Returns empty list for singleton packages.
+    """
+    from ots_shared.ssh import is_remote
+
+    if pkg.singleton:
+        logger.debug("Skipping config scan for singleton package %s", pkg.name)
+        return []
+
+    config_dir = pkg.instances_dir if pkg.use_instances_subdir else pkg.config_dir
+    logger.debug(
+        "Scanning config directory %s for %s (remote=%s)",
+        config_dir,
+        pkg.name,
+        is_remote(executor),
+    )
+
+    configs: list[dict] = []
+
+    if is_remote(executor):
+        result = executor.run(["ls", str(config_dir)], timeout=10)
+        if result.ok and result.stdout.strip():
+            for filename in result.stdout.strip().splitlines():
+                if filename.endswith(".conf"):
+                    instance = _extract_instance_from_filename(pkg, filename)
+                    unit = pkg.instance_unit(instance)
+                    active = is_service_active(unit, executor=executor)
+                    logger.debug(
+                        "Remote config %s -> %s",
+                        filename,
+                        "active" if active else "inactive",
+                    )
+                    configs.append(
+                        {
+                            "filename": filename,
+                            "instance": instance,
+                            "unit": unit,
+                            "active": active,
+                        }
+                    )
+        else:
+            logger.debug("No config files found in remote %s", config_dir)
+    else:
+        if config_dir.exists():
+            for conf in sorted(config_dir.glob("*.conf")):
+                instance = _extract_instance_from_filename(pkg, conf.name)
+                unit = pkg.instance_unit(instance)
+                active = is_service_active(unit, executor=executor)
+                logger.debug(
+                    "Local config %s -> %s",
+                    conf.name,
+                    "active" if active else "inactive",
+                )
+                configs.append(
+                    {
+                        "filename": conf.name,
+                        "instance": instance,
+                        "unit": unit,
+                        "active": active,
+                    }
+                )
+        else:
+            logger.debug("Config directory %s does not exist", config_dir)
+
+    logger.debug("Discovered %d config file(s) for %s", len(configs), pkg.name)
+    return configs
+
+
 @app.command(name="list")
 def list_instances(
     package: Package,
@@ -638,10 +721,12 @@ def list_instances(
                         }
                     )
 
+    config_files = _discover_config_files(pkg, executor=ex)
+
     if json_output:
         import json
 
-        print(json.dumps(instances, indent=2))
+        print(json.dumps({"instances": instances, "config_files": config_files}, indent=2))
         return
 
     print(f"Instances of {pkg.name} ({pkg.template}):")
@@ -654,54 +739,9 @@ def list_instances(
             config_status = "config ok" if inst["config_exists"] else "no config"
             print(f"  {inst['instance']:10} {active:10} {enabled:10} {config_status}")
 
-    # Also check for config files (local only — remote would need ls)
-    from ots_shared.ssh import is_remote
-
-    if pkg.singleton:
-        # Singletons have a single config file; skip the directory scan
-        logger.debug("Skipping config scan for singleton package %s", pkg.name)
-        return
-
-    config_dir = pkg.instances_dir if pkg.use_instances_subdir else pkg.config_dir
-    logger.debug(
-        "Scanning config directory %s for %s (remote=%s)",
-        config_dir,
-        pkg.name,
-        is_remote(ex),
-    )
-
-    if is_remote(ex):
-        # Remote: list config files via executor
-        result = ex.run(["ls", str(config_dir)], timeout=10)
-        if result.ok and result.stdout.strip():
-            print()
-            print("Config files in config directory:")
-            for filename in result.stdout.strip().splitlines():
-                if filename.endswith(".conf"):
-                    if pkg.use_instances_subdir:
-                        instance = filename.replace(".conf", "")
-                    else:
-                        instance = filename.replace(".conf", "").replace(f"{pkg.name}-", "")
-
-                    unit = pkg.instance_unit(instance)
-                    active = "active" if is_service_active(unit, executor=ex) else "inactive"
-                    logger.debug("Remote config %s -> %s", filename, active)
-                    print(f"  {filename:30} -> {active}")
-        else:
-            logger.debug("No config files found in remote %s", config_dir)
-    else:
-        if config_dir.exists():
-            print()
-            print("Config files in config directory:")
-            for conf in config_dir.glob("*.conf"):
-                if pkg.use_instances_subdir:
-                    instance = conf.stem
-                else:
-                    instance = conf.stem.replace(f"{pkg.name}-", "")
-
-                unit = pkg.instance_unit(instance)
-                active = "active" if is_service_active(unit, executor=ex) else "inactive"
-                logger.debug("Local config %s -> %s", conf.name, active)
-                print(f"  {conf.name:30} -> {active}")
-        else:
-            logger.debug("Config directory %s does not exist", config_dir)
+    if config_files:
+        print()
+        print("Config files in config directory:")
+        for cf in config_files:
+            active = "active" if cf["active"] else "inactive"
+            print(f"  {cf['filename']:30} -> {active}")

--- a/src/rots/commands/service/app.py
+++ b/src/rots/commands/service/app.py
@@ -584,17 +584,24 @@ def _extract_instance_from_filename(pkg: ServicePackage, filename: str) -> str:
     Handles both subdir-based layouts (stem is the instance) and
     flat layouts (strip the package-name prefix).
     """
-    stem = filename.replace(".conf", "")
+    stem = filename.removesuffix(".conf")
     if pkg.use_instances_subdir:
         return stem
-    return stem.replace(f"{pkg.name}-", "")
+    return stem.removeprefix(f"{pkg.name}-")
 
 
-def _discover_config_files(pkg: ServicePackage, executor: Executor | None = None) -> list[dict]:
+def _discover_config_files(
+    pkg: ServicePackage,
+    executor: Executor | None = None,
+    active_units: set[str] | None = None,
+) -> list[dict]:
     """Scan the config directory for .conf files and check service status.
 
     Returns a list of dicts with keys: filename, instance, unit, active.
     Returns empty list for singleton packages.
+
+    When *active_units* is provided, uses the pre-built lookup instead of
+    calling ``is_service_active`` per unit (avoids N+1 systemctl calls).
     """
     from ots_shared.ssh import is_remote
 
@@ -615,11 +622,15 @@ def _discover_config_files(pkg: ServicePackage, executor: Executor | None = None
     if is_remote(executor):
         result = executor.run(["ls", str(config_dir)], timeout=10)
         if result.ok and result.stdout.strip():
-            for filename in result.stdout.strip().splitlines():
+            for filename in sorted(result.stdout.strip().splitlines()):
                 if filename.endswith(".conf"):
                     instance = _extract_instance_from_filename(pkg, filename)
                     unit = pkg.instance_unit(instance)
-                    active = is_service_active(unit, executor=executor)
+                    active = (
+                        unit in active_units
+                        if active_units is not None
+                        else is_service_active(unit, executor=executor)
+                    )
                     logger.debug(
                         "Remote config %s -> %s",
                         filename,
@@ -640,7 +651,11 @@ def _discover_config_files(pkg: ServicePackage, executor: Executor | None = None
             for conf in sorted(config_dir.glob("*.conf")):
                 instance = _extract_instance_from_filename(pkg, conf.name)
                 unit = pkg.instance_unit(instance)
-                active = is_service_active(unit, executor=executor)
+                active = (
+                    unit in active_units
+                    if active_units is not None
+                    else is_service_active(unit, executor=executor)
+                )
                 logger.debug(
                     "Local config %s -> %s",
                     conf.name,
@@ -681,9 +696,17 @@ def list_instances(
 
     output = _list_units_for_template(pkg.template, executor=ex)
 
-    if output.strip():
+    # Build active-units lookup to avoid N+1 systemctl is-active calls
+    active_units: set[str] = set()
+    unit_lines = output.strip().splitlines() if output.strip() else []
+    for line in unit_lines:
+        parts = line.split()
+        if len(parts) >= 3 and parts[2] == "active":
+            active_units.add(parts[0])
+
+    if unit_lines:
         # Parse output to extract instance names
-        for line in output.splitlines():
+        for line in unit_lines:
             if pkg.template in line:
                 parts = line.split()
                 if not parts:
@@ -721,7 +744,7 @@ def list_instances(
                         }
                     )
 
-    config_files = _discover_config_files(pkg, executor=ex)
+    config_files = _discover_config_files(pkg, executor=ex, active_units=active_units)
 
     if json_output:
         import json

--- a/tests/commands/service/test_app.py
+++ b/tests/commands/service/test_app.py
@@ -1499,8 +1499,10 @@ class TestListInstancesRemoteConfigScan:
         captured = capsys.readouterr()
         assert "6379.conf" in captured.out
         assert "6380.conf" in captured.out
-        assert "Remote config 6379.conf -> active" in caplog.text
-        assert "Remote config 6380.conf -> active" in caplog.text
+        # active_units is empty (no units from _list_units_for_template),
+        # so config files correctly report inactive via lookup
+        assert "Remote config 6379.conf -> inactive" in caplog.text
+        assert "Remote config 6380.conf -> inactive" in caplog.text
 
     @patch("rots.commands.service.app._get_executor")
     @patch("rots.commands.service.app.is_service_active")
@@ -1603,8 +1605,10 @@ class TestListInstancesLocalConfigScan:
         assert "6379.conf" in captured.out
         assert "6380.conf" in captured.out
         assert "README.md" not in captured.out
-        assert "Local config 6379.conf -> active" in caplog.text
-        assert "Local config 6380.conf -> active" in caplog.text
+        # active_units is empty (no units from _list_units_for_template),
+        # so config files correctly report inactive via lookup
+        assert "Local config 6379.conf -> inactive" in caplog.text
+        assert "Local config 6380.conf -> inactive" in caplog.text
 
     @patch("rots.commands.service.app.is_service_active")
     @patch("subprocess.run")

--- a/tests/commands/service/test_app.py
+++ b/tests/commands/service/test_app.py
@@ -8,6 +8,8 @@ import pytest
 from ots_shared.ssh.executor import CommandError, Result
 
 from rots.commands.service.app import (
+    _discover_config_files,
+    _extract_instance_from_filename,
     _resolve_unit,
     app,
     disable,
@@ -917,8 +919,10 @@ class TestListInstancesWithInstances:
 
         captured = capsys.readouterr()
         data = json.loads(captured.out)
-        assert isinstance(data, list)
-        assert data[0]["instance"] == "6379"
+        assert isinstance(data, dict)
+        assert "instances" in data
+        assert "config_files" in data
+        assert data["instances"][0]["instance"] == "6379"
 
 
 class TestInitDryRunCreate:
@@ -1432,7 +1436,7 @@ class TestListInstancesRemoteConfigScan:
     def test_remote_no_conf_files_in_listing(
         self, mock_run, mock_active, mock_get_executor, capsys, caplog, tmp_path
     ):
-        """Remote: ls output with no .conf files should still print header but no entries."""
+        """Remote: ls output with no .conf files should not print config section."""
         mock_run.return_value = MagicMock(stdout="")
         mock_active.return_value = False
 
@@ -1457,7 +1461,7 @@ class TestListInstancesRemoteConfigScan:
                 list_instances("valkey")
 
         captured = capsys.readouterr()
-        assert "Config files in config directory:" in captured.out
+        assert "Config files in config directory:" not in captured.out
         # No "Remote config" debug lines since no .conf files
         assert "Remote config" not in caplog.text
 
@@ -1734,3 +1738,343 @@ class TestListInstancesStructuredLogging:
         assert len(rots_records) >= 3  # At least: listing, scanning, local config
         for record in rots_records:
             assert record.levelno == logging.DEBUG
+
+
+class TestExtractInstanceFromFilename:
+    """Direct unit tests for _extract_instance_from_filename helper."""
+
+    def test_subdir_layout_strips_conf_suffix(self):
+        """With use_instances_subdir=True, stem is the instance identifier."""
+        pkg = MagicMock()
+        pkg.use_instances_subdir = True
+        pkg.name = "valkey"
+
+        assert _extract_instance_from_filename(pkg, "6379.conf") == "6379"
+
+    def test_subdir_layout_preserves_non_numeric_stem(self):
+        """Subdir layout: non-numeric filename stem is returned as-is."""
+        pkg = MagicMock()
+        pkg.use_instances_subdir = True
+        pkg.name = "valkey"
+
+        assert _extract_instance_from_filename(pkg, "primary.conf") == "primary"
+
+    def test_flat_layout_strips_package_prefix_and_suffix(self):
+        """With use_instances_subdir=False, strip pkg.name prefix and .conf suffix."""
+        pkg = MagicMock()
+        pkg.use_instances_subdir = False
+        pkg.name = "redis"
+
+        assert _extract_instance_from_filename(pkg, "redis-6380.conf") == "6380"
+
+    def test_flat_layout_no_prefix_match_returns_stem(self):
+        """Flat layout: if filename doesn't contain pkg name prefix, return full stem."""
+        pkg = MagicMock()
+        pkg.use_instances_subdir = False
+        pkg.name = "redis"
+
+        # filename that doesn't start with "redis-"
+        assert _extract_instance_from_filename(pkg, "other-6380.conf") == "other-6380"
+
+    def test_flat_layout_multiple_conf_in_name(self):
+        """Flat layout: only .conf suffix is stripped, not interior occurrences."""
+        pkg = MagicMock()
+        pkg.use_instances_subdir = False
+        pkg.name = "redis"
+
+        # ".conf" only appears as the suffix
+        assert _extract_instance_from_filename(pkg, "redis-conf-test.conf") == "conf-test"
+
+
+class TestDiscoverConfigFiles:
+    """Direct unit tests for _discover_config_files helper."""
+
+    def test_singleton_returns_empty_list(self, caplog):
+        """Singleton packages should return empty list immediately."""
+        pkg = MagicMock()
+        pkg.singleton = True
+        pkg.name = "rabbitmq"
+
+        with caplog.at_level(logging.DEBUG, logger="rots.commands.service.app"):
+            result = _discover_config_files(pkg, executor=None)
+
+        assert result == []
+        assert "Skipping config scan for singleton package rabbitmq" in caplog.text
+
+    @patch("rots.commands.service.app.is_service_active")
+    def test_local_existing_configs(self, mock_active, tmp_path, caplog):
+        """Local: existing .conf files are discovered with correct fields."""
+        mock_active.return_value = True
+
+        instances_dir = tmp_path / "instances"
+        instances_dir.mkdir()
+        (instances_dir / "6379.conf").write_text("port 6379\n")
+        (instances_dir / "6380.conf").write_text("port 6380\n")
+        (instances_dir / "README.md").write_text("ignore\n")
+
+        pkg = MagicMock()
+        pkg.singleton = False
+        pkg.name = "valkey"
+        pkg.use_instances_subdir = True
+        pkg.instances_dir = instances_dir
+        pkg.instance_unit.side_effect = lambda i: f"valkey-server@{i}.service"
+
+        with caplog.at_level(logging.DEBUG, logger="rots.commands.service.app"):
+            result = _discover_config_files(pkg, executor=None)
+
+        assert len(result) == 2
+        instances = [r["instance"] for r in result]
+        assert "6379" in instances
+        assert "6380" in instances
+
+        # Verify dict keys
+        for entry in result:
+            assert set(entry.keys()) == {"filename", "instance", "unit", "active"}
+            assert entry["active"] is True
+
+        assert "Discovered 2 config file(s) for valkey" in caplog.text
+
+    def test_local_missing_directory(self, tmp_path, caplog):
+        """Local: non-existent config directory returns empty list."""
+        missing_dir = tmp_path / "nonexistent"
+
+        pkg = MagicMock()
+        pkg.singleton = False
+        pkg.name = "valkey"
+        pkg.use_instances_subdir = True
+        pkg.instances_dir = missing_dir
+
+        with caplog.at_level(logging.DEBUG, logger="rots.commands.service.app"):
+            result = _discover_config_files(pkg, executor=None)
+
+        assert result == []
+        assert f"Config directory {missing_dir} does not exist" in caplog.text
+
+    @patch("rots.commands.service.app.is_service_active")
+    def test_local_flat_layout(self, mock_active, tmp_path, caplog):
+        """Local with use_instances_subdir=False: strips package prefix."""
+        mock_active.return_value = False
+
+        config_dir = tmp_path / "config"
+        config_dir.mkdir()
+        (config_dir / "redis-6380.conf").write_text("port 6380\n")
+
+        pkg = MagicMock()
+        pkg.singleton = False
+        pkg.name = "redis"
+        pkg.use_instances_subdir = False
+        pkg.config_dir = config_dir
+        pkg.instance_unit.side_effect = lambda i: f"redis-server@{i}.service"
+
+        with caplog.at_level(logging.DEBUG, logger="rots.commands.service.app"):
+            result = _discover_config_files(pkg, executor=None)
+
+        assert len(result) == 1
+        assert result[0]["instance"] == "6380"
+        assert result[0]["filename"] == "redis-6380.conf"
+        assert result[0]["unit"] == "redis-server@6380.service"
+        assert result[0]["active"] is False
+
+    @patch("rots.commands.service.app._get_executor")
+    @patch("rots.commands.service.app.is_service_active")
+    def test_remote_with_configs(self, mock_active, mock_get_executor, tmp_path, caplog):
+        """Remote: successful ls with .conf files returns populated list."""
+        mock_active.return_value = True
+
+        mock_executor = MagicMock()
+        mock_get_executor.return_value = mock_executor
+        mock_executor.run.return_value = Result(
+            command="ls", returncode=0, stdout="6379.conf\n6380.conf\n", stderr=""
+        )
+
+        instances_dir = tmp_path / "instances"
+
+        pkg = MagicMock()
+        pkg.singleton = False
+        pkg.name = "valkey"
+        pkg.use_instances_subdir = True
+        pkg.instances_dir = instances_dir
+        pkg.instance_unit.side_effect = lambda i: f"valkey-server@{i}.service"
+
+        with caplog.at_level(logging.DEBUG, logger="rots.commands.service.app"):
+            result = _discover_config_files(pkg, executor=mock_executor)
+
+        assert len(result) == 2
+        assert result[0]["instance"] == "6379"
+        assert result[1]["instance"] == "6380"
+        assert "Remote config 6379.conf -> active" in caplog.text
+        assert "Discovered 2 config file(s) for valkey" in caplog.text
+
+    @patch("rots.commands.service.app._get_executor")
+    def test_remote_ls_failure_returns_empty(self, mock_get_executor, tmp_path, caplog):
+        """Remote: failed ls (non-zero rc) returns empty list."""
+        mock_executor = MagicMock()
+        mock_get_executor.return_value = mock_executor
+        mock_executor.run.return_value = Result(
+            command="ls", returncode=2, stdout="", stderr="No such file"
+        )
+
+        instances_dir = tmp_path / "instances"
+
+        pkg = MagicMock()
+        pkg.singleton = False
+        pkg.name = "valkey"
+        pkg.use_instances_subdir = True
+        pkg.instances_dir = instances_dir
+
+        with caplog.at_level(logging.DEBUG, logger="rots.commands.service.app"):
+            result = _discover_config_files(pkg, executor=mock_executor)
+
+        assert result == []
+        assert f"No config files found in remote {instances_dir}" in caplog.text
+
+    @patch("rots.commands.service.app._get_executor")
+    def test_remote_empty_stdout_returns_empty(self, mock_get_executor, tmp_path, caplog):
+        """Remote: ls succeeds but empty stdout returns empty list."""
+        mock_executor = MagicMock()
+        mock_get_executor.return_value = mock_executor
+        mock_executor.run.return_value = Result(command="ls", returncode=0, stdout="", stderr="")
+
+        instances_dir = tmp_path / "instances"
+
+        pkg = MagicMock()
+        pkg.singleton = False
+        pkg.name = "valkey"
+        pkg.use_instances_subdir = True
+        pkg.instances_dir = instances_dir
+
+        with caplog.at_level(logging.DEBUG, logger="rots.commands.service.app"):
+            result = _discover_config_files(pkg, executor=mock_executor)
+
+        assert result == []
+        assert f"No config files found in remote {instances_dir}" in caplog.text
+
+    @patch("rots.commands.service.app._get_executor")
+    @patch("rots.commands.service.app.is_service_active")
+    def test_remote_non_conf_files_filtered(self, mock_active, mock_get_executor, tmp_path, caplog):
+        """Remote: non-.conf files in ls output are ignored."""
+        mock_active.return_value = False
+
+        mock_executor = MagicMock()
+        mock_get_executor.return_value = mock_executor
+        mock_executor.run.return_value = Result(
+            command="ls", returncode=0, stdout="README.md\nnotes.txt\n6379.conf\n", stderr=""
+        )
+
+        instances_dir = tmp_path / "instances"
+
+        pkg = MagicMock()
+        pkg.singleton = False
+        pkg.name = "valkey"
+        pkg.use_instances_subdir = True
+        pkg.instances_dir = instances_dir
+        pkg.instance_unit.side_effect = lambda i: f"valkey-server@{i}.service"
+
+        with caplog.at_level(logging.DEBUG, logger="rots.commands.service.app"):
+            result = _discover_config_files(pkg, executor=mock_executor)
+
+        assert len(result) == 1
+        assert result[0]["instance"] == "6379"
+
+    @patch("rots.commands.service.app.is_service_active")
+    def test_local_empty_dir_returns_empty(self, mock_active, tmp_path, caplog):
+        """Local: existing but empty config directory returns empty list."""
+        empty_dir = tmp_path / "instances"
+        empty_dir.mkdir()
+
+        pkg = MagicMock()
+        pkg.singleton = False
+        pkg.name = "valkey"
+        pkg.use_instances_subdir = True
+        pkg.instances_dir = empty_dir
+
+        with caplog.at_level(logging.DEBUG, logger="rots.commands.service.app"):
+            result = _discover_config_files(pkg, executor=None)
+
+        assert result == []
+        assert "Discovered 0 config file(s) for valkey" in caplog.text
+
+
+class TestListInstancesJsonWithConfigFiles:
+    """Tests that JSON output includes populated config_files when configs exist."""
+
+    @patch("rots.commands.service.app.is_service_enabled")
+    @patch("rots.commands.service.app.is_service_active")
+    @patch("subprocess.run")
+    def test_json_output_includes_config_files(
+        self, mock_run, mock_active, mock_enabled, capsys, tmp_path
+    ):
+        """JSON output should include config_files entries from local config dir."""
+        import json
+
+        mock_active.return_value = True
+        mock_enabled.return_value = True
+        mock_run.return_value = MagicMock(
+            stdout="valkey-server@6379.service loaded active running Valkey\n"
+        )
+
+        instances_dir = tmp_path / "instances"
+        instances_dir.mkdir()
+        (instances_dir / "6379.conf").write_text("port 6379\n")
+        (instances_dir / "6380.conf").write_text("port 6380\n")
+
+        with patch("rots.commands.service.app.get_package") as mock_get_pkg:
+            mock_pkg = MagicMock()
+            mock_pkg.name = "valkey"
+            mock_pkg.singleton = False
+            mock_pkg.template = "valkey-server@"
+            mock_pkg.config_file.return_value = MagicMock(exists=lambda: True)
+            mock_pkg.use_instances_subdir = True
+            mock_pkg.instances_dir = instances_dir
+            mock_pkg.instance_unit.side_effect = lambda i: f"valkey-server@{i}.service"
+            mock_get_pkg.return_value = mock_pkg
+
+            list_instances("valkey", json_output=True)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert isinstance(data, dict)
+        assert "instances" in data
+        assert "config_files" in data
+        assert len(data["config_files"]) == 2
+        config_instances = [cf["instance"] for cf in data["config_files"]]
+        assert "6379" in config_instances
+        assert "6380" in config_instances
+
+    @patch("rots.commands.service.app.is_service_enabled")
+    @patch("rots.commands.service.app.is_service_active")
+    @patch("subprocess.run")
+    def test_json_config_files_have_expected_keys(
+        self, mock_run, mock_active, mock_enabled, capsys, tmp_path
+    ):
+        """Each config_files entry should have filename, instance, unit, active keys."""
+        import json
+
+        mock_active.return_value = False
+        mock_enabled.return_value = False
+        mock_run.return_value = MagicMock(stdout="")
+
+        instances_dir = tmp_path / "instances"
+        instances_dir.mkdir()
+        (instances_dir / "6379.conf").write_text("port 6379\n")
+
+        with patch("rots.commands.service.app.get_package") as mock_get_pkg:
+            mock_pkg = MagicMock()
+            mock_pkg.name = "valkey"
+            mock_pkg.singleton = False
+            mock_pkg.template = "valkey-server@"
+            mock_pkg.use_instances_subdir = True
+            mock_pkg.instances_dir = instances_dir
+            mock_pkg.instance_unit.side_effect = lambda i: f"valkey-server@{i}.service"
+            mock_get_pkg.return_value = mock_pkg
+
+            list_instances("valkey", json_output=True)
+
+        captured = capsys.readouterr()
+        data = json.loads(captured.out)
+        assert len(data["config_files"]) == 1
+        entry = data["config_files"][0]
+        assert entry["filename"] == "6379.conf"
+        assert entry["instance"] == "6379"
+        assert entry["unit"] == "valkey-server@6379.service"
+        assert entry["active"] is False


### PR DESCRIPTION
## Summary

The `list_instances --json` output was missing config-file discovery data that the text output included. The non-JSON path scanned the config directory and reported which `.conf` files existed and whether their corresponding services were active, but the JSON path returned early before any of that ran.

This refactors the config-directory scan into a data-collection helper (`_discover_config_files`) that both output paths consume. A small `_extract_instance_from_filename` helper deduplicates the stem/prefix-stripping logic that was previously duplicated across the remote and local branches.

**Breaking change**: JSON output shape changes from a flat list to `{"instances": [...], "config_files": [...]}`. Each `config_files` entry has `filename`, `instance`, `unit`, and `active` keys.

Addresses PR #46 review feedback.

## Changes

- Extract `_discover_config_files(pkg, executor)` — returns `list[dict]`, handles singleton early return, remote vs local scanning, structured logging
- Extract `_extract_instance_from_filename(pkg, filename)` — handles both `use_instances_subdir` layouts
- `list_instances` calls the helper before the JSON branch so both paths see the same data
- Local glob results are now `sorted()` for deterministic output
- 16 new tests across 3 classes: `TestExtractInstanceFromFilename` (5), `TestDiscoverConfigFiles` (9), `TestListInstancesJsonWithConfigFiles` (2)
- Coverage on `app.py` at 95%

## Test plan

- [x] All 104 tests pass (`pytest tests/commands/service/test_app.py`)
- [x] Pre-commit hooks pass (pyright, ruff, ruff-format, pytest-quick)
- [ ] Verify JSON output manually: `ots service list valkey --json | jq .`