### PR TITLE
Fix: preserve full image path when OTS_REGISTRY is set

### DIFF
--- a/src/rots/config.py
+++ b/src/rots/config.py
@@ -84,8 +84,8 @@ def _strip_registry_prefix(image: str) -> str:
     """Strip the registry hostname from an OCI image reference, keeping the path.
 
     OCI convention: the first ``/``-delimited component is a registry hostname
-    when it contains a ``.`` or ``:``.  Otherwise the entire string is an
-    image path (e.g. ``library/nginx``).
+    when it contains a ``.`` or ``:``, or is ``localhost``.  Otherwise the
+    entire string is an image path (e.g. ``library/nginx``).
 
     Examples::
 
@@ -94,6 +94,9 @@ def _strip_registry_prefix(image: str) -> str:
 
         _strip_registry_prefix("registry:5000/org/app")
         # -> "org/app"
+
+        _strip_registry_prefix("localhost/image")
+        # -> "image"
 
         _strip_registry_prefix("onetimesecret/onetimesecret")
         # -> "onetimesecret/onetimesecret"  (no registry to strip)
@@ -105,7 +108,7 @@ def _strip_registry_prefix(image: str) -> str:
     if slash == -1:
         return image
     first_component = image[:slash]
-    if "." in first_component or ":" in first_component:
+    if "." in first_component or ":" in first_component or first_component == "localhost":
         return image[slash + 1 :]
     return image
 
@@ -245,6 +248,12 @@ class Config:
     def image_with_tag(self) -> str:
         return join_image_tag(self.image, self.tag)
 
+    def _apply_registry_override(self, image: str) -> str:
+        """Apply OTS_REGISTRY override to an image path."""
+        if self.registry:
+            return f"{self.registry}/{_strip_registry_prefix(image)}"
+        return image
+
     @property
     def effective_image(self) -> str:
         """Image path with OTS_REGISTRY override applied when set.
@@ -253,10 +262,7 @@ class Config:
         of the image path with the configured registry, preserving the
         full image path. When not set, returns self.image unchanged.
         """
-        if self.registry:
-            image_path = _strip_registry_prefix(self.image)
-            return f"{self.registry}/{image_path}"
-        return self.image
+        return self._apply_registry_override(self.image)
 
     @property
     def registry_auth_file(self) -> Path:
@@ -596,9 +602,7 @@ class Config:
                 # over the alias image.  The alias only supplies the image
                 # when no explicit override was given.
                 image = self.image if self._image_explicit else alias.image
-                if self.registry:
-                    image = f"{self.registry}/{_strip_registry_prefix(image)}"
-                return (image, alias.tag)
+                return (self._apply_registry_override(image), alias.tag)
 
         # Not an alias (or alias not set) — return as-is.
         # Callers that need a real tag (e.g. pull) should check for the

--- a/src/rots/config.py
+++ b/src/rots/config.py
@@ -246,6 +246,19 @@ class Config:
         return join_image_tag(self.image, self.tag)
 
     @property
+    def effective_image(self) -> str:
+        """Image path with OTS_REGISTRY override applied when set.
+
+        When OTS_REGISTRY is configured, replaces the registry hostname
+        of the image path with the configured registry, preserving the
+        full image path. When not set, returns self.image unchanged.
+        """
+        if self.registry:
+            image_path = _strip_registry_prefix(self.image)
+            return f"{self.registry}/{image_path}"
+        return self.image
+
+    @property
     def registry_auth_file(self) -> Path:
         """Container registry auth file path.
 
@@ -325,8 +338,7 @@ class Config:
         """Image path for private registry (requires OTS_REGISTRY env var)."""
         if not self.registry:
             return None
-        image_path = _strip_registry_prefix(self.image)
-        return f"{self.registry}/{image_path}"
+        return self.effective_image
 
     @property
     def private_image_with_tag(self) -> str | None:
@@ -584,12 +596,14 @@ class Config:
                 # over the alias image.  The alias only supplies the image
                 # when no explicit override was given.
                 image = self.image if self._image_explicit else alias.image
+                if self.registry:
+                    image = f"{self.registry}/{_strip_registry_prefix(image)}"
                 return (image, alias.tag)
 
         # Not an alias (or alias not set) — return as-is.
         # Callers that need a real tag (e.g. pull) should check for the
         # sentinel '@current' / '@rollback' and raise an appropriate error.
-        return (self.image, self.tag)
+        return (self.effective_image, self.tag)
 
     def resolved_image_with_tag(self, *, executor: Executor | None = None) -> str:
         """Operational image:tag string for podman pull/run.

--- a/tests/commands/image/test_app.py
+++ b/tests/commands/image/test_app.py
@@ -1175,6 +1175,7 @@ class TestPullPrivateRegistry:
         pull(private=True)
 
         # The podman subprocess should receive the private registry image
+        # effective_image strips ghcr.io registry, preserves onetimesecret/onetimesecret path
         cmd = mock_run.call_args[0][0]
         full_ref = " ".join(cmd)
         assert "registry.example.com/onetimesecret/onetimesecret:v1.0.0" in full_ref

--- a/tests/commands/instance/test_shell.py
+++ b/tests/commands/instance/test_shell.py
@@ -443,17 +443,23 @@ class TestShellSentinelRejection:
 
 
 class TestShellPrivateRegistry:
-    """shell should use private registry when OTS_REGISTRY is set."""
+    """shell should use private registry when OTS_REGISTRY is set.
+
+    Since resolve_image_tag() now applies OTS_REGISTRY centrally,
+    the mock return value includes the registry-applied image.
+    """
 
     def test_shell_uses_private_registry(self, mocker, tmp_path):
-        """shell should rewrite image to use OTS_REGISTRY."""
-        mock_config, mock_executor = _setup_shell_mocks(
+        """shell should use registry-applied image from resolve_image_tag."""
+        _mock_config, mock_executor = _setup_shell_mocks(
             mocker,
             tmp_path,
             tag="edge",
-            resolve_image_tag=(DEFAULT_IMAGE, "edge"),
+            resolve_image_tag=(
+                "container-registry.infra.onetime.co/onetimesecret/onetimesecret",
+                "edge",
+            ),
         )
-        mock_config.registry = "container-registry.infra.onetime.co"
 
         instance.shell(quiet=True)
 
@@ -462,13 +468,12 @@ class TestShellPrivateRegistry:
 
     def test_shell_no_registry_uses_default_image(self, mocker, tmp_path):
         """shell without OTS_REGISTRY should use default image path."""
-        mock_config, mock_executor = _setup_shell_mocks(
+        _mock_config, mock_executor = _setup_shell_mocks(
             mocker,
             tmp_path,
             tag="edge",
             resolve_image_tag=(DEFAULT_IMAGE, "edge"),
         )
-        mock_config.registry = None
 
         instance.shell(quiet=True)
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -720,6 +720,12 @@ class TestStripRegistryPrefix:
 
         assert _strip_registry_prefix("registry:5000/org/image") == "org/image"
 
+    def test_strips_localhost(self):
+        """Should strip localhost as a registry hostname per OCI convention."""
+        from rots.config import _strip_registry_prefix
+
+        assert _strip_registry_prefix("localhost/image") == "image"
+
     def test_preserves_path_without_registry(self):
         """Should preserve full path when first component has no dot or colon."""
         from rots.config import _strip_registry_prefix

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -705,6 +705,74 @@ class TestConfigPrivateImage:
         assert cfg.private_image == "myreg.example.com/team/webapp"
 
 
+class TestStripRegistryPrefix:
+    """Test _strip_registry_prefix() helper function."""
+
+    def test_strips_registry_with_dot(self):
+        """Should strip registry hostname containing a dot."""
+        from rots.config import _strip_registry_prefix
+
+        assert _strip_registry_prefix("ghcr.io/org/image") == "org/image"
+
+    def test_strips_registry_with_port(self):
+        """Should strip registry hostname containing a port."""
+        from rots.config import _strip_registry_prefix
+
+        assert _strip_registry_prefix("registry:5000/org/image") == "org/image"
+
+    def test_preserves_path_without_registry(self):
+        """Should preserve full path when first component has no dot or colon."""
+        from rots.config import _strip_registry_prefix
+
+        assert _strip_registry_prefix("onetimesecret/onetimesecret") == "onetimesecret/onetimesecret"
+
+    def test_bare_image_name(self):
+        """Should return bare image name unchanged."""
+        from rots.config import _strip_registry_prefix
+
+        assert _strip_registry_prefix("nginx") == "nginx"
+
+    def test_multi_component_path(self):
+        """Should preserve multi-component path after stripping registry."""
+        from rots.config import _strip_registry_prefix
+
+        assert (
+            _strip_registry_prefix("ghcr.io/onetimesecret/onetimesecret")
+            == "onetimesecret/onetimesecret"
+        )
+
+
+class TestEffectiveImage:
+    """Test Config.effective_image property."""
+
+    def test_no_registry_returns_image(self, monkeypatch):
+        """effective_image should return self.image when no OTS_REGISTRY is set."""
+        monkeypatch.delenv("OTS_REGISTRY", raising=False)
+        from rots.config import Config
+
+        cfg = Config()
+        assert cfg.effective_image == cfg.image
+
+    def test_with_registry_replaces_hostname(self, monkeypatch):
+        """effective_image should replace registry hostname, preserving full path."""
+        monkeypatch.setenv("OTS_REGISTRY", "private.registry.co")
+        monkeypatch.delenv("IMAGE", raising=False)
+        from rots.config import Config
+
+        cfg = Config()
+        # Default IMAGE is ghcr.io/onetimesecret/onetimesecret
+        assert cfg.effective_image == "private.registry.co/onetimesecret/onetimesecret"
+
+    def test_with_registry_and_custom_image(self, monkeypatch):
+        """IMAGE without registry prefix + OTS_REGISTRY should prepend registry."""
+        monkeypatch.setenv("OTS_REGISTRY", "private.registry.co")
+        monkeypatch.setenv("IMAGE", "onetimesecret/onetimesecret")
+        from rots.config import Config
+
+        cfg = Config()
+        assert cfg.effective_image == "private.registry.co/onetimesecret/onetimesecret"
+
+
 class TestConfigResolveImageTag:
     """Test Config.resolve_image_tag() with a real SQLite database."""
 
@@ -777,6 +845,34 @@ class TestConfigResolveImageTag:
         image, tag = cfg.resolve_image_tag()
         assert image == "myregistry/myimage"
         assert tag == "v3.0.0"
+
+    def test_resolve_applies_registry(self, monkeypatch, tmp_path):
+        """OTS_REGISTRY should be applied to the image in non-alias resolution."""
+        from rots.config import Config
+
+        monkeypatch.setenv("TAG", "v1.0.0")
+        monkeypatch.delenv("IMAGE", raising=False)
+        monkeypatch.setenv("OTS_REGISTRY", "private.registry.co")
+        cfg = Config(var_dir=tmp_path)
+        image, tag = cfg.resolve_image_tag()
+        assert image == "private.registry.co/onetimesecret/onetimesecret"
+        assert tag == "v1.0.0"
+
+    def test_resolve_alias_applies_registry(self, monkeypatch, tmp_path):
+        """OTS_REGISTRY should be applied to alias-resolved images."""
+        from rots import db
+        from rots.config import Config
+
+        db_path = tmp_path / "deployments.db"
+        db.init_db(db_path)
+        db.set_current(db_path, "ghcr.io/onetimesecret/onetimesecret", "v1.5.0")
+
+        monkeypatch.delenv("TAG", raising=False)
+        monkeypatch.setenv("OTS_REGISTRY", "private.registry.co")
+        cfg = Config(var_dir=tmp_path)
+        image, tag = cfg.resolve_image_tag()
+        assert image == "private.registry.co/onetimesecret/onetimesecret"
+        assert tag == "v1.5.0"
 
 
 class TestConfigValkeyService:

--- a/tests/test_image_reference_precedence.py
+++ b/tests/test_image_reference_precedence.py
@@ -325,3 +325,62 @@ def test_precedence_matrix(
     cfg = _apply_reference_overrides(cfg, reference=reference, tag_flag=tag_flag)
     assert cfg.image == expected_image
     assert cfg.tag == expected_tag
+
+
+class TestRegistryOverrideEndToEnd:
+    """End-to-end tests for OTS_REGISTRY override through the full resolution chain."""
+
+    def test_registry_with_explicit_image_and_tag(self, monkeypatch):
+        """OTS_REGISTRY + IMAGE (no registry prefix) + TAG -> registry/path:tag."""
+        monkeypatch.setenv("OTS_REGISTRY", "ghcr.io")
+        monkeypatch.setenv("IMAGE", "onetimesecret/onetimesecret")
+        monkeypatch.setenv("TAG", "v1")
+
+        cfg = Config()
+        assert cfg.resolved_image_with_tag() == "ghcr.io/onetimesecret/onetimesecret:v1"
+
+    def test_registry_with_default_image(self, monkeypatch):
+        """OTS_REGISTRY + default IMAGE + TAG -> replaces default registry."""
+        monkeypatch.setenv("OTS_REGISTRY", "private.registry.co")
+        monkeypatch.delenv("IMAGE", raising=False)
+        monkeypatch.setenv("TAG", "edge")
+
+        cfg = Config()
+        assert (
+            cfg.resolved_image_with_tag() == "private.registry.co/onetimesecret/onetimesecret:edge"
+        )
+
+    def test_no_registry_default_image(self, monkeypatch):
+        """No OTS_REGISTRY, default IMAGE, explicit TAG -> default registry."""
+        monkeypatch.delenv("OTS_REGISTRY", raising=False)
+        monkeypatch.delenv("IMAGE", raising=False)
+        monkeypatch.setenv("TAG", "v1")
+
+        cfg = Config()
+        assert cfg.resolved_image_with_tag() == "ghcr.io/onetimesecret/onetimesecret:v1"
+
+    def test_resolved_matches_effective_image_plus_tag(self, monkeypatch):
+        """resolved_image_with_tag() should equal effective_image:tag."""
+        monkeypatch.setenv("OTS_REGISTRY", "private.registry.co")
+        monkeypatch.delenv("IMAGE", raising=False)
+        monkeypatch.setenv("TAG", "v2.0.0")
+
+        cfg = Config()
+        expected = f"{cfg.effective_image}:{cfg.tag}"
+        assert cfg.resolved_image_with_tag() == expected
+
+    def test_registry_with_alias_resolution(self, monkeypatch, tmp_path):
+        """OTS_REGISTRY should apply to alias-resolved images."""
+        from rots import db
+
+        db_path = tmp_path / "deployments.db"
+        db.init_db(db_path)
+        db.set_current(db_path, "ghcr.io/onetimesecret/onetimesecret", "v1.5.0")
+
+        monkeypatch.delenv("TAG", raising=False)
+        monkeypatch.setenv("OTS_REGISTRY", "private.registry.co")
+        cfg = Config(var_dir=tmp_path)
+        assert (
+            cfg.resolved_image_with_tag()
+            == "private.registry.co/onetimesecret/onetimesecret:v1.5.0"
+        )


### PR DESCRIPTION
## Summary

When `OTS_REGISTRY` is set, the previous logic in the `shell` command used `.split("/")[-1]` to extract the image name — which reduced multi-component paths like `onetimesecret/onetimesecret` to just `onetimesecret`. This fix centralizes registry override logic in `Config.resolve_image_tag()` so all commands behave correctly, not just the ones that happened to have local workarounds.

The new `_extract_image_path()` helper identifies registry hostnames by checking whether the first path component contains a `.` or `:` (per OCI convention), then preserves everything else. So `OTS_REGISTRY=registry.co` + `IMAGE=docker.io/org/app` now correctly produces `registry.co/org/app` instead of `registry.co/app`.

## What changed

- `config.py`: added `_extract_image_path()` helper and `effective_image` property; updated `resolve_image_tag()` and simplified `private_image` to delegate to it
- `commands/instance/app.py`: removed the ad-hoc registry rewriting from `shell` — it now relies on `resolve_image_tag()` like every other command
- Tests updated across `test_config.py`, `test_image_reference_precedence.py`, `test_shell.py`, and `test_image/test_app.py` to reflect full path preservation and verify the centralized behavior

## Behavior change

Users relying on the buggy basename-only behavior (e.g. expecting `registry.co/app` from a multi-component image path) will see the corrected output `registry.co/org/app`. Default behavior when `OTS_REGISTRY` is unset is unchanged.