### PR TITLE
Deduplicate init command, re-export shared types

### DIFF
--- a/packages/ots-shared/src/ots_shared/exit_codes.py
+++ b/packages/ots-shared/src/ots_shared/exit_codes.py
@@ -1,8 +1,8 @@
 """Standardised exit codes for all OTS CLI tools.
 
-All commands across ots-containers, hcloud-manager, otsinfra, and
-ots-cloudinit use this scheme so that CI pipelines and shell scripts
-can distinguish between different failure modes.
+All commands across rots, lots, and pots use this scheme so that CI
+pipelines and shell scripts can distinguish between different failure
+modes.
 
 Usage::
 

--- a/packages/ots-shared/src/ots_shared/init.py
+++ b/packages/ots-shared/src/ots_shared/init.py
@@ -11,7 +11,6 @@ Usage in a tool's ``cli.py``::
 
 from __future__ import annotations
 
-import logging
 import sys
 from pathlib import Path
 from typing import Annotated
@@ -24,8 +23,6 @@ from ots_shared.ssh.env import (
     create_gitignore,
     create_marker,
 )
-
-logger = logging.getLogger(__name__)
 
 app = cyclopts.App(
     name="init",
@@ -49,7 +46,9 @@ def init(
     ] = Path("."),
     force: Annotated[
         bool,
-        cyclopts.Parameter(help="Overwrite existing marker file"),
+        cyclopts.Parameter(
+            help="Overwrite existing init files (.otsinfra.yaml, .gitignore, .envrc template)"
+        ),
     ] = False,
 ) -> None:
     """Create .otsinfra.yaml environment marker.
@@ -67,7 +66,7 @@ def init(
         pots init -C ~/ops/environments/non-prod/eu2
     """
     target = directory.resolve()
-    environment = environment or target.name
+    environment = environment or target.name or "default"
     if not target.is_dir():
         print(f"Error: {target} is not a directory", file=sys.stderr)
         sys.exit(1)

--- a/packages/ots-shared/src/ots_shared/init.py
+++ b/packages/ots-shared/src/ots_shared/init.py
@@ -1,0 +1,89 @@
+"""Shared ``init`` sub-app for OTS CLI tools.
+
+Creates the ``.otsinfra.yaml`` marker file that signals "this is an
+OTS environment directory" to all OTS tools (lots, pots, rots).
+
+Usage in a tool's ``cli.py``::
+
+    from ots_shared.init import app as init_app
+    root_app.command(init_app)
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from typing import Annotated
+
+import cyclopts
+
+from ots_shared.ssh.env import (
+    DEFAULT_HOSTS,
+    create_envrc_template,
+    create_gitignore,
+    create_marker,
+)
+
+logger = logging.getLogger(__name__)
+
+app = cyclopts.App(
+    name="init",
+    help="Initialize an OTS environment directory.",
+)
+
+
+@app.default
+def init(
+    environment: Annotated[
+        str | None,
+        cyclopts.Parameter(help="Environment name (default: directory name)"),
+    ] = None,
+    *,
+    directory: Annotated[
+        Path,
+        cyclopts.Parameter(
+            name=["--directory", "-C"],
+            help="Target directory (default: current directory)",
+        ),
+    ] = Path("."),
+    force: Annotated[
+        bool,
+        cyclopts.Parameter(help="Overwrite existing marker file"),
+    ] = False,
+) -> None:
+    """Create .otsinfra.yaml environment marker.
+
+    The marker signals to lots, pots, and rots that the directory is
+    an OTS environment. Direnv handles env vars; this file carries
+    structured metadata (environment name, creation date).
+
+    When no environment name is given, uses the directory name.
+
+    Examples:
+        lots init              # uses current directory name
+        pots init              # same command, same result
+        lots init eu2
+        pots init -C ~/ops/environments/non-prod/eu2
+    """
+    target = directory.resolve()
+    environment = environment or target.name
+    if not target.is_dir():
+        print(f"Error: {target} is not a directory", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        path = create_marker(target, environment, hosts=DEFAULT_HOSTS, force=force)
+        print(f"Created {path}")
+    except FileExistsError as e:
+        print(f"Error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    for create_fn in (create_gitignore, create_envrc_template):
+        try:
+            path = create_fn(target, force=force)
+            print(f"Created {path}")
+        except FileExistsError as e:
+            print(f"Warning: {e}", file=sys.stderr)
+
+    print("Run 'direnv allow' after editing .envrc")

--- a/packages/ots-shared/src/ots_shared/ssh/env.py
+++ b/packages/ots-shared/src/ots_shared/ssh/env.py
@@ -195,6 +195,7 @@ def create_marker(
     environment: str,
     *,
     force: bool = False,
+    hosts: dict[str, dict[str, str]] | None = None,
     **metadata: str,
 ) -> Path:
     """Create ``.otsinfra.yaml`` in *directory*.
@@ -207,7 +208,7 @@ def create_marker(
     marker_path = directory / MARKER_FILENAME
     if marker_path.exists() and not force:
         raise FileExistsError(f"{marker_path} already exists (use --force to overwrite)")
-    content = generate_marker(environment, **metadata)
+    content = generate_marker(environment, hosts=hosts, **metadata)
     marker_path.write_text(content)
     return marker_path
 

--- a/packages/ots-shared/tests/ssh/test_env.py
+++ b/packages/ots-shared/tests/ssh/test_env.py
@@ -483,6 +483,28 @@ class TestCreateMarker:
         assert data["environment"] == "us-prod"
         assert "created" in data
 
+    def test_hosts_written_to_yaml(self, tmp_path):
+        hosts = {"db": {"private_ip_address": "10.0.0.11"}}
+        path = create_marker(tmp_path, "eu2", hosts=hosts)
+        data = load_marker(path)
+        assert data["hosts"] == {"db": {"private_ip_address": "10.0.0.11"}}
+
+    def test_hosts_multiple_roles(self, tmp_path):
+        hosts = {
+            "db": {"private_ip_address": "10.0.0.11"},
+            "web": {"private_ip_address": "10.0.0.12", "public_ip": "203.0.113.5"},
+        }
+        path = create_marker(tmp_path, "eu2", hosts=hosts)
+        data = load_marker(path)
+        assert data["hosts"]["db"]["private_ip_address"] == "10.0.0.11"
+        assert data["hosts"]["web"]["private_ip_address"] == "10.0.0.12"
+        assert data["hosts"]["web"]["public_ip"] == "203.0.113.5"
+
+    def test_hosts_none_omits_block(self, tmp_path):
+        path = create_marker(tmp_path, "eu2", hosts=None)
+        content = path.read_text()
+        assert "hosts:" not in content
+
 
 class TestGenerateEnvTemplate:
     """Tests for .otsinfra.env template generation."""

--- a/packages/ots-shared/tests/test_init.py
+++ b/packages/ots-shared/tests/test_init.py
@@ -1,8 +1,11 @@
 """Tests for ots_shared.init — shared init sub-app."""
 
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
 
-from ots_shared.init import app
+from ots_shared.init import app, init
 from ots_shared.ssh.env import MARKER_FILENAME, load_marker
 
 
@@ -94,3 +97,24 @@ class TestInitErrorCases:
         # Scaffold files should NOT have been overwritten
         assert (tmp_path / ".gitignore").read_text() == "old\n"
         assert (tmp_path / ".envrc").read_text() == "old\n"
+
+
+class TestInitDefaultEnvironmentFallback:
+    """Edge case: environment falls back to 'default' when directory name is empty."""
+
+    @patch("ots_shared.init.create_envrc_template")
+    @patch("ots_shared.init.create_gitignore")
+    @patch("ots_shared.init.create_marker")
+    def test_root_path_uses_default_as_environment_name(
+        self, mock_create_marker, mock_create_gitignore, mock_create_envrc_template
+    ):
+        """Path('/').resolve().name is '', so environment should fall back to 'default'."""
+        mock_create_marker.return_value = Path("/.otsinfra.yaml")
+        mock_create_gitignore.return_value = Path("/.gitignore")
+        mock_create_envrc_template.return_value = Path("/.envrc")
+
+        init(directory=Path("/"))
+
+        mock_create_marker.assert_called_once()
+        call_args = mock_create_marker.call_args
+        assert call_args[0][1] == "default"

--- a/packages/ots-shared/tests/test_init.py
+++ b/packages/ots-shared/tests/test_init.py
@@ -1,0 +1,96 @@
+"""Tests for ots_shared.init — shared init sub-app."""
+
+import pytest
+
+from ots_shared.init import app
+from ots_shared.ssh.env import MARKER_FILENAME, load_marker
+
+
+class TestInitCreatesFiles:
+    """The init command should create marker, .gitignore, and .envrc."""
+
+    def test_creates_marker_with_explicit_name(self, tmp_path):
+        with pytest.raises(SystemExit) as exc_info:
+            app(["myenv", "--directory", str(tmp_path)])
+        assert exc_info.value.code is None or exc_info.value.code == 0
+        marker = tmp_path / MARKER_FILENAME
+        assert marker.exists()
+        data = load_marker(marker)
+        assert data["environment"] == "myenv"
+
+    def test_defaults_name_from_directory(self, tmp_path):
+        target = tmp_path / "staging"
+        target.mkdir()
+        with pytest.raises(SystemExit) as exc_info:
+            app(["--directory", str(target)])
+        assert exc_info.value.code is None or exc_info.value.code == 0
+        data = load_marker(target / MARKER_FILENAME)
+        assert data["environment"] == "staging"
+
+    def test_creates_gitignore(self, tmp_path):
+        with pytest.raises(SystemExit):
+            app(["env1", "--directory", str(tmp_path)])
+        assert (tmp_path / ".gitignore").exists()
+
+    def test_creates_envrc(self, tmp_path):
+        with pytest.raises(SystemExit):
+            app(["env1", "--directory", str(tmp_path)])
+        assert (tmp_path / ".envrc").exists()
+
+
+class TestInitOverwriteBehavior:
+    """Marker file overwrite and --force flag."""
+
+    def test_refuses_overwrite_without_force(self, tmp_path):
+        marker = tmp_path / MARKER_FILENAME
+        marker.write_text("existing\n")
+        with pytest.raises(SystemExit) as exc_info:
+            app(["eu2", "--directory", str(tmp_path)])
+        assert exc_info.value.code == 1
+        assert marker.read_text() == "existing\n"
+
+    def test_force_overwrites_marker(self, tmp_path):
+        marker = tmp_path / MARKER_FILENAME
+        marker.write_text("old\n")
+        with pytest.raises(SystemExit):
+            app(["eu2", "--directory", str(tmp_path), "--force"])
+        data = load_marker(marker)
+        assert data["environment"] == "eu2"
+
+    def test_force_overwrites_gitignore(self, tmp_path):
+        gitignore = tmp_path / ".gitignore"
+        gitignore.write_text("old content\n")
+        with pytest.raises(SystemExit):
+            app(["env1", "--directory", str(tmp_path), "--force"])
+        assert gitignore.read_text() != "old content\n"
+
+    def test_force_overwrites_envrc(self, tmp_path):
+        envrc = tmp_path / ".envrc"
+        envrc.write_text("old content\n")
+        with pytest.raises(SystemExit):
+            app(["env1", "--directory", str(tmp_path), "--force"])
+        assert envrc.read_text() != "old content\n"
+
+
+class TestInitErrorCases:
+    """Error handling for invalid inputs."""
+
+    def test_nonexistent_directory_exits_with_code_1(self, tmp_path):
+        nonexistent = tmp_path / "does-not-exist"
+        with pytest.raises(SystemExit) as exc_info:
+            app(["env1", "--directory", str(nonexistent)])
+        assert exc_info.value.code == 1
+
+    def test_existing_scaffold_without_force_still_creates_marker(self, tmp_path):
+        """When .gitignore/.envrc exist but marker does not, marker is created
+        and warnings are emitted for the scaffold files."""
+        (tmp_path / ".gitignore").write_text("old\n")
+        (tmp_path / ".envrc").write_text("old\n")
+        with pytest.raises(SystemExit) as exc_info:
+            app(["env1", "--directory", str(tmp_path)])
+        # Marker should succeed (exit 0 or None), scaffold warnings go to stderr
+        assert exc_info.value.code is None or exc_info.value.code == 0
+        assert (tmp_path / MARKER_FILENAME).exists()
+        # Scaffold files should NOT have been overwritten
+        assert (tmp_path / ".gitignore").read_text() == "old\n"
+        assert (tmp_path / ".envrc").read_text() == "old\n"

--- a/src/rots/commands/common.py
+++ b/src/rots/commands/common.py
@@ -1,105 +1,37 @@
 # src/rots/commands/common.py
 
-"""Shared CLI annotations and constants for consistency across commands.
+"""Shared CLI annotations and constants for consistency across rots commands.
 
-All common flags use long+short forms for consistency:
-  --quiet, -q
-  --dry-run, -n
-  --yes, -y
-  --follow, -f
-  --lines, -l
-  --json, -j
-
-Exit code convention
---------------------
-All commands use this scheme so that CI pipelines and shell scripts can
-distinguish between different failure modes:
-
-  EXIT_SUCCESS  (0)  Command completed successfully; all operations applied.
-  EXIT_FAILURE  (1)  General command failure (unexpected error, bad arguments).
-  EXIT_PARTIAL  (2)  Partial success: at least one operation succeeded and at
-                     least one failed.  Check the output for details.
-  EXIT_PRECOND  (3)  Precondition not met: required configuration is absent
-                     (e.g. missing env file, missing Podman secrets, image not
-                     pulled).  No destructive action was attempted.
+Common flags and exit codes are defined in ots_shared and re-exported here
+so that rots commands import from a single location. Rots-specific type
+aliases (ImageRef, TagFlag) are defined locally below.
 """
 
 from typing import Annotated
 
 import cyclopts
 
-# ------------------------------------------------------------------
-# Exit code constants
-# ------------------------------------------------------------------
+# Re-export shared CLI type aliases
+from ots_shared.cli import DryRun, Follow, JsonOutput, Lines, Quiet, Yes
 
-EXIT_SUCCESS: int = 0
-"""Command completed successfully; all operations applied."""
+# Re-export shared exit codes
+from ots_shared.exit_codes import EXIT_FAILURE, EXIT_PARTIAL, EXIT_PRECOND, EXIT_SUCCESS
 
-EXIT_FAILURE: int = 1
-"""General command failure (unexpected error, bad arguments, etc.)."""
-
-EXIT_PARTIAL: int = 2
-"""Partial success: at least one operation succeeded and at least one failed."""
-
-EXIT_PRECOND: int = 3
-"""Precondition not met: required configuration is absent."""
-
-# Output control
-Quiet = Annotated[
-    bool,
-    cyclopts.Parameter(
-        name=["--quiet", "-q"],
-        help="Suppress output",
-    ),
+# Silence F401 for re-exports
+__all__ = [
+    "DryRun",
+    "Follow",
+    "JsonOutput",
+    "Lines",
+    "Quiet",
+    "Yes",
+    "EXIT_FAILURE",
+    "EXIT_PARTIAL",
+    "EXIT_PRECOND",
+    "EXIT_SUCCESS",
+    "ImageRef",
+    "TagFlag",
 ]
-
-DryRun = Annotated[
-    bool,
-    cyclopts.Parameter(
-        name=["--dry-run", "-n"],
-        help="Show what would be done without doing it",
-        negative=[],  # Disable --no-dry-run generation
-    ),
-]
-
-
-# Confirmation
-Yes = Annotated[
-    bool,
-    cyclopts.Parameter(
-        name=["--yes", "-y"],
-        help="Skip confirmation prompts",
-    ),
-]
-
-
-# Log viewing
-Follow = Annotated[
-    bool,
-    cyclopts.Parameter(
-        name=["--follow", "-f"],
-        help="Follow log output",
-    ),
-]
-
-Lines = Annotated[
-    int,
-    cyclopts.Parameter(
-        name=["--lines", "-l"],
-        help="Number of lines to show",
-    ),
-]
-
-
-# JSON output
-JsonOutput = Annotated[
-    bool,
-    cyclopts.Parameter(
-        name=["--json", "-j"],
-        help="Output as JSON",
-    ),
-]
-
 
 # Image reference annotations
 ImageRef = Annotated[

--- a/src/rots/config.py
+++ b/src/rots/config.py
@@ -514,7 +514,7 @@ class Config:
             return LocalExecutor()
 
         if resolved not in _ssh_cache:
-            logger.info("Connecting to %s ...", resolved)
+            logger.info("Connecting to %s...", resolved)
             try:
                 _ssh_cache[resolved] = ssh_connect(resolved)
             except ImportError:

--- a/src/rots/config.py
+++ b/src/rots/config.py
@@ -514,7 +514,7 @@ class Config:
             return LocalExecutor()
 
         if resolved not in _ssh_cache:
-            logger.info(f"Connecting to {resolved}...")
+            logger.info("Connecting to %s ...", resolved)
             try:
                 _ssh_cache[resolved] = ssh_connect(resolved)
             except ImportError:

--- a/tests/test_common_reexports.py
+++ b/tests/test_common_reexports.py
@@ -1,0 +1,99 @@
+"""Tests for rots.commands.common — re-exports from ots_shared."""
+
+import ots_shared.cli
+import ots_shared.exit_codes
+
+from rots.commands.common import (
+    EXIT_FAILURE,
+    EXIT_PARTIAL,
+    EXIT_PRECOND,
+    EXIT_SUCCESS,
+    DryRun,
+    Follow,
+    ImageRef,
+    JsonOutput,
+    Lines,
+    Quiet,
+    TagFlag,
+    Yes,
+)
+
+
+class TestCliAliasReexports:
+    """Re-exported CLI aliases must be the same objects as ots_shared.cli."""
+
+    def test_dry_run_is_same_object(self):
+        assert DryRun is ots_shared.cli.DryRun
+
+    def test_quiet_is_same_object(self):
+        assert Quiet is ots_shared.cli.Quiet
+
+    def test_yes_is_same_object(self):
+        assert Yes is ots_shared.cli.Yes
+
+    def test_follow_is_same_object(self):
+        assert Follow is ots_shared.cli.Follow
+
+    def test_lines_is_same_object(self):
+        assert Lines is ots_shared.cli.Lines
+
+    def test_json_output_is_same_object(self):
+        assert JsonOutput is ots_shared.cli.JsonOutput
+
+
+class TestExitCodeReexports:
+    """Re-exported exit codes must match ots_shared.exit_codes values."""
+
+    def test_exit_success(self):
+        assert EXIT_SUCCESS is ots_shared.exit_codes.EXIT_SUCCESS
+
+    def test_exit_failure(self):
+        assert EXIT_FAILURE is ots_shared.exit_codes.EXIT_FAILURE
+
+    def test_exit_partial(self):
+        assert EXIT_PARTIAL is ots_shared.exit_codes.EXIT_PARTIAL
+
+    def test_exit_precond(self):
+        assert EXIT_PRECOND is ots_shared.exit_codes.EXIT_PRECOND
+
+
+class TestRotsSpecificAliases:
+    """ImageRef and TagFlag are rots-specific and should not come from ots_shared."""
+
+    def test_image_ref_is_annotated(self):
+        import typing
+
+        assert typing.get_origin(ImageRef) is typing.Annotated
+
+    def test_tag_flag_is_annotated(self):
+        import typing
+
+        assert typing.get_origin(TagFlag) is typing.Annotated
+
+    def test_image_ref_not_in_ots_shared_cli(self):
+        assert not hasattr(ots_shared.cli, "ImageRef")
+
+    def test_tag_flag_not_in_ots_shared_cli(self):
+        assert not hasattr(ots_shared.cli, "TagFlag")
+
+
+class TestAllExports:
+    """__all__ should list every public name."""
+
+    def test_all_contains_cli_aliases(self):
+        from rots.commands import common
+
+        for name in ("DryRun", "Quiet", "Yes", "Follow", "Lines", "JsonOutput"):
+            assert name in common.__all__
+
+    def test_all_contains_exit_codes(self):
+        from rots.commands import common
+
+        for name in ("EXIT_SUCCESS", "EXIT_FAILURE", "EXIT_PARTIAL", "EXIT_PRECOND"):
+            assert name in common.__all__
+
+    def test_all_contains_rots_specific(self):
+        from rots.commands import common
+
+        for name in ("ImageRef", "TagFlag"):
+            assert name in common.__all__

--- a/tests/test_common_reexports.py
+++ b/tests/test_common_reexports.py
@@ -42,19 +42,31 @@ class TestCliAliasReexports:
 
 
 class TestExitCodeReexports:
-    """Re-exported exit codes must match ots_shared.exit_codes values."""
+    """Re-exported exit codes must be the ots_shared.exit_codes attributes."""
 
     def test_exit_success(self):
-        assert EXIT_SUCCESS is ots_shared.exit_codes.EXIT_SUCCESS
+        from rots.commands import common
+
+        assert common.EXIT_SUCCESS is ots_shared.exit_codes.EXIT_SUCCESS
+        assert EXIT_SUCCESS == ots_shared.exit_codes.EXIT_SUCCESS
 
     def test_exit_failure(self):
-        assert EXIT_FAILURE is ots_shared.exit_codes.EXIT_FAILURE
+        from rots.commands import common
+
+        assert common.EXIT_FAILURE is ots_shared.exit_codes.EXIT_FAILURE
+        assert EXIT_FAILURE == ots_shared.exit_codes.EXIT_FAILURE
 
     def test_exit_partial(self):
-        assert EXIT_PARTIAL is ots_shared.exit_codes.EXIT_PARTIAL
+        from rots.commands import common
+
+        assert common.EXIT_PARTIAL is ots_shared.exit_codes.EXIT_PARTIAL
+        assert EXIT_PARTIAL == ots_shared.exit_codes.EXIT_PARTIAL
 
     def test_exit_precond(self):
-        assert EXIT_PRECOND is ots_shared.exit_codes.EXIT_PRECOND
+        from rots.commands import common
+
+        assert common.EXIT_PRECOND is ots_shared.exit_codes.EXIT_PRECOND
+        assert EXIT_PRECOND == ots_shared.exit_codes.EXIT_PRECOND
 
 
 class TestRotsSpecificAliases:


### PR DESCRIPTION
## Summary
- Extract identical `init` command from lots/pots into `ots_shared.init` as a reusable cyclopts sub-app
- Replace duplicated type aliases and exit codes in `rots/commands/common.py` with re-exports from `ots_shared`
- Fix stale tool names in `exit_codes.py` docstring (was referencing legacy names)
- Use lazy `%s` formatting in `config.py` logger call

## Test plan
- [x] 10 new tests for `ots_shared/init.py` (marker creation, overwrite, force, error cases)
- [x] 17 new tests for rots re-exports (identity checks, `__all__` coverage)
- [x] All 221 ots-shared tests pass
- [x] All 2346 rots tests pass (5 skipped)