### PR TITLE
[#55] Two-phase provisioning: RPC verbs + operator bootstrap command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@ build/
 # Virtual environments
 .venv/
 venv/
-ENV/
 
 # IDE
 .idea/

--- a/docs/SIDECAR-SPEC.md
+++ b/docs/SIDECAR-SPEC.md
@@ -104,6 +104,25 @@ Discrete operations, not shell execution. Unknown commands are rejected.
 | `health` | `{port: int}` | HTTP health check result |
 | `status` | `{unit: string}` | Systemd unit status |
 | `instances.restart_all` | `{type?: string}` | Rolling restart of all instances |
+| `postgres.bootstrap_app` | `{app: string, owner_role: string, peer_ip: string, peer_id: string}` | Roles: `db`. Create role + database, generate password, deliver to `peer_id` via `secrets.deliver`. Returns `PostgresBootstrapAppData` `{role, database, password_delivered_to, changed}`. Idempotent: if `owner_role` already exists, short-circuits with `changed=False` (password cannot be re-derived). `changed: bool` surfaces whether state was mutated. |
+| `postgres.add_hba` | `{name: string, content: string}` | Roles: `db`. Write a `pg_hba.d/` drop-in (basename allowlist, `.conf` suffix enforced, no symlinks) and call `pg_reload_conf()`. Returns `PostgresAddHbaData` `{reloaded, changed}`. Idempotent: byte-for-byte comparison against existing file. `changed: bool`. |
+| `postgres.rotate_password` | `{role: string, peer_id: string}` | Roles: `db`. Generate a fresh password for an existing role and deliver it to `peer_id`. Returns `PostgresRotatePasswordData` `{delivered_to, changed}`. Non-idempotent by design — every call mints a new password. `changed: bool` is always `True` on success; kept for uniform result shape. |
+| `valkey.create_acl_user` | `{name: string, rules: list[string], peer_id: string}` | Roles: `db`. Create or update an ACL user, rotate token only when rules differ from stored form, persist via `ACL SAVE`, deliver token to `peer_id`. Returns `ValkeyCreateAclUserData` `{delivered_to, changed}`. Idempotent on rules; token rotates only on rule change. `changed: bool`. |
+| `valkey.reload_acl` | `{}` | Roles: `db`. Snapshot `ACL LIST`, run `ACL LOAD`, snapshot again; compares sorted hashes to detect observable difference. Returns `ValkeyReloadAclData` `{ok, changed}`. `ACL LOAD` always runs; `changed: bool` flips only when the in-memory state actually shifted. |
+| `secrets.deliver` | `{name: string, value: string, env_file?: string}` | Roles: `db`, `web`. Write-if-different of a named secret into the OTS env file. Hardened allowlists — see callout below. Returns `SecretsDeliverData` `{written, path, changed}`. Idempotent: identical value is a no-op (preserves mtime). `changed: bool`. |
+| `backup.install` | `{profile: string, target: string, schedule: string}` | Roles: `db`. Install `ots-backup-<profile>.service` + `.timer` + rclone fragment; `systemctl daemon-reload` and `enable --now` the timer. Profile names allowlisted (`db-daily`, `valkey-hourly`). Returns `BackupInstallData` `{unit, timer, changed}`. Idempotent: write-if-different + enable is a no-op when nothing differed. `changed: bool`. |
+| `backup.uninstall` | `{profile: string}` | Roles: `db`. `systemctl disable --now` the timer, unlink the three generated files, `daemon-reload` if anything was removed. Returns `BackupUninstallData` `{ok, changed}`. Idempotent: absent profile returns `changed=False`. `changed: bool`. |
+
+### `secrets.deliver` Allowlist
+
+The `secrets.deliver` handler is reachable from any peer that can publish on the sidecar's queue. Its surface is deliberately narrow:
+
+- `env_file`: allowlisted to `/etc/default/onetimesecret`. No other target accepted; default applied when omitted.
+- `name`: allowlisted to `PG_PASSWORD` and `VALKEY_PASSWORD`. Expanding this set requires a threat-model review.
+- Symlink defence: the target is `lstat`ed first; a symlink at the path is rejected before any write.
+- Atomic write: tempfile created in the same directory, `fsync`, `chmod`, then `os.rename` into place.
+- Mode `0640`: owner + group readable, not world-readable.
+- The secret value is never logged — only the `name` and target `path`.
 
 ### Staged Config Pattern
 
@@ -134,6 +153,40 @@ STRIPE_PUBLISHABLE_KEY
 ```
 
 Requests for unlisted keys return an error.
+
+## Two-phase provisioning
+
+New in issue #55. Cloud-init (`lots`) brings services to life; the sidecar (`rots`) handles application-level provisioning. The split is deliberate: cloud-init is good at installing packages, binding sockets, enabling auth mechanisms, and dropping a bootstrap principal from `LoadCredentialEncrypted`. It is a poor fit for generating passwords, creating roles, delivering secrets to peers, or installing backup jobs — operations that need coordination across hosts and idempotent receipts.
+
+### Phase 1 — cloud-init (`lots`)
+
+Scope: install `postgresql` / `valkey`, bind the local socket, configure peer auth (postgres) or drop a bootstrap ACL user + token (valkey). No application roles, no application databases, no secrets generated in `runcmd`. Tracked externally in `tools-monorepo#37` (Phase 1 of provisioning, lots side — the upstream dependency for this phase).
+
+### Phase 2 — sidecar (`rots`)
+
+Scope: everything above the "service is up" line. Generate application passwords, create roles / databases / ACL users / schemas, deliver secrets to peers via `secrets.deliver`, install and manage backup timers, manage `pg_hba.d/` drop-ins. Triggered by an operator command (`rots env bootstrap --env <env>`, not documented here — this spec is the sidecar contract, not the operator CLI).
+
+### Idempotency contract
+
+Every Phase 2 handler returns a `CommandResult` whose `data` payload includes `changed: bool`. A re-run of the same call against the same state is a no-op (`changed=False`). The one documented exception is `postgres.rotate_password`: it is non-idempotent by design (every call mints a fresh password) and its `changed` field is always `True` on success — the key is kept for uniform payload shape.
+
+### Role gating
+
+Role membership is declared at handler registration:
+
+```python
+@register_handler(Command.POSTGRES_BOOTSTRAP_APP, roles={"db"})
+```
+
+- Web sidecars register `secrets.deliver` plus the existing container-lifecycle commands (`restart.*`, `config.*`, `status`, etc.).
+- DB sidecars register everything: postgres, valkey, backup, secrets, plus container-lifecycle.
+- Wrong-role invocation is rejected by the dispatcher before reaching the handler; the caller receives a `CommandResult.fail` with an explicit role-mismatch error.
+
+### Cross-host delivery
+
+Handlers that generate secrets (`postgres.bootstrap_app`, `postgres.rotate_password`, `valkey.create_acl_user`) deliver the generated value to the web peer's sidecar by publishing `secrets.deliver` at `peer_id`. The operator workstation never sees the secret — it transits from db-sidecar to web-sidecar over the RabbitMQ control plane and is written into `/etc/default/onetimesecret` atomically. Delivery failure triggers a rollback (`DROP ROLE`, `ACL DELUSER`, or `ALTER ROLE ... PASSWORD NULL` depending on the handler).
+
+The routing piece — ensuring a publish at `peer_id` reaches that specific web host's sidecar and no other — depends on `tools-monorepo#12` (per-host queue routing). That dependency is external to this repo and gates the operator command's end-to-end flow, not the handlers themselves (handlers are correct in isolation; the transport just has to deliver).
 
 ## Message Format
 

--- a/src/rots/commands/env/app.py
+++ b/src/rots/commands/env/app.py
@@ -25,6 +25,7 @@ from rots.environment_file import (
 from rots.quadlet import DEFAULT_ENV_FILE
 
 from ..common import DryRun, JsonOutput
+from .bootstrap import bootstrap as _bootstrap_command
 from .server_init import app as _server_init_app
 
 if TYPE_CHECKING:
@@ -39,6 +40,11 @@ app = cyclopts.App(
 
 # Server-side initialization (was top-level `rots init`, now `rots env init`)
 app.command(_server_init_app)
+
+# Two-phase provisioning bootstrap (issue #55). Implemented in bootstrap.py so
+# it can be imported as a module-level function (``bootstrap._get_rpc_client``
+# is the test seam).
+app.command(_bootstrap_command, name="bootstrap")
 
 
 def _file_exists(path: Path, executor: Executor) -> bool:

--- a/src/rots/commands/env/bootstrap.py
+++ b/src/rots/commands/env/bootstrap.py
@@ -1,0 +1,390 @@
+# src/rots/commands/env/bootstrap.py
+
+"""`rots env bootstrap` -- operator-facing command that drives the two-phase
+provisioning handlers registered on the db sidecar.
+
+The command is deliberately thin: read ``.otsinfra.yaml``, issue four RPC
+calls to the db sidecar in order, surface per-step receipts. The db sidecar
+owns cross-host secret delivery; this command never addresses the web
+sidecar directly.
+
+Call sequence::
+
+    1. postgres.bootstrap_app   (or postgres.rotate_password when --rotate)
+    2. valkey.create_acl_user
+    3. postgres.add_hba         (role must exist first)
+    4. backup.install           (skipped when no backup block)
+
+Exit codes follow the project convention:
+
+    0  EXIT_SUCCESS  -- every step ok (or --dry-run printed its plan)
+    1  EXIT_FAILURE  -- an RPC failed, timed out, or the remote returned an error
+    3  EXIT_PRECOND  -- ``.otsinfra.yaml`` missing or schema-invalid
+
+The RPC client factory :func:`_get_rpc_client` is the test seam -- tests
+monkeypatch ``bootstrap._get_rpc_client`` to return an
+:class:`~rots.commands.sidecar.handlers._transport.InProcessRpcClient`.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Annotated, Any
+
+import cyclopts
+
+from rots.commands.common import (
+    EXIT_FAILURE,
+    EXIT_PRECOND,
+    EXIT_SUCCESS,
+    DryRun,
+    JsonOutput,
+)
+from rots.commands.sidecar.handlers._transport import RabbitMqRpcClient
+from rots.infra_marker import EnvConfig, InfraMarkerError, load_env_config
+from rots.sidecar.commands import Command, CommandResult
+
+if TYPE_CHECKING:
+    from rots.commands.sidecar.handlers._transport import RpcClient
+
+logger = logging.getLogger(__name__)
+
+# Per-step RPC timeout (seconds). Matches handler-internal expectations --
+# bootstrap_app + create_acl_user do a sub-publish to secrets.deliver with a
+# 10s inner timeout, so we give the outer call enough head-room to complete.
+_RPC_TIMEOUT: float = 30.0
+
+
+def _get_rpc_client() -> RpcClient:
+    """Return an :class:`RpcClient` bound to the active broker.
+
+    Test seam: tests monkeypatch this function to return an
+    :class:`InProcessRpcClient`. Production returns a fresh
+    :class:`RabbitMqRpcClient`; :class:`RabbitMQConfig` is loaded per-publish
+    inside the client.
+    """
+    return RabbitMqRpcClient()
+
+
+# --- step plumbing --------------------------------------------------------
+
+
+@dataclass
+class _StepReceipt:
+    """One step's outcome, serialisable for ``--json`` output."""
+
+    name: str
+    host: str
+    params: dict[str, Any]
+    success: bool = False
+    changed: bool = False
+    data: dict[str, Any] | None = None
+    warnings: list[str] = field(default_factory=list)
+    error: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "host": self.host,
+            "params": self.params,
+            "success": self.success,
+            "changed": self.changed,
+            "data": self.data,
+            "warnings": list(self.warnings),
+            "error": self.error,
+        }
+
+
+def _render_hba_line(ip: str, role: str, database: str) -> str:
+    """Render the pg_hba drop-in content for the web peer.
+
+    Format is fixed per spec: a single ``hostssl`` line with ``/32`` CIDR
+    and ``scram-sha-256`` auth, followed by a trailing newline. Inputs are
+    NOT escaped -- the db handler validates role/database identifiers and
+    ``peer_ip`` is surfaced verbatim into the authz rule.
+    """
+    return f"hostssl {database} {role} {ip}/32 scram-sha-256\n"
+
+
+def _plan_steps(cfg: EnvConfig, *, rotate: bool) -> list[_StepReceipt]:
+    """Build the ordered list of planned RPC calls.
+
+    Returned receipts carry only ``name``, ``host``, and ``params``; the
+    success / data fields are populated when the step runs. Splitting
+    planning from execution makes ``--dry-run`` a pure projection.
+    """
+    db_host = cfg.db.host_id
+    steps: list[_StepReceipt] = []
+
+    if rotate:
+        # Rotate path: postgres.rotate_password takes {role, peer_id}
+        # (handler param is literally 'role', not 'owner_role').
+        steps.append(
+            _StepReceipt(
+                name=Command.POSTGRES_ROTATE_PASSWORD.value,
+                host=db_host,
+                params={
+                    "role": cfg.app.owner_role,
+                    "peer_id": cfg.web.host_id,
+                },
+            )
+        )
+    else:
+        steps.append(
+            _StepReceipt(
+                name=Command.POSTGRES_BOOTSTRAP_APP.value,
+                host=db_host,
+                params={
+                    "app": cfg.app.name,
+                    "owner_role": cfg.app.owner_role,
+                    "peer_ip": cfg.web.ip,
+                    "peer_id": cfg.web.host_id,
+                },
+            )
+        )
+
+    steps.append(
+        _StepReceipt(
+            name=Command.VALKEY_CREATE_ACL_USER.value,
+            host=db_host,
+            # NOTE: --rotate does NOT force a valkey token rotation. The
+            # handler is naturally idempotent on rules -- rotating the token
+            # without a rule change is out of scope for this PR.
+            params={
+                "name": cfg.app.name,
+                "rules": list(cfg.valkey.rules),
+                "peer_id": cfg.web.host_id,
+            },
+        )
+    )
+
+    steps.append(
+        _StepReceipt(
+            name=Command.POSTGRES_ADD_HBA.value,
+            host=db_host,
+            params={
+                "name": "10-web",
+                "content": _render_hba_line(
+                    ip=cfg.web.ip,
+                    role=cfg.app.owner_role,
+                    database=cfg.app.name,
+                ),
+            },
+        )
+    )
+
+    if cfg.backup is not None:
+        steps.append(
+            _StepReceipt(
+                name=Command.BACKUP_INSTALL.value,
+                host=db_host,
+                params={
+                    "profile": cfg.backup.profile,
+                    "target": cfg.backup.target,
+                    "schedule": cfg.backup.schedule,
+                },
+            )
+        )
+
+    return steps
+
+
+def _run_step(client: RpcClient, step: _StepReceipt) -> None:
+    """Execute a single step, mutating the receipt in place.
+
+    Short-circuits on :class:`TimeoutError` / transport errors: the receipt
+    ends up with ``success=False`` and an ``error`` describing which RPC
+    failed. The caller decides whether to halt or continue (this command
+    halts on first failure).
+    """
+    try:
+        result: CommandResult = client.publish(
+            step.host,
+            step.name,
+            step.params,
+            timeout=_RPC_TIMEOUT,
+        )
+    except TimeoutError as exc:
+        step.success = False
+        step.error = f"RPC timeout after {_RPC_TIMEOUT:.0f}s: {exc}"
+        return
+    except Exception as exc:  # noqa: BLE001 -- transport-level surface
+        step.success = False
+        step.error = f"transport error: {exc.__class__.__name__}: {exc}"
+        return
+
+    step.success = bool(result.success)
+    step.error = result.error
+    step.warnings = list(result.warnings)
+    # ``data`` shape is a TypedDict per step (see handlers/_types.py). We
+    # surface it verbatim -- callers can introspect it for changed / per-step
+    # echo fields.
+    if isinstance(result.data, dict):
+        step.data = dict(result.data)
+        step.changed = bool(result.data.get("changed"))
+    else:
+        step.data = None
+        step.changed = False
+
+
+# --- output helpers -------------------------------------------------------
+
+
+def _print_plan_text(cfg: EnvConfig, steps: list[_StepReceipt]) -> None:
+    source = str(cfg.source) if cfg.source is not None else "<inline>"
+    print(f"Dry-run plan for env={cfg.env} (source={source}):")
+    for step in steps:
+        print(f"  {step.host} <- {step.name} {step.params!r}")
+
+
+def _print_plan_json(cfg: EnvConfig, steps: list[_StepReceipt], *, rotate: bool) -> None:
+    payload = {
+        "env": cfg.env,
+        "rotate": rotate,
+        "dry_run": True,
+        "source": str(cfg.source) if cfg.source is not None else None,
+        "steps": [{"name": s.name, "host": s.host, "params": s.params} for s in steps],
+        "success": True,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+def _print_results_text(cfg: EnvConfig, steps: list[_StepReceipt]) -> None:
+    print(f"Bootstrap {cfg.env}:")
+    for step in steps:
+        if not step.success:
+            status = "FAIL"
+        elif step.changed:
+            status = "CHANGED"
+        else:
+            status = "OK (no-op)"
+        print(f"  [{status}] {step.host} <- {step.name}")
+        if step.data:
+            # Hide the raw params on success; show the receipt instead.
+            for k, v in step.data.items():
+                print(f"      {k}: {v}")
+        for w in step.warnings:
+            print(f"      warning: {w}")
+        if step.error:
+            print(f"      error: {step.error}")
+
+
+def _print_results_json(
+    cfg: EnvConfig,
+    steps: list[_StepReceipt],
+    *,
+    rotate: bool,
+    overall_success: bool,
+) -> None:
+    payload = {
+        "env": cfg.env,
+        "rotate": rotate,
+        "dry_run": False,
+        "source": str(cfg.source) if cfg.source is not None else None,
+        "steps": [s.to_dict() for s in steps],
+        "success": overall_success,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+
+
+# --- command --------------------------------------------------------------
+
+
+def bootstrap(
+    *,
+    env: Annotated[
+        str,
+        cyclopts.Parameter(
+            name=["--env", "-e"],
+            help="Environment name matching a block under 'envs:' in .otsinfra.yaml.",
+        ),
+    ],
+    rotate: Annotated[
+        bool,
+        cyclopts.Parameter(
+            name=["--rotate"],
+            help=(
+                "Rotate the Postgres password instead of creating the role. "
+                "Re-runs valkey.create_acl_user (idempotent on rules) and "
+                "postgres.add_hba. Does not force a Valkey token rotation."
+            ),
+            negative=[],
+        ),
+    ] = False,
+    dry_run: DryRun = False,
+    json_output: JsonOutput = False,
+) -> None:
+    """Bootstrap an environment from a fresh state via the db sidecar.
+
+    Reads ``.otsinfra.yaml`` (walked up from the current directory) and
+    publishes the bootstrap sequence to the db sidecar for ``--env``:
+
+        1. ``postgres.bootstrap_app`` (or ``postgres.rotate_password`` with
+           ``--rotate``) -- creates the application role + database and
+           delivers ``PG_PASSWORD`` to the web peer via ``secrets.deliver``.
+        2. ``valkey.create_acl_user`` -- creates the ACL user + delivers
+           ``VALKEY_PASSWORD`` to the web peer.
+        3. ``postgres.add_hba`` -- drops in a ``hostssl`` line authorising
+           the web peer's private IP.
+        4. ``backup.install`` -- optional; only when the env has a
+           ``backup:`` block.
+
+    Idempotent: a second run should return ``changed=False`` everywhere.
+    Failures short-circuit: a failed step stops the sequence.
+
+    Examples:
+        rots env bootstrap --env eu-demo
+        rots env bootstrap --env eu-demo --dry-run
+        rots env bootstrap --env eu-demo --rotate --json
+    """
+    # --- load + validate -------------------------------------------------
+    try:
+        cfg = load_env_config(env)
+    except InfraMarkerError as exc:
+        if json_output:
+            print(
+                json.dumps(
+                    {
+                        "env": env,
+                        "error": str(exc),
+                        "exit_code": EXIT_PRECOND,
+                    },
+                    sort_keys=True,
+                )
+            )
+        else:
+            logger.error("%s", exc)
+        sys.exit(EXIT_PRECOND)
+
+    steps = _plan_steps(cfg, rotate=rotate)
+
+    # --- dry-run branch --------------------------------------------------
+    if dry_run:
+        if json_output:
+            _print_plan_json(cfg, steps, rotate=rotate)
+        else:
+            _print_plan_text(cfg, steps)
+        sys.exit(EXIT_SUCCESS)
+
+    # --- execute ---------------------------------------------------------
+    client = _get_rpc_client()
+    overall_success = True
+    for step in steps:
+        _run_step(client, step)
+        if not step.success:
+            overall_success = False
+            break  # short-circuit; leave later steps with success=False defaults
+
+    # --- render output ---------------------------------------------------
+    if json_output:
+        _print_results_json(cfg, steps, rotate=rotate, overall_success=overall_success)
+    else:
+        _print_results_text(cfg, steps)
+
+    sys.exit(EXIT_SUCCESS if overall_success else EXIT_FAILURE)
+
+
+__all__ = ["bootstrap"]

--- a/src/rots/commands/env/bootstrap.py
+++ b/src/rots/commands/env/bootstrap.py
@@ -28,6 +28,7 @@ monkeypatch ``bootstrap._get_rpc_client`` to return an
 
 from __future__ import annotations
 
+import ipaddress
 import json
 import logging
 import sys
@@ -101,12 +102,14 @@ class _StepReceipt:
 def _render_hba_line(ip: str, role: str, database: str) -> str:
     """Render the pg_hba drop-in content for the web peer.
 
-    Format is fixed per spec: a single ``hostssl`` line with ``/32`` CIDR
-    and ``scram-sha-256`` auth, followed by a trailing newline. Inputs are
-    NOT escaped -- the db handler validates role/database identifiers and
-    ``peer_ip`` is surfaced verbatim into the authz rule.
+    Single ``hostssl`` line with a host-scoped CIDR and ``scram-sha-256``
+    auth, followed by a trailing newline. The CIDR prefix is ``/32`` for
+    IPv4 and ``/128`` for IPv6 — pg_hba rejects ``/32`` on an IPv6 host
+    and vice versa. ``infra_marker`` has already validated that ``ip``
+    parses as an IP address.
     """
-    return f"hostssl {database} {role} {ip}/32 scram-sha-256\n"
+    prefix = 128 if isinstance(ipaddress.ip_address(ip), ipaddress.IPv6Address) else 32
+    return f"hostssl {database} {role} {ip}/{prefix} scram-sha-256\n"
 
 
 def _plan_steps(cfg: EnvConfig, *, rotate: bool) -> list[_StepReceipt]:

--- a/src/rots/commands/sidecar/app.py
+++ b/src/rots/commands/sidecar/app.py
@@ -422,6 +422,18 @@ def run(
             help="Disable RabbitMQ consumer",
         ),
     ] = False,
+    role: Annotated[
+        str | None,
+        cyclopts.Parameter(
+            name="--role",
+            help=(
+                "Sidecar role gate: 'db' or 'web'. When set, only handlers "
+                "whose @register_handler(roles=...) includes this role are "
+                "exposed by the dispatcher. Omit to expose every registered "
+                "handler (useful for ad-hoc / single-host setups)."
+            ),
+        ),
+    ] = None,
 ):
     """Run the sidecar daemon in foreground mode.
 
@@ -431,6 +443,8 @@ def run(
     Examples:
         rots sidecar run
         rots sidecar run --socket /tmp/test.sock --no-rabbitmq
+        rots sidecar run --role db
+        rots sidecar run --role web
     """
     import signal
     import sys
@@ -440,8 +454,10 @@ def run(
     from rots.sidecar.rabbitmq import RabbitMQConfig, RabbitMQConsumer
     from rots.sidecar.socket import SocketServer
 
-    # Register all command handlers before creating servers
-    _import_handlers()
+    # Register all command handlers before creating servers. When --role is
+    # supplied the dispatcher is narrowed to handlers that declared that role
+    # via @register_handler(roles=...).
+    _import_handlers(role=role)
 
     # Load RabbitMQ config (resolves host_id) before creating consumer
     rabbitmq_config = None if no_rabbitmq else RabbitMQConfig.from_environment()
@@ -449,6 +465,7 @@ def run(
     print(f"Starting sidecar daemon (PID: {os.getpid()})")
     print(f"Socket: {socket}")
     print(f"RabbitMQ: {'disabled' if no_rabbitmq else 'enabled'}")
+    print(f"Role: {role if role else 'all'}")
     if rabbitmq_config:
         print(f"Host ID: {rabbitmq_config.host_id}")
 

--- a/src/rots/commands/sidecar/handlers/__init__.py
+++ b/src/rots/commands/sidecar/handlers/__init__.py
@@ -1,0 +1,27 @@
+# src/rots/commands/sidecar/handlers/__init__.py
+
+"""Two-phase provisioning RPC handlers (issue #55).
+
+These handlers extend the sidecar command vocabulary with verbs that move
+provisioning work out of cloud-init and into the sidecar. They live under
+``rots.commands.sidecar.handlers`` (not ``rots.sidecar.handlers_*``) because
+they share types (``_types``) and transport (``_transport``) with the operator
+command ``rots env bootstrap`` that drives them.
+
+Registration still lands in the single dispatcher at
+``rots.sidecar.commands._handlers``. The import that triggers
+``@register_handler`` decorators happens from
+``rots.sidecar.commands._import_handlers``.
+
+Modules:
+    postgres  — postgres.bootstrap_app / add_hba / rotate_password (role: db)
+    valkey    — valkey.create_acl_user / reload_acl (role: db)
+    backup    — backup.install / uninstall (role: db)
+    secrets   — secrets.deliver (role: db + web)
+
+Helpers:
+    _types     — shared payload shapes (changed: bool on every return)
+    _transport — RpcClient protocol + production/in-process implementations
+"""
+
+from __future__ import annotations

--- a/src/rots/commands/sidecar/handlers/_transport.py
+++ b/src/rots/commands/sidecar/handlers/_transport.py
@@ -1,0 +1,255 @@
+# src/rots/commands/sidecar/handlers/_transport.py
+
+"""Transport abstraction for sidecar-to-sidecar RPC.
+
+The operator command (``rots env bootstrap``) addresses sidecars by host_id
+and expects a ``CommandResult`` back. Production flows through RabbitMQ via
+the existing :func:`rots.sidecar.rabbitmq.publish_command`. Tests need the
+same call surface without a broker, so they use :class:`InProcessRpcClient`
+to route publishes to in-memory dispatchers.
+
+Both clients implement the :class:`RpcClient` protocol so downstream impl
+agents (postgres / valkey / backup handlers) program against the protocol,
+not against a concrete transport, and tests can swap in the in-process
+version without touching handler code.
+
+Example (production)::
+
+    from rots.sidecar.rabbitmq import RabbitMQConfig
+    from rots.commands.sidecar.handlers._transport import RabbitMqRpcClient
+
+    client = RabbitMqRpcClient(RabbitMQConfig.from_environment())
+    result = client.publish(
+        host_id="eu-demo-web",
+        command="secrets.deliver",
+        params={"name": "PG_PASSWORD", "value": "..."},
+        timeout=30.0,
+    )
+    assert result.success
+
+Example (test)::
+
+    from rots.commands.sidecar.handlers._transport import InProcessRpcClient
+    from rots.sidecar.commands import dispatch
+
+    bus = InProcessRpcClient({"web-host": dispatch, "db-host": dispatch})
+    result = bus.publish("web-host", "secrets.deliver", {...}, timeout=5.0)
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any, Protocol, runtime_checkable
+
+from rots.sidecar.commands import CommandResult
+
+
+@runtime_checkable
+class RpcClient(Protocol):
+    """Protocol for delivering commands to a target sidecar by host_id.
+
+    Implementations MUST:
+
+    * Accept an arbitrary ``command`` string. The target dispatcher owns
+      validation — unknown commands come back as ``CommandResult.fail(...)``.
+    * Return a :class:`CommandResult` constructed from the remote response.
+    * Raise :class:`TimeoutError` if ``timeout`` seconds pass without a reply.
+
+    Implementations SHOULD:
+
+    * Treat ``host_id`` as an opaque routing key. Do not parse or interpret.
+    * Be thread-safe enough for the operator command's sequential use (the
+      command does not parallelise publishes).
+    """
+
+    def publish(
+        self,
+        host_id: str,
+        command: str,
+        params: dict[str, Any],
+        *,
+        timeout: float = 30.0,
+    ) -> CommandResult:
+        """Send ``command`` with ``params`` to the sidecar on ``host_id``.
+
+        Args:
+            host_id: Routing target. Matches the target sidecar's
+                ``SIDECAR_HOST_ID`` / hostname.
+            command: Dotted command name, e.g. ``"secrets.deliver"``.
+            params: JSON-serialisable parameters for the remote handler.
+            timeout: Seconds to wait for a reply before raising
+                :class:`TimeoutError`. Default 30 s.
+
+        Returns:
+            :class:`CommandResult` reconstructed from the remote response.
+            ``result.success`` is the remote handler's ``success``;
+            ``result.data`` is the remote handler's ``data``; ``result.error``
+            is the remote handler's ``error``; warnings propagate too.
+
+        Raises:
+            TimeoutError: No reply within ``timeout`` seconds.
+            RuntimeError: Transport-level failure (broker down, etc.).
+        """
+        ...
+
+
+class RabbitMqRpcClient:
+    """Production RPC client backed by :mod:`rots.sidecar.rabbitmq`.
+
+    Thin adapter around :func:`publish_command` that reshapes the ``dict``
+    response into a :class:`CommandResult`. Does not cache the connection —
+    each ``publish`` opens and closes a blocking connection, matching
+    the existing CLI behaviour (``rots sidecar publish``).
+    """
+
+    def __init__(self, config: Any | None = None) -> None:
+        """Create a client.
+
+        Args:
+            config: Optional ``RabbitMQConfig``. When ``None`` the helper
+                loads it via ``RabbitMQConfig.from_environment()`` on each
+                publish. Kept as ``Any`` here to avoid importing pika at
+                module load time.
+        """
+        self._config = config
+
+    def publish(
+        self,
+        host_id: str,
+        command: str,
+        params: dict[str, Any],
+        *,
+        timeout: float = 30.0,
+    ) -> CommandResult:
+        # Deferred import — pika is not on the test path for unit tests and
+        # we want this module safe to import without it.
+        from rots.sidecar.rabbitmq import RabbitMQConfig, publish_command
+
+        config = self._config or RabbitMQConfig.from_environment()
+        response = publish_command(
+            command,
+            params,
+            config=config,
+            timeout=timeout,
+            target_host=host_id,
+        )
+        return _result_from_response(response)
+
+
+@dataclass
+class _Peer:
+    """In-process peer registration for :class:`InProcessRpcClient`."""
+
+    host_id: str
+    dispatch: Callable[[str, dict[str, Any]], CommandResult]
+
+
+class InProcessRpcClient:
+    """In-memory RPC client for tests — routes ``publish`` to local dispatchers.
+
+    Intended for:
+
+    * Integration-style tests that cover operator-command -> handler loops
+      without running RabbitMQ.
+    * The ``in_process_bus`` pytest fixture (see
+      ``tests/commands/sidecar/handlers/conftest.py``).
+
+    Not intended for production. The class does not serialise/deserialise
+    its params — handlers see the exact dict the caller passed.
+
+    Example::
+
+        from rots.sidecar.commands import dispatch as local_dispatch
+
+        bus = InProcessRpcClient({
+            "db-host": local_dispatch,
+            "web-host": local_dispatch,
+        })
+        result = bus.publish(
+            "web-host",
+            "secrets.deliver",
+            {"name": "PG_PASSWORD", "value": "abc123"},
+            timeout=5.0,
+        )
+    """
+
+    def __init__(
+        self,
+        peers: dict[str, Callable[[str, dict[str, Any]], CommandResult]] | None = None,
+    ) -> None:
+        """Create a bus with the given peers.
+
+        Args:
+            peers: Mapping of ``host_id`` to dispatcher callable. The
+                callable must accept ``(command, params)`` and return a
+                :class:`CommandResult` — the same signature as
+                :func:`rots.sidecar.commands.dispatch`. Omit to start empty
+                and use :meth:`register`.
+        """
+        self._peers: dict[str, _Peer] = {}
+        if peers:
+            for host_id, dispatcher in peers.items():
+                self.register(host_id, dispatcher)
+
+    def register(
+        self,
+        host_id: str,
+        dispatcher: Callable[[str, dict[str, Any]], CommandResult],
+    ) -> None:
+        """Add (or replace) a peer.
+
+        Args:
+            host_id: Routing key.
+            dispatcher: ``(command, params) -> CommandResult`` callable.
+        """
+        self._peers[host_id] = _Peer(host_id=host_id, dispatch=dispatcher)
+
+    def peers(self) -> list[str]:
+        """Return the list of registered host_ids (test helper)."""
+        return sorted(self._peers.keys())
+
+    def publish(
+        self,
+        host_id: str,
+        command: str,
+        params: dict[str, Any],
+        *,
+        timeout: float = 30.0,
+    ) -> CommandResult:
+        """Deliver ``command`` to the peer registered for ``host_id``.
+
+        ``timeout`` is accepted for protocol-compatibility but ignored —
+        the dispatch is synchronous.
+
+        Raises:
+            KeyError: if no peer is registered for ``host_id``.
+        """
+        del timeout  # synchronous — kept for Protocol compatibility
+        try:
+            peer = self._peers[host_id]
+        except KeyError as exc:
+            raise KeyError(
+                f"No in-process peer registered for host_id={host_id!r}. "
+                f"Known peers: {sorted(self._peers.keys())}"
+            ) from exc
+        return peer.dispatch(command, params)
+
+
+def _result_from_response(response: dict[str, Any]) -> CommandResult:
+    """Reshape a wire-format response dict into a :class:`CommandResult`.
+
+    :func:`rots.sidecar.rabbitmq.publish_command` returns the structure
+    written by :meth:`RabbitMQConsumer._on_message`:
+
+        {"success": bool, "result": data, "error": str | None, "warnings": [...]}
+
+    This function is deliberately forgiving — missing keys default to
+    sensible values so a partial response does not crash the caller.
+    """
+    return CommandResult(
+        success=bool(response.get("success")),
+        data=response.get("result"),
+        error=response.get("error"),
+        warnings=list(response.get("warnings") or []),
+    )

--- a/src/rots/commands/sidecar/handlers/_types.py
+++ b/src/rots/commands/sidecar/handlers/_types.py
@@ -1,0 +1,159 @@
+# src/rots/commands/sidecar/handlers/_types.py
+
+"""Shared payload shapes for two-phase provisioning handlers.
+
+Every handler returns ``CommandResult.ok(data=...)`` where ``data`` is a dict
+matching one of the TypedDicts in this module. The invariant that ties them
+together is ``changed: bool`` — the operator command (``rots env bootstrap``)
+relies on it to produce accurate idempotency receipts:
+
+* ``changed=True``  — the handler mutated state (role created, ACL added,
+  password rotated, env file rewritten, timer enabled, ...).
+* ``changed=False`` — the desired state already held; no mutation performed.
+
+Handlers must set ``changed`` truthfully. "Wrote a file with the same content"
+is ``changed=False``. "Wrote a file with new content" is ``changed=True``.
+
+TypedDicts are used (not dataclasses) because the wire format is JSON through
+RabbitMQ and the dispatcher stores ``CommandResult.data`` as an ``Any`` dict.
+Using TypedDict lets pyright check handler implementations without forcing
+client code (``rots env bootstrap``) through a decode path.
+"""
+
+from __future__ import annotations
+
+from typing import TypedDict
+
+
+class SecretsDeliverData(TypedDict):
+    """Return payload for ``secrets.deliver``.
+
+    Attributes:
+        written: ``True`` if the handler opened the env file for write (even
+            when content was identical — a ``write-if-different`` handler may
+            short-circuit before opening, in which case this is ``False``).
+        path: Absolute path of the env file that was targeted. Always the
+            value passed in via ``env_file`` (defaults to
+            ``/etc/default/onetimesecret``).
+        changed: ``True`` when the on-disk content changed as a result of
+            this call. ``False`` on idempotent re-delivery with the same
+            value.
+    """
+
+    written: bool
+    path: str
+    changed: bool
+
+
+class PostgresBootstrapAppData(TypedDict):
+    """Return payload for ``postgres.bootstrap_app``.
+
+    Attributes:
+        role: The application role name that exists after the call
+            (created or already-present).
+        database: The application database name that exists after the call.
+        password_delivered_to: ``host_id`` of the web sidecar that received
+            the generated password via ``secrets.deliver``. Echoed back so
+            the operator can confirm delivery in its receipt.
+        changed: ``True`` when the role or database was created, or when
+            ``rotate_password`` semantics were triggered. ``False`` when
+            everything already existed and no password was rotated.
+    """
+
+    role: str
+    database: str
+    password_delivered_to: str
+    changed: bool
+
+
+class PostgresAddHbaData(TypedDict):
+    """Return payload for ``postgres.add_hba``.
+
+    Attributes:
+        reloaded: ``True`` when ``pg_ctl reload`` (or equivalent) was
+            invoked because the file's contents changed. Mirrors
+            ``changed`` — kept as a separate key so existing call-sites
+            that read ``reloaded`` keep working.
+        changed: ``True`` when the pg_hba.d drop-in was created or its
+            contents updated. ``False`` on an identical re-apply.
+    """
+
+    reloaded: bool
+    changed: bool
+
+
+class PostgresRotatePasswordData(TypedDict):
+    """Return payload for ``postgres.rotate_password``.
+
+    Attributes:
+        delivered_to: ``host_id`` of the sidecar that received the new
+            password via ``secrets.deliver``.
+        changed: Always ``True`` on success. ``rotate_password`` is not
+            idempotent — every call mints a fresh password. Included for
+            uniformity so the operator command can treat every data
+            payload identically.
+    """
+
+    delivered_to: str
+    changed: bool
+
+
+class ValkeyCreateAclUserData(TypedDict):
+    """Return payload for ``valkey.create_acl_user``.
+
+    Attributes:
+        delivered_to: ``host_id`` of the sidecar that received the
+            generated token via ``secrets.deliver``.
+        changed: ``True`` when the ACL user was created or updated (rules
+            differ from the stored entry). ``False`` when the user already
+            exists with matching rules and no token rotation occurred.
+    """
+
+    delivered_to: str
+    changed: bool
+
+
+class ValkeyReloadAclData(TypedDict):
+    """Return payload for ``valkey.reload_acl``.
+
+    Attributes:
+        ok: Echo of success (always ``True`` on a successful call). Kept
+            for backward-compat with the signature in the issue body.
+        changed: ``True`` when reloading the ACL file produced observable
+            differences (users added/removed/updated). ``False`` when the
+            running ACL state was already consistent with the file.
+    """
+
+    ok: bool
+    changed: bool
+
+
+class BackupInstallData(TypedDict):
+    """Return payload for ``backup.install``.
+
+    Attributes:
+        unit: Name of the generated ``.service`` unit (e.g.
+            ``ots-backup-db-daily.service``).
+        timer: Name of the generated ``.timer`` unit.
+        changed: ``True`` when any of { service, timer, rclone fragment,
+            enabled state } was created or updated on this call.
+    """
+
+    unit: str
+    timer: str
+    changed: bool
+
+
+class BackupUninstallData(TypedDict):
+    """Return payload for ``backup.uninstall``.
+
+    Attributes:
+        ok: Echo of success. Kept for backward-compat with the signature
+            in the issue body.
+        changed: ``True`` when units/fragments were actually removed from
+            disk (and ``systemctl disable`` ran). ``False`` if the profile
+            was already absent.
+    """
+
+    ok: bool
+    changed: bool

--- a/src/rots/commands/sidecar/handlers/backup.py
+++ b/src/rots/commands/sidecar/handlers/backup.py
@@ -184,6 +184,8 @@ def _validate_target(target: str) -> str | None:
         return f"invalid remote name {remote!r}: must match ^[A-Za-z0-9_-]+$"
     if "\n" in path:
         return "target path must not contain newline"
+    if any(c in path for c in ("$", "`", '"', "'", "\\")):
+        return "target path contains unsafe shell characters (one of: $ ` \" ' \\)"
     return None
 
 

--- a/src/rots/commands/sidecar/handlers/backup.py
+++ b/src/rots/commands/sidecar/handlers/backup.py
@@ -1,0 +1,443 @@
+# src/rots/commands/sidecar/handlers/backup.py
+
+"""Backup job provisioning handlers (``backup.*``).
+
+These handlers run on the **db sidecar** (``roles={"db"}``). They install
+and uninstall systemd timer-based backup jobs, with rclone as the upload
+transport. Profiles are named (``"db-daily"``, ``"valkey-hourly"``, etc.)
+and each profile maps to a fixed ``.service`` + ``.timer`` pair and an
+rclone config fragment.
+
+System layout
+-------------
+* Units live in :data:`SYSTEMD_DIR`.
+* rclone fragments live in :data:`RCLONE_FRAGMENTS_DIR` (one file per
+  profile). The base rclone config is owned by the operator; handlers
+  only touch files under this fragments dir.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from rots.sidecar.commands import Command, CommandResult, register_handler
+
+from ._types import BackupInstallData, BackupUninstallData
+
+__all__ = [
+    "ALLOWED_PROFILES",
+    "BackupInstallData",
+    "BackupUninstallData",
+    "RCLONE_FRAGMENTS_DIR",
+    "SYSTEMD_DIR",
+    "handle_install",
+    "handle_uninstall",
+]
+
+logger = logging.getLogger(__name__)
+
+# Directory where generated systemd unit + timer files are written. Each
+# profile produces two files:
+#   ots-backup-<profile>.service
+#   ots-backup-<profile>.timer
+# Implementations MUST NOT write anywhere else.
+SYSTEMD_DIR: str = "/etc/systemd/system"
+
+# Per-profile rclone configuration fragments. The rclone binary assembles
+# the full config by reading every ``*.conf`` under this directory in
+# addition to the primary config. Implementations create / remove a single
+# file per profile: ``<profile>.conf``.
+RCLONE_FRAGMENTS_DIR: str = "/etc/rclone/conf.d"
+
+# Allowlisted profile names. Narrow on purpose -- expanding this requires
+# corresponding templates. Impl agents add entries here AND ship matching
+# script content for the ``.service`` unit.
+ALLOWED_PROFILES: frozenset[str] = frozenset({"db-daily", "valkey-hourly"})
+
+# Regex for the ``<remote>`` part of a ``<remote>:<path>`` rclone target.
+_REMOTE_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# File modes for generated artifacts.
+_UNIT_MODE = 0o644
+_RCLONE_FRAGMENT_MODE = 0o640
+
+
+# --- unit rendering -------------------------------------------------------
+
+
+def _render_service(profile: str, target: str) -> str:
+    """Return the content of ``ots-backup-<profile>.service``.
+
+    The ExecStart is a ``/bin/bash -c "..."`` invocation with ``set -euo
+    pipefail`` so any non-zero step propagates and systemd records the
+    failure.
+    """
+    if profile == "db-daily":
+        description = "OneTimeSecret Postgres daily backup"
+        # pg_dumpall streamed through gzip and piped to rclone rcat --
+        # avoids staging the dump on disk. set -euo pipefail guarantees the
+        # pipeline fails the service on any broken stage.
+        script = (
+            "set -euo pipefail; "
+            'ts="$(date -u +%Y%m%dT%H%M%SZ)"; '
+            "sudo -u postgres pg_dumpall "
+            "| gzip "
+            f'| rclone rcat "{target}/postgres-${{ts}}.sql.gz"'
+        )
+    elif profile == "valkey-hourly":
+        description = "OneTimeSecret Valkey hourly backup"
+        # BGSAVE is asynchronous -- poll LASTSAVE until it advances past
+        # the value we captured before triggering it. Then copy the RDB
+        # snapshot to the remote. redis-cli talks to the local valkey
+        # over its default socket / localhost.
+        script = (
+            "set -euo pipefail; "
+            'ts="$(date -u +%Y%m%dT%H%M%SZ)"; '
+            'start="$(redis-cli LASTSAVE)"; '
+            "redis-cli BGSAVE >/dev/null; "
+            'while [ "$(redis-cli LASTSAVE)" = "$start" ]; do sleep 1; done; '
+            "rclone copyto /var/lib/valkey/dump.rdb "
+            f'"{target}/valkey-${{ts}}.rdb"'
+        )
+    else:
+        # Should have been rejected by the allowlist check upstream.
+        raise ValueError(f"Unsupported profile: {profile!r}")
+
+    return (
+        "[Unit]\n"
+        f"Description={description}\n"
+        "After=network-online.target\n"
+        "Wants=network-online.target\n"
+        "\n"
+        "[Service]\n"
+        "Type=oneshot\n"
+        f"ExecStart=/bin/bash -c {_shell_quote(script)}\n"
+    )
+
+
+def _render_timer(profile: str, schedule: str) -> str:
+    """Return the content of ``ots-backup-<profile>.timer``."""
+    unit = f"ots-backup-{profile}.service"
+    return (
+        "[Unit]\n"
+        f"Description=Timer for {unit}\n"
+        "\n"
+        "[Timer]\n"
+        f"OnCalendar={schedule}\n"
+        "Persistent=true\n"
+        f"Unit={unit}\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=timers.target\n"
+    )
+
+
+def _render_rclone_fragment(profile: str, target: str) -> str:
+    """Return the rclone fragment content for ``<profile>.conf``.
+
+    The fragment is a comment-only stub: the ``<remote>`` referenced in the
+    ``target`` is expected to exist in the operator-managed primary rclone
+    config. Writing a comment-only file lets uninstall track existence
+    without committing handler code to a specific remote schema.
+    """
+    return (
+        f"# rclone fragment for backup profile {profile}\n"
+        "# The <remote> part of the target must be defined in the\n"
+        "# operator-managed rclone config. This file is managed by\n"
+        "# rots; do not edit by hand.\n"
+    )
+
+
+def _shell_quote(s: str) -> str:
+    """Wrap ``s`` in double quotes for an ``ExecStart=/bin/bash -c "..."``.
+
+    Escapes backslashes and double quotes. Shell ``$`` and backticks are
+    left intact -- the rendered script deliberately uses shell expansion.
+    """
+    escaped = s.replace("\\", "\\\\").replace('"', '\\"')
+    return f'"{escaped}"'
+
+
+# --- validation helpers ---------------------------------------------------
+
+
+def _validate_target(target: str) -> str | None:
+    """Return ``None`` if ``target`` is acceptable, else an error string."""
+    if not target or target.strip() == "":
+        return "target must be non-empty"
+    if "\n" in target:
+        return "target must not contain newline"
+    # Colon-style only. The fragment-style ("[remote]\n...") path listed in
+    # the docstring is not exercised by current profiles, so we reject it
+    # explicitly rather than silently accepting something the handler does
+    # not finish.
+    if ":" not in target:
+        return "target must be in '<remote>:<path>' form"
+    remote, _, path = target.partition(":")
+    if not _REMOTE_RE.match(remote):
+        return f"invalid remote name {remote!r}: must match ^[A-Za-z0-9_-]+$"
+    if "\n" in path:
+        return "target path must not contain newline"
+    return None
+
+
+def _validate_schedule(schedule: str) -> str | None:
+    """Return ``None`` if ``schedule`` is accepted by ``systemd-analyze``."""
+    if not schedule or not schedule.strip():
+        return "schedule must be non-empty"
+    try:
+        subprocess.run(
+            ["systemd-analyze", "calendar", schedule],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except FileNotFoundError:
+        return "systemd-analyze not available to validate schedule"
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip() or (exc.stdout or "").strip()
+        return f"invalid schedule {schedule!r}: {stderr}"
+    return None
+
+
+# --- atomic write ---------------------------------------------------------
+
+
+def _read_existing(path: Path) -> bytes | None:
+    """Return the bytes at ``path`` or ``None`` if missing.
+
+    Uses ``O_NOFOLLOW`` to refuse to read through a symlink -- a symlink
+    at the target location is a hijack vector. The caller treats an
+    ``OSError`` as "cannot safely read, proceed with a write anyway" by
+    raising; we surface it.
+    """
+    try:
+        fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+    except FileNotFoundError:
+        return None
+    with os.fdopen(fd, "rb") as f:
+        return f.read()
+
+
+def _write_if_different(path: Path, content: str, mode: int) -> bool:
+    """Write ``content`` to ``path`` atomically iff it differs.
+
+    Returns ``True`` if the file was (re)written, ``False`` if the existing
+    content already matched byte-for-byte. Raises :class:`OSError` on any
+    filesystem failure -- the caller decides how to surface it.
+    """
+    encoded = content.encode("utf-8")
+
+    existing = _read_existing(path)
+    if existing == encoded:
+        return False
+
+    parent = path.parent
+    parent.mkdir(parents=True, exist_ok=True)
+
+    tmp_fd: int | None = None
+    tmp_name: str | None = None
+    try:
+        tmp_fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=str(parent),
+        )
+        with os.fdopen(tmp_fd, "wb") as f:
+            tmp_fd = None  # fdopen owns it now
+            f.write(encoded)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_name, mode)
+        os.rename(tmp_name, path)
+        tmp_name = None
+    finally:
+        if tmp_fd is not None:
+            try:
+                os.close(tmp_fd)
+            except OSError:
+                pass
+        if tmp_name is not None:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+
+    return True
+
+
+# --- systemctl wrappers ---------------------------------------------------
+
+
+def _systemctl(*args: str) -> subprocess.CompletedProcess[str]:
+    """Invoke ``systemctl`` and return the completed process.
+
+    Does NOT raise on non-zero exit -- the caller inspects ``returncode``.
+    """
+    return subprocess.run(
+        ["systemctl", *args],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _systemctl_checked(*args: str) -> None:
+    """Invoke ``systemctl`` and raise :class:`subprocess.CalledProcessError` on failure."""
+    subprocess.run(
+        ["systemctl", *args],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+# --- handlers -------------------------------------------------------------
+
+
+@register_handler(Command.BACKUP_INSTALL, roles={"db"})
+def handle_install(params: dict[str, Any]) -> CommandResult:
+    """Install a backup profile's ``.service`` + ``.timer`` + rclone fragment.
+
+    See module docstring / spec for the full param + behaviour contract.
+    """
+    # --- param gates ------------------------------------------------------
+    profile = params.get("profile")
+    if not isinstance(profile, str) or not profile:
+        return CommandResult.fail("Missing or empty 'profile' parameter")
+    if profile not in ALLOWED_PROFILES:
+        return CommandResult.fail(
+            f"Rejected profile: {profile!r}. Allowed profiles: {sorted(ALLOWED_PROFILES)}"
+        )
+
+    target = params.get("target")
+    if not isinstance(target, str):
+        return CommandResult.fail("Missing 'target' parameter")
+    target_err = _validate_target(target)
+    if target_err is not None:
+        # Do not echo ``target`` -- it may carry credentials in a URL.
+        return CommandResult.fail(f"Invalid target for profile {profile!r}: {target_err}")
+
+    schedule = params.get("schedule")
+    if not isinstance(schedule, str):
+        return CommandResult.fail("Missing 'schedule' parameter")
+    schedule_err = _validate_schedule(schedule)
+    if schedule_err is not None:
+        return CommandResult.fail(schedule_err)
+
+    # --- render -----------------------------------------------------------
+    service_content = _render_service(profile, target)
+    timer_content = _render_timer(profile, schedule)
+    rclone_content = _render_rclone_fragment(profile, target)
+
+    service_path = Path(SYSTEMD_DIR) / f"ots-backup-{profile}.service"
+    timer_path = Path(SYSTEMD_DIR) / f"ots-backup-{profile}.timer"
+    rclone_path = Path(RCLONE_FRAGMENTS_DIR) / f"{profile}.conf"
+
+    # --- write-if-different ----------------------------------------------
+    any_changed = False
+    try:
+        for path, content, mode in (
+            (service_path, service_content, _UNIT_MODE),
+            (timer_path, timer_content, _UNIT_MODE),
+            (rclone_path, rclone_content, _RCLONE_FRAGMENT_MODE),
+        ):
+            wrote = _write_if_different(path, content, mode)
+            if wrote:
+                logger.info("backup.install wrote %s for profile %s", path, profile)
+                any_changed = True
+    except OSError as exc:
+        return CommandResult.fail(f"Failed to write backup artifacts for {profile!r}: {exc}")
+
+    # --- daemon-reload (only if something changed) ------------------------
+    if any_changed:
+        try:
+            _systemctl_checked("daemon-reload")
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            return CommandResult.fail(f"systemctl daemon-reload failed: {stderr}")
+
+    # --- enable --now (idempotent at systemd layer) -----------------------
+    timer_unit = f"ots-backup-{profile}.timer"
+    try:
+        _systemctl_checked("enable", "--now", timer_unit)
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        return CommandResult.fail(f"systemctl enable --now {timer_unit} failed: {stderr}")
+
+    data = BackupInstallData(
+        unit=f"ots-backup-{profile}.service",
+        timer=timer_unit,
+        changed=any_changed,
+    )
+    return CommandResult.ok(data)
+
+
+@register_handler(Command.BACKUP_UNINSTALL, roles={"db"})
+def handle_uninstall(params: dict[str, Any]) -> CommandResult:
+    """Remove a previously-installed backup profile.
+
+    See module docstring / spec for the full param + behaviour contract.
+    """
+    profile = params.get("profile")
+    if not isinstance(profile, str) or not profile:
+        return CommandResult.fail("Missing or empty 'profile' parameter")
+    if profile not in ALLOWED_PROFILES:
+        return CommandResult.fail(
+            f"Rejected profile: {profile!r}. Allowed profiles: {sorted(ALLOWED_PROFILES)}"
+        )
+
+    timer_unit = f"ots-backup-{profile}.timer"
+    service_path = Path(SYSTEMD_DIR) / f"ots-backup-{profile}.service"
+    timer_path = Path(SYSTEMD_DIR) / f"ots-backup-{profile}.timer"
+    rclone_path = Path(RCLONE_FRAGMENTS_DIR) / f"{profile}.conf"
+
+    # --- disable --now ----------------------------------------------------
+    # Run unconditionally. Expected-failure case: unit is not loaded (e.g.
+    # the profile was never installed, or already uninstalled). We detect
+    # that via stderr and suppress; any other failure surfaces.
+    disable_proc = _systemctl(
+        "disable",
+        "--now",
+        timer_unit,
+    )
+    if disable_proc.returncode != 0:
+        stderr = (disable_proc.stderr or "").strip()
+        lower = stderr.lower()
+        not_loaded = (
+            "not loaded" in lower
+            or "no such file" in lower
+            or "does not exist" in lower
+            or "not found" in lower
+        )
+        if not not_loaded:
+            return CommandResult.fail(f"systemctl disable --now {timer_unit} failed: {stderr}")
+
+    # --- unlink the three files ------------------------------------------
+    any_removed = False
+    try:
+        for path in (service_path, timer_path, rclone_path):
+            existed = path.exists()
+            path.unlink(missing_ok=True)
+            if existed:
+                logger.info("backup.uninstall removed %s for profile %s", path, profile)
+                any_removed = True
+    except OSError as exc:
+        return CommandResult.fail(f"Failed to remove backup artifacts for {profile!r}: {exc}")
+
+    # --- daemon-reload (only if something was removed) --------------------
+    if any_removed:
+        try:
+            _systemctl_checked("daemon-reload")
+        except subprocess.CalledProcessError as exc:
+            stderr = (exc.stderr or "").strip()
+            return CommandResult.fail(f"systemctl daemon-reload failed: {stderr}")
+
+    data = BackupUninstallData(ok=True, changed=any_removed)
+    return CommandResult.ok(data)

--- a/src/rots/commands/sidecar/handlers/postgres.py
+++ b/src/rots/commands/sidecar/handlers/postgres.py
@@ -1,0 +1,603 @@
+# src/rots/commands/sidecar/handlers/postgres.py
+
+"""Postgres provisioning handlers (``postgres.*``).
+
+These handlers run on the **db sidecar** (``roles={"db"}``). They own the
+second phase of provisioning: generating application passwords, creating
+roles / databases, managing ``pg_hba.d/`` drop-ins, and rotating
+credentials. Cloud-init (``lots``) no longer touches any of this.
+
+Auth model
+----------
+The sidecar runs as root on the db host. It invokes ``sudo -u postgres
+psql`` over the local UNIX socket, relying on postgres peer authentication.
+Peer auth means presence-on-the-host is the credential — there is no
+secret to read at sidecar startup. Implementations MUST use this channel
+(do not open a TCP connection, do not store a ``.pgpass``).
+
+Cross-host delivery
+-------------------
+Generated passwords travel to the web peer via ``secrets.deliver`` on the
+``peer_id`` sidecar. Handlers obtain an :class:`RpcClient` from module-level
+factory (``_get_rpc_client()``) so tests can swap in
+:class:`InProcessRpcClient`. Implementations MUST deliver the password
+**before** returning success — a dropped delivery is a provisioning
+failure, not a warning.
+
+Status
+------
+This module is a scaffold. All handlers raise :class:`NotImplementedError`.
+Impl and test agents write against the spec below.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import secrets as _stdlib_secrets
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from rots.sidecar.commands import Command, CommandResult, register_handler
+
+from ._transport import RpcClient
+from ._types import (
+    PostgresAddHbaData,
+    PostgresBootstrapAppData,
+    PostgresRotatePasswordData,
+)
+
+__all__ = [
+    "PG_HBA_D",
+    "PSQL_PEER_CMD",
+    "PostgresAddHbaData",
+    "PostgresBootstrapAppData",
+    "PostgresRotatePasswordData",
+    "RpcClient",
+    "handle_add_hba",
+    "handle_bootstrap_app",
+    "handle_rotate_password",
+]
+
+logger = logging.getLogger(__name__)
+
+# The directory under which pg_hba.d drop-ins live on Debian/Ubuntu.
+# Implementations MUST NOT write outside this directory. The ``name`` parameter
+# of :func:`handle_add_hba` is joined into this path after basename validation
+# (no slashes, no ``..``, ``.conf`` suffix enforced).
+PG_HBA_D: str = "/etc/postgresql/pg_hba.d"
+
+# Wrapper command to invoke psql as the postgres OS user over the local socket.
+# Implementations MUST use this form — do not pass `-h hostname` (that forces
+# TCP and breaks peer auth).
+PSQL_PEER_CMD: tuple[str, ...] = ("sudo", "-u", "postgres", "psql", "-v", "ON_ERROR_STOP=1")
+
+# Identifier regex used for role / database / app names. Anchored, lowercase,
+# starts with a letter, up to 63 characters total (postgres NAMEDATALEN cap).
+# Chosen narrow enough that a validated identifier is safe to interpolate into
+# a double-quoted SQL identifier without further escaping.
+_IDENT_RE = re.compile(r"^[a-z][a-z0-9_]{0,62}$")
+
+# Valid first-token keywords for a pg_hba.d/ drop-in line.
+_HBA_PREFIXES: frozenset[str] = frozenset(
+    {"host", "hostssl", "hostnossl", "local", "hostgssenc", "hostnogssenc"}
+)
+
+# File mode for a pg_hba.d drop-in — readable by owner and by postgres group.
+_HBA_FILE_MODE = 0o640
+
+# Maximum length for an hba drop-in name *before* the .conf suffix is appended.
+_HBA_NAME_MAX = 64
+
+
+def _get_rpc_client() -> RpcClient:
+    """Return an :class:`RpcClient` bound to the active broker.
+
+    Implementations (and tests) MUST route cross-host calls through this
+    seam so the in-process test client can be swapped in.
+
+    Default implementation returns a :class:`RabbitMqRpcClient` using
+    :func:`RabbitMQConfig.from_environment`. Tests override via::
+
+        import rots.commands.sidecar.handlers.postgres as pg
+        monkeypatch.setattr(pg, "_get_rpc_client", lambda: test_bus)
+    """
+    from ._transport import RabbitMqRpcClient
+
+    return RabbitMqRpcClient()
+
+
+# --- helpers -------------------------------------------------------------
+
+
+def _valid_ident(name: str) -> bool:
+    """Return ``True`` when ``name`` matches the safe-identifier pattern."""
+    return bool(_IDENT_RE.match(name))
+
+
+def _psql(
+    args: tuple[str, ...], *, input_sql: str | None = None
+) -> subprocess.CompletedProcess[str]:
+    """Run a psql command with peer auth and ``ON_ERROR_STOP=1``.
+
+    Args:
+        args: Extra CLI args appended to :data:`PSQL_PEER_CMD`.
+        input_sql: Optional SQL to feed via stdin. Passing SQL via stdin (instead
+            of ``-c``) keeps secrets out of ``/proc/<pid>/cmdline`` and the
+            process table. Used for ``CREATE ROLE ... PASSWORD ...`` etc.
+
+    Returns:
+        The ``CompletedProcess`` from :func:`subprocess.run` on success.
+
+    Raises:
+        subprocess.CalledProcessError: psql returned non-zero.
+    """
+    cmd = PSQL_PEER_CMD + args
+    return subprocess.run(
+        cmd,
+        input=input_sql,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _role_exists(role: str) -> bool:
+    """Return ``True`` if the role exists. Caller validates ``role``."""
+    # -tA => tuples-only, unaligned; empty stdout means no row, "1" means present.
+    proc = _psql(
+        ("-tA", "-c", f"SELECT 1 FROM pg_roles WHERE rolname = '{role}'"),
+    )
+    return proc.stdout.strip() == "1"
+
+
+def _database_exists(database: str) -> bool:
+    """Return ``True`` if the database exists. Caller validates ``database``."""
+    proc = _psql(
+        ("-tA", "-c", f"SELECT 1 FROM pg_database WHERE datname = '{database}'"),
+    )
+    return proc.stdout.strip() == "1"
+
+
+def _create_role_with_password(role: str, password: str) -> None:
+    """Create a LOGIN role with the given password via stdin-piped SQL.
+
+    ``role`` MUST already be identifier-validated. ``password`` is passed
+    through stdin so it never appears in the process argv.
+    """
+    # token_urlsafe() produces only [A-Za-z0-9_-]; no need to escape for SQL
+    # string literal, but we still double single-quotes defensively.
+    safe_pw = password.replace("'", "''")
+    sql = f"CREATE ROLE \"{role}\" LOGIN PASSWORD '{safe_pw}';\n"
+    _psql((), input_sql=sql)
+
+
+def _drop_role(role: str) -> None:
+    """Best-effort ``DROP ROLE`` used to roll back a failed delivery."""
+    _psql(("-c", f'DROP ROLE IF EXISTS "{role}"'))
+
+
+def _alter_role_password(role: str, password: str) -> None:
+    """Change the password on an existing role via stdin-piped SQL."""
+    safe_pw = password.replace("'", "''")
+    sql = f"ALTER ROLE \"{role}\" WITH PASSWORD '{safe_pw}';\n"
+    _psql((), input_sql=sql)
+
+
+def _revoke_role_password(role: str) -> None:
+    """Null-out the password on a role. Used to strand an undelivered rotation."""
+    _psql(("-c", f'ALTER ROLE "{role}" WITH PASSWORD NULL'))
+
+
+def _create_database(database: str, owner: str) -> None:
+    """Create a database owned by ``owner``. Both names identifier-validated."""
+    _psql(("-c", f'CREATE DATABASE "{database}" OWNER "{owner}"'))
+
+
+def _reload_conf() -> bool:
+    """Call ``pg_reload_conf()``. Return ``True`` when postgres returned ``t``."""
+    proc = _psql(("-tA", "-c", "SELECT pg_reload_conf();"))
+    return proc.stdout.strip() == "t"
+
+
+def _chown_postgres(path: str) -> None:
+    """Best-effort ``chown postgres:postgres``. Silent on failure."""
+    try:
+        import pwd
+
+        entry = pwd.getpwnam("postgres")
+        os.chown(path, entry.pw_uid, entry.pw_gid)
+    except (KeyError, OSError, PermissionError) as exc:
+        logger.debug("chown postgres:postgres on %s skipped: %s", path, exc)
+
+
+def _deliver_password(
+    client: RpcClient,
+    peer_id: str,
+    value: str,
+    *,
+    name: str = "PG_PASSWORD",
+) -> CommandResult:
+    """Publish ``secrets.deliver`` at ``peer_id`` with the given value.
+
+    Intentionally omits ``env_file`` — the secrets.deliver handler defaults
+    to :data:`rots.commands.sidecar.handlers.secrets.ALLOWED_ENV_FILE`, and
+    passing a path at call time would bypass the allowlist invariant (and
+    break tests that redirect the allowlist at a tmp_path).
+    """
+    return client.publish(
+        peer_id,
+        "secrets.deliver",
+        {
+            "name": name,
+            "value": value,
+        },
+        timeout=10.0,
+    )
+
+
+# --- handlers ------------------------------------------------------------
+
+
+@register_handler(Command.POSTGRES_BOOTSTRAP_APP, roles={"db"})
+def handle_bootstrap_app(params: dict[str, Any]) -> CommandResult:
+    """Create an application role + database, generate a password, deliver it.
+
+    See module docstring and issue #55 for the contract. Implementation notes:
+
+    * When the owner role already exists, this is a full short-circuit:
+      step 4 (``secrets.deliver``) and step 5 (database existence check +
+      CREATE DATABASE) are both skipped. Returns ``changed=False`` with
+      ``password_delivered_to=peer_id`` as an informational echo. A re-run
+      is thus a no-op end-to-end, matching operator intuition — if the
+      role is here, the full bootstrap happened on a prior call and we do
+      not know the password we would need to re-deliver.
+    * ``changed`` is ``True`` only on the first run where the role was
+      created. If the role was absent but the database already existed
+      (an unusual state, e.g. after a manual restore), ``changed`` still
+      reports the role creation + password delivery truthfully.
+    """
+    app = params.get("app")
+    owner_role = params.get("owner_role")
+    peer_ip = params.get("peer_ip")
+    peer_id = params.get("peer_id")
+
+    for key, val in (
+        ("app", app),
+        ("owner_role", owner_role),
+        ("peer_ip", peer_ip),
+        ("peer_id", peer_id),
+    ):
+        if not isinstance(val, str) or not val:
+            return CommandResult.fail(f"Missing or empty '{key}' parameter")
+
+    # Narrow types for pyright (the guard above proves these are non-empty strs).
+    assert isinstance(app, str)
+    assert isinstance(owner_role, str)
+    assert isinstance(peer_ip, str)
+    assert isinstance(peer_id, str)
+
+    if not _valid_ident(app):
+        return CommandResult.fail(f"Invalid app name: {app!r}")
+    if not _valid_ident(owner_role):
+        return CommandResult.fail(f"Invalid owner_role name: {owner_role!r}")
+
+    # peer_ip is not interpolated into SQL in this handler; its presence is
+    # required but full validation happens in add_hba. Still, reject obvious
+    # junk so we don't surface a confused success receipt.
+    if not peer_ip.strip():
+        return CommandResult.fail("Invalid peer_ip: empty string")
+
+    role_changed = False
+    db_changed = False
+
+    # --- role branch -----------------------------------------------------
+    try:
+        role_is_present = _role_exists(owner_role)
+    except subprocess.CalledProcessError as exc:
+        return CommandResult.fail(f"psql failed: {exc.stderr.strip() or exc}")
+
+    if role_is_present:
+        # Full short-circuit. We cannot re-deliver a password we do not
+        # know, so echo the receipt and return changed=False.
+        logger.info(
+            "postgres.bootstrap_app: role %s already exists; no-op (changed=False)",
+            owner_role,
+        )
+        existing_data: PostgresBootstrapAppData = {
+            "role": owner_role,
+            "database": app,
+            "password_delivered_to": peer_id,
+            "changed": False,
+        }
+        return CommandResult.ok(existing_data)
+
+    # --- role does not exist: create + deliver -------------------------
+    password = _stdlib_secrets.token_urlsafe(32)
+    try:
+        _create_role_with_password(owner_role, password)
+    except subprocess.CalledProcessError as exc:
+        return CommandResult.fail(f"psql failed: {exc.stderr.strip() or exc}")
+    role_changed = True
+    logger.info("postgres.bootstrap_app created role %s", owner_role)
+
+    # Deliver before returning success. On any delivery failure, roll back.
+    client = _get_rpc_client()
+    try:
+        delivery = _deliver_password(client, peer_id, password)
+    except TimeoutError:
+        try:
+            _drop_role(owner_role)
+        except subprocess.CalledProcessError as drop_exc:
+            logger.warning(
+                "postgres.bootstrap_app rollback DROP ROLE %s failed after delivery timeout: %s",
+                owner_role,
+                drop_exc.stderr.strip() or drop_exc,
+            )
+        return CommandResult.fail("secrets.deliver timed out")
+    except Exception as exc:  # noqa: BLE001 — transport-level surface
+        try:
+            _drop_role(owner_role)
+        except subprocess.CalledProcessError as drop_exc:
+            logger.warning(
+                "postgres.bootstrap_app rollback DROP ROLE %s failed: %s",
+                owner_role,
+                drop_exc.stderr.strip() or drop_exc,
+            )
+        return CommandResult.fail(f"secrets.deliver transport error: {exc}")
+
+    if not delivery.success:
+        try:
+            _drop_role(owner_role)
+        except subprocess.CalledProcessError as drop_exc:
+            logger.warning(
+                "postgres.bootstrap_app rollback DROP ROLE %s failed after delivery error: %s",
+                owner_role,
+                drop_exc.stderr.strip() or drop_exc,
+            )
+        return CommandResult.fail(f"secrets.deliver failed: {delivery.error or 'unknown error'}")
+
+    # --- database branch -------------------------------------------------
+    try:
+        database_is_present = _database_exists(app)
+    except subprocess.CalledProcessError as exc:
+        return CommandResult.fail(f"psql failed: {exc.stderr.strip() or exc}")
+
+    if not database_is_present:
+        try:
+            _create_database(app, owner_role)
+        except subprocess.CalledProcessError as exc:
+            return CommandResult.fail(f"psql failed: {exc.stderr.strip() or exc}")
+        db_changed = True
+        logger.info("postgres.bootstrap_app created database %s owner=%s", app, owner_role)
+
+    data: PostgresBootstrapAppData = {
+        "role": owner_role,
+        "database": app,
+        "password_delivered_to": peer_id,
+        "changed": role_changed or db_changed,
+    }
+    return CommandResult.ok(data)
+
+
+@register_handler(Command.POSTGRES_ADD_HBA, roles={"db"})
+def handle_add_hba(params: dict[str, Any]) -> CommandResult:
+    """Install (or update) a ``pg_hba.d/`` drop-in and reload postgres.
+
+    See module docstring for the contract.
+    """
+    name = params.get("name")
+    content = params.get("content")
+
+    if not isinstance(name, str) or not name:
+        return CommandResult.fail("Missing or empty 'name' parameter")
+    if not isinstance(content, str) or content == "":
+        return CommandResult.fail("Missing or empty 'content' parameter")
+
+    # --- name validation -------------------------------------------------
+    # Enforce bare basename: no "/", no "..", no leading ".".
+    # Length cap applies to the pre-suffix form.
+    bare_name = name[:-5] if name.endswith(".conf") else name
+    if (
+        "/" in bare_name
+        or bare_name.startswith(".")
+        or ".." in bare_name
+        or not bare_name
+        or len(bare_name) > _HBA_NAME_MAX
+    ):
+        return CommandResult.fail(f"Invalid hba name: {name!r}")
+
+    # --- content validation ---------------------------------------------
+    if not content.endswith("\n"):
+        content = content + "\n"
+
+    for idx, line in enumerate(content.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split()
+        if not parts or parts[0] not in _HBA_PREFIXES:
+            return CommandResult.fail(
+                f"Invalid hba line {idx}: expected one of {sorted(_HBA_PREFIXES)}, got {parts[0]!r}"
+                if parts
+                else f"Invalid hba line {idx}: empty"
+            )
+
+    # --- path + idempotency ---------------------------------------------
+    filename = f"{bare_name}.conf"
+    target = Path(PG_HBA_D) / filename
+
+    # Byte-for-byte existence check. Refuse to follow a symlink target.
+    try:
+        lst = os.lstat(target)
+    except FileNotFoundError:
+        lst = None
+    except OSError as exc:
+        return CommandResult.fail(f"Failed to stat {target}: {exc}")
+
+    if lst is not None and stat.S_ISLNK(lst.st_mode):
+        return CommandResult.fail(f"Refusing to write: {target} is a symbolic link")
+
+    if lst is not None:
+        try:
+            fd = os.open(target, os.O_RDONLY | os.O_NOFOLLOW)
+        except OSError as exc:
+            return CommandResult.fail(f"Failed to open {target}: {exc}")
+        try:
+            with os.fdopen(fd, "r", encoding="utf-8") as f:
+                existing = f.read()
+        except OSError as exc:
+            return CommandResult.fail(f"Failed to read {target}: {exc}")
+        if existing == content:
+            logger.info("postgres.add_hba no-op: %s already current", target)
+            no_op: PostgresAddHbaData = {"reloaded": False, "changed": False}
+            return CommandResult.ok(no_op)
+
+    # --- atomic write ----------------------------------------------------
+    parent = target.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return CommandResult.fail(f"Failed to ensure parent dir {parent}: {exc}")
+
+    tmp_fd: int | None = None
+    tmp_name: str | None = None
+    try:
+        tmp_fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            dir=str(parent),
+        )
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            tmp_fd = None
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_name, _HBA_FILE_MODE)
+        _chown_postgres(tmp_name)
+        os.rename(tmp_name, target)
+        tmp_name = None
+    except OSError as exc:
+        return CommandResult.fail(f"Failed to write {target}: {exc}")
+    finally:
+        if tmp_fd is not None:
+            try:
+                os.close(tmp_fd)
+            except OSError:
+                pass
+        if tmp_name is not None:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+
+    logger.info("postgres.add_hba wrote %s (mode=0%o)", target, _HBA_FILE_MODE)
+
+    # --- reload ----------------------------------------------------------
+    warnings: list[str] = []
+    reloaded = False
+    try:
+        reloaded = _reload_conf()
+    except subprocess.CalledProcessError as exc:
+        return CommandResult(
+            success=False,
+            error=(
+                f"pg_reload_conf() failed: {exc.stderr.strip() or exc}. "
+                f"File {target} was written; run 'systemctl reload postgresql' manually."
+            ),
+        )
+
+    if not reloaded:
+        warnings.append(
+            f"pg_reload_conf() returned false (postgres may not be running); "
+            f"{target} written but reload did not take effect"
+        )
+        logger.warning("postgres.add_hba: pg_reload_conf() returned false for %s", target)
+
+    data: PostgresAddHbaData = {"reloaded": reloaded, "changed": True}
+    return CommandResult(success=True, data=data, warnings=warnings)
+
+
+@register_handler(Command.POSTGRES_ROTATE_PASSWORD, roles={"db"})
+def handle_rotate_password(params: dict[str, Any]) -> CommandResult:
+    """Generate a new password for a role and deliver it to ``peer_id``.
+
+    See module docstring for the contract.
+    """
+    role = params.get("role")
+    peer_id = params.get("peer_id")
+
+    for key, val in (("role", role), ("peer_id", peer_id)):
+        if not isinstance(val, str) or not val:
+            return CommandResult.fail(f"Missing or empty '{key}' parameter")
+
+    assert isinstance(role, str)
+    assert isinstance(peer_id, str)
+
+    if not _valid_ident(role):
+        return CommandResult.fail(f"Invalid role name: {role!r}")
+
+    try:
+        if not _role_exists(role):
+            return CommandResult.fail(f"Role does not exist: {role!r}")
+    except subprocess.CalledProcessError as exc:
+        return CommandResult.fail(f"psql failed: {exc.stderr.strip() or exc}")
+
+    new_password = _stdlib_secrets.token_urlsafe(32)
+    try:
+        _alter_role_password(role, new_password)
+    except subprocess.CalledProcessError as exc:
+        return CommandResult.fail(f"psql failed: {exc.stderr.strip() or exc}")
+    logger.info("postgres.rotate_password altered role %s", role)
+
+    # Delivery — on any failure, run a best-effort password revoke.
+    client = _get_rpc_client()
+    warnings: list[str] = []
+    try:
+        delivery = _deliver_password(client, peer_id, new_password)
+    except TimeoutError:
+        _best_effort_revoke(role, warnings)
+        return CommandResult(
+            success=False,
+            error="secrets.deliver timed out",
+            warnings=warnings,
+        )
+    except Exception as exc:  # noqa: BLE001 — transport-level surface
+        _best_effort_revoke(role, warnings)
+        return CommandResult(
+            success=False,
+            error=f"secrets.deliver transport error: {exc}",
+            warnings=warnings,
+        )
+
+    if not delivery.success:
+        _best_effort_revoke(role, warnings)
+        return CommandResult(
+            success=False,
+            error=f"secrets.deliver failed: {delivery.error or 'unknown error'}",
+            warnings=warnings,
+        )
+
+    data: PostgresRotatePasswordData = {"delivered_to": peer_id, "changed": True}
+    return CommandResult.ok(data)
+
+
+def _best_effort_revoke(role: str, warnings: list[str]) -> None:
+    """Null the password on ``role`` and append any failure to ``warnings``."""
+    try:
+        _revoke_role_password(role)
+    except subprocess.CalledProcessError as exc:
+        msg = (
+            f"Best-effort password revoke for {role!r} failed after delivery error: "
+            f"{exc.stderr.strip() or exc}. Operator must re-run rotate_password."
+        )
+        warnings.append(msg)
+        logger.warning("postgres.rotate_password revoke failed: %s", msg)
+    except OSError as exc:
+        msg = f"Best-effort password revoke for {role!r} failed: {exc}"
+        warnings.append(msg)
+        logger.warning("postgres.rotate_password revoke failed: %s", msg)

--- a/src/rots/commands/sidecar/handlers/secrets.py
+++ b/src/rots/commands/sidecar/handlers/secrets.py
@@ -1,0 +1,289 @@
+# src/rots/commands/sidecar/handlers/secrets.py
+
+"""``secrets.deliver`` — hardened write-if-different of application secrets
+into the OTS env file.
+
+This handler is the web sidecar's slice of the two-phase provisioning flow
+(issue #55). The db sidecar generates application passwords, then publishes
+``secrets.deliver`` at the web peer so the secret lands in
+``/etc/default/onetimesecret`` without ever touching a log, shell history,
+or intermediate file on the db side.
+
+Hardening:
+
+* Allowlisted ``env_file`` — only ``/etc/default/onetimesecret``.
+* Allowlisted ``name`` — only ``PG_PASSWORD`` and ``VALKEY_PASSWORD``.
+* ``O_NOFOLLOW`` on the target path (and ``lstat`` pre-check) — a symlinked
+  env file is rejected before anything is written.
+* Atomic replace via ``os.rename`` of a same-directory tempfile — a crash
+  mid-write leaves the original file intact.
+* Mode ``0640`` — readable by the service user (via group), not world.
+* The secret value is never logged. Only the ``name`` and ``path``.
+
+Role: registered for ``{"db", "web"}`` — the db sidecar also runs it so a
+single-host test setup can exercise the flow end-to-end without a second
+host.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import stat
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from rots.sidecar.commands import Command, CommandResult, register_handler
+
+from ._types import SecretsDeliverData
+
+logger = logging.getLogger(__name__)
+
+# Hardened allowlist. Expand here (and in ALLOWED_NAMES) only after a threat
+# model review — broadening this surface is the first thing an attacker will
+# try to exploit if they find an RPC publish path.
+ALLOWED_ENV_FILE: str = "/etc/default/onetimesecret"
+ALLOWED_NAMES: frozenset[str] = frozenset({"PG_PASSWORD", "VALKEY_PASSWORD"})
+
+# File mode for the env file — readable by owner, readable by group (so the
+# rootless container user in the `onetimesecret` group can load it), not
+# world-readable. Matches what `rots env process` sets today.
+ENV_FILE_MODE = 0o640
+
+
+@register_handler(Command.SECRETS_DELIVER, roles={"db", "web"})
+def handle_secrets_deliver(params: dict[str, Any]) -> CommandResult:
+    """Write a named secret into the OTS env file, atomically and idempotently.
+
+    Params:
+        name (str): Which env variable to set. Must be a member of
+            :data:`ALLOWED_NAMES`. Unknown names are rejected before any
+            filesystem work.
+        value (str): The secret value. Not logged; only its presence is
+            checked. Empty-string values are accepted (treated as a
+            deliberate clear) — caller is expected to validate upstream.
+        env_file (str, optional): Target env file. Must equal
+            :data:`ALLOWED_ENV_FILE`. Defaults to that value. Anything else
+            is rejected.
+
+    Returns:
+        :class:`CommandResult` with ``data`` matching
+        :class:`SecretsDeliverData`.
+
+        * On idempotent no-op (value already matches):
+          ``{"written": False, "path": ..., "changed": False}``
+        * On mutation:
+          ``{"written": True, "path": ..., "changed": True}``
+
+    Rejection cases (all return ``CommandResult.fail(...)``):
+
+    * ``name`` missing, or not in :data:`ALLOWED_NAMES`
+    * ``value`` missing (``None``) — empty string is accepted
+    * ``env_file`` not equal to :data:`ALLOWED_ENV_FILE`
+    * Target path is a symlink (``lstat`` test), defeating a TOCTOU redirect
+    * ``OSError`` raised anywhere during the atomic write — the on-disk
+      file is left intact (``os.rename`` is atomic on POSIX within a dir).
+    """
+    # --- allowlist gates --------------------------------------------------
+    name = params.get("name")
+    if not isinstance(name, str) or not name:
+        return CommandResult.fail("Missing or empty 'name' parameter")
+    if name not in ALLOWED_NAMES:
+        return CommandResult.fail(
+            f"Rejected secret name: {name!r}. Allowed names: {sorted(ALLOWED_NAMES)}"
+        )
+
+    if "value" not in params:
+        return CommandResult.fail("Missing 'value' parameter")
+    value = params["value"]
+    if not isinstance(value, str):
+        return CommandResult.fail(f"'value' must be a string, got {type(value).__name__}")
+
+    env_file = params.get("env_file", ALLOWED_ENV_FILE)
+    if env_file != ALLOWED_ENV_FILE:
+        return CommandResult.fail(
+            f"Rejected env_file: {env_file!r}. Only {ALLOWED_ENV_FILE!r} is permitted."
+        )
+
+    path = Path(env_file)
+
+    # --- symlink defence --------------------------------------------------
+    # If the path exists as a symlink, refuse. We deliberately do not resolve
+    # and proceed — a symlink is a hijack vector (attacker with write access
+    # to the parent dir could have repointed it).
+    try:
+        lst = os.lstat(path)
+    except FileNotFoundError:
+        lst = None
+    except OSError as exc:
+        return CommandResult.fail(f"Failed to stat {env_file}: {exc}")
+
+    if lst is not None and stat.S_ISLNK(lst.st_mode):
+        return CommandResult.fail(f"Refusing to write: {env_file} is a symbolic link")
+
+    # --- read current content (NOFOLLOW on the real open) -----------------
+    current_lines: list[str] = []
+    if lst is not None:
+        try:
+            fd = os.open(path, os.O_RDONLY | os.O_NOFOLLOW)
+        except OSError as exc:
+            return CommandResult.fail(f"Failed to open {env_file}: {exc}")
+        try:
+            with os.fdopen(fd, "r", encoding="utf-8") as f:
+                current_lines = f.read().splitlines(keepends=True)
+        except OSError as exc:
+            return CommandResult.fail(f"Failed to read {env_file}: {exc}")
+
+    # --- compute updated content ------------------------------------------
+    new_lines, changed = _set_env_key(current_lines, name, value)
+
+    if not changed:
+        # No-op: content matches. Do NOT rewrite — preserve mtime so external
+        # watchers (systemd path units, etc.) do not see a spurious change.
+        logger.info("secrets.deliver no-op: %s already set in %s", name, env_file)
+        return CommandResult.ok(SecretsDeliverData(written=False, path=str(path), changed=False))
+
+    # --- atomic write-if-different ----------------------------------------
+    # Tempfile in the same directory so os.rename is atomic. delete=False so
+    # we can rename it into place; on exception we clean up manually.
+    new_body = "".join(new_lines)
+    parent = path.parent
+    try:
+        parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        return CommandResult.fail(f"Failed to ensure parent dir {parent}: {exc}")
+
+    tmp_fd: int | None = None
+    tmp_name: str | None = None
+    try:
+        tmp_fd, tmp_name = tempfile.mkstemp(
+            prefix=f".{path.name}.",
+            suffix=".tmp",
+            dir=str(parent),
+        )
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as f:
+            tmp_fd = None  # fdopen owns it now — do not double-close
+            f.write(new_body)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp_name, ENV_FILE_MODE)
+        os.rename(tmp_name, path)
+        tmp_name = None  # renamed, no cleanup needed
+    except OSError as exc:
+        return CommandResult.fail(f"Atomic write failed for {env_file}: {exc}")
+    finally:
+        if tmp_fd is not None:
+            try:
+                os.close(tmp_fd)
+            except OSError:
+                pass
+        if tmp_name is not None:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+
+    logger.info(
+        "secrets.deliver wrote %s into %s (mode=0%o)",
+        name,
+        env_file,
+        ENV_FILE_MODE,
+    )
+    return CommandResult.ok(SecretsDeliverData(written=True, path=str(path), changed=True))
+
+
+# --- env-file round-trip helper ------------------------------------------
+
+
+def _set_env_key(
+    lines: list[str],
+    name: str,
+    value: str,
+) -> tuple[list[str], bool]:
+    """Return (new_lines, changed) after applying ``name=value`` to ``lines``.
+
+    Behaviour:
+
+    * If ``name`` already appears as a non-commented assignment and the
+      existing value (with surrounding quotes stripped) equals ``value``,
+      nothing changes and ``changed=False``.
+    * If ``name`` already appears with a different value, the line is
+      replaced in place with ``name=value``. Line ending is preserved if
+      the original had one; otherwise a trailing newline is added.
+    * If ``name`` does not appear, a new ``name=value`` line is appended at
+      the end of the file. A trailing newline is ensured.
+    * Comments and other keys are preserved byte-for-byte.
+
+    The quoting of the emitted ``name=value`` line follows a conservative
+    rule: if ``value`` contains whitespace, ``#``, or quotes, it is
+    double-quoted with existing double-quotes escaped. Otherwise it is
+    written bare. This matches shell-source semantics used by systemd's
+    ``EnvironmentFile=``.
+    """
+    formatted = _format_assignment(name, value)
+    prefix = f"{name}="
+
+    found = False
+    new_lines: list[str] = []
+    for line in lines:
+        stripped = line.lstrip()
+        if stripped.startswith("#") or "=" not in stripped:
+            new_lines.append(line)
+            continue
+        key, _, rest = stripped.partition("=")
+        if key.strip() != name:
+            new_lines.append(line)
+            continue
+        # Found the assignment. Compare values.
+        existing_value = _parse_value(rest.rstrip("\n"))
+        if existing_value == value:
+            new_lines.append(line)
+            found = True
+            continue
+        # Replace, preserve trailing newline if present.
+        trailing = "\n" if line.endswith("\n") else ""
+        new_lines.append(formatted + trailing)
+        found = True
+
+    if found:
+        # Whether changed depends on whether any replacement happened; compare
+        # outputs.
+        return new_lines, new_lines != lines
+
+    # Append. Ensure a trailing newline on the prior last line first so we
+    # never produce "OTHER=valNEW=val\n".
+    if new_lines and not new_lines[-1].endswith("\n"):
+        new_lines[-1] = new_lines[-1] + "\n"
+    new_lines.append(formatted + "\n")
+    _ = prefix  # kept for clarity / future use
+    return new_lines, True
+
+
+def _format_assignment(name: str, value: str) -> str:
+    """Render a ``name=value`` line with conservative quoting."""
+    needs_quote = any(c.isspace() for c in value) or any(
+        c in value for c in ('"', "'", "#", "=", "$", "\\", "`")
+    )
+    if not needs_quote and value != "":
+        return f"{name}={value}"
+    escaped = value.replace("\\", "\\\\").replace('"', '\\"')
+    return f'{name}="{escaped}"'
+
+
+def _parse_value(raw: str) -> str:
+    """Strip surrounding single or double quotes from an env-file value.
+
+    Does not interpret backslash escapes — the one-sided inverse of
+    :func:`_format_assignment`. Good enough for the comparison in
+    :func:`_set_env_key` because we round-trip our own output, and any
+    value that came from our writer uses only double quotes with ``\\"``
+    escapes.
+    """
+    v = raw.strip()
+    if len(v) >= 2 and v[0] == v[-1] and v[0] in ('"', "'"):
+        inner = v[1:-1]
+        if v[0] == '"':
+            inner = inner.replace('\\"', '"').replace("\\\\", "\\")
+        return inner
+    return v

--- a/src/rots/commands/sidecar/handlers/secrets.py
+++ b/src/rots/commands/sidecar/handlers/secrets.py
@@ -170,6 +170,18 @@ def handle_secrets_deliver(params: dict[str, Any]) -> CommandResult:
         os.chmod(tmp_name, ENV_FILE_MODE)
         os.rename(tmp_name, path)
         tmp_name = None  # renamed, no cleanup needed
+        # Preserve pre-existing owner/group. The tempfile was created by the
+        # sidecar process (likely root); without this restore the onetimesecret
+        # group bit that the container user depends on would be dropped.
+        if lst is not None:
+            try:
+                os.chown(path, lst.st_uid, lst.st_gid)
+            except OSError as exc:
+                logger.warning(
+                    "secrets.deliver: failed to restore owner/group on %s: %s",
+                    env_file,
+                    exc,
+                )
     except OSError as exc:
         return CommandResult.fail(f"Atomic write failed for {env_file}: {exc}")
     finally:

--- a/src/rots/commands/sidecar/handlers/valkey.py
+++ b/src/rots/commands/sidecar/handlers/valkey.py
@@ -8,19 +8,25 @@ application ACL users and reload the ACL file after external edits.
 Auth model
 ----------
 The sidecar authenticates to local valkey as the fixed bootstrap user
-``bootstrap`` (provisioned by upstream cloud-init, lots #41, which also
-disables the ``default`` user). The bootstrap token is sealed into the
-systemd credstore and mounted into the sidecar unit's runtime credential
-directory via ``LoadCredentialEncrypted=valkey-bootstrap-token:…``.
-systemd decrypts the token at service start and exposes it at
+``bootstrap`` (provisioned by upstream cloud-init, lots #41, alongside
+the app's ``default`` user, which stays enabled with its own password —
+the onetimesecret client cannot currently carry a username in its
+connection URL, so it must connect as ``default``). The bootstrap token
+is sealed into the systemd credstore and mounted into the sidecar unit's
+runtime credential directory via
+``LoadCredentialEncrypted=valkey-bootstrap-token:…``. systemd decrypts
+the token at service start and exposes it at
 ``$CREDENTIALS_DIRECTORY/valkey-bootstrap-token``; this handler reads
 that path per-invocation (no caching, so rotations are picked up).
-Callers running outside a systemd unit (tests, interactive debugging)
-have no ``CREDENTIALS_DIRECTORY`` set and fall through to unauthenticated
-loopback. The on-disk ``/etc/valkey/users.acl`` is root/valkey-owned
-mode 0640 and is never read by this handler. All commands are issued
-through ``valkey-cli`` to ``127.0.0.1:6379``; no TCP credentials ship
-over the wire.
+When ``CREDENTIALS_DIRECTORY`` is unset (running outside a systemd unit
+— tests, interactive debugging), the handler falls through to
+unauthenticated ``valkey-cli``. That is transparent in test fixtures
+that leave ``default on nopass``; in production (``default on`` with
+``requirepass``) the fall-through surfaces ``NOAUTH`` on the next
+command — loud failure, not a silent degradation. The on-disk
+``/etc/valkey/users.acl`` is root/valkey-owned mode 0640 and is never
+read by this handler. All commands are issued through ``valkey-cli``
+to ``127.0.0.1:6379``; no TCP credentials ship over the wire.
 
 Cross-host delivery
 -------------------
@@ -132,7 +138,7 @@ _CREDENTIAL_NAME = "valkey-bootstrap-token"
 _VALKEY_CLI_TIMEOUT = 10
 
 # Name validation: same identifier shape as Postgres roles. Valkey also rejects
-# the literal ``default`` (reserved for the bootstrap user), handled separately.
+# the literal ``default`` (valkey's built-in ACL user), handled separately.
 _NAME_MAX_LEN = 64
 
 # Known ACL GETUSER field names and whether the value is an array (True) or
@@ -178,8 +184,10 @@ def _load_bootstrap_auth() -> tuple[str, str] | None:
     mounts the sealed bootstrap token as ``valkey-bootstrap-token`` inside
     that directory. Callers running outside a systemd unit (tests,
     interactive debugging) have no ``CREDENTIALS_DIRECTORY`` set and fall
-    through to unauthenticated loopback — safe in test fixtures where
-    valkey's ``default on nopass`` user still applies.
+    through. In test fixtures that leave ``default on nopass`` this is
+    transparent; in production (``default on`` with ``requirepass``) the
+    next ``valkey-cli`` call will surface ``NOAUTH`` and fail loudly —
+    the intended failure mode when the credstore is missing its token.
 
     Called per-invocation (no caching) so a rotated token is picked up on
     the next RPC without restarting the sidecar.
@@ -436,7 +444,7 @@ def handle_create_acl_user(params: dict[str, Any]) -> CommandResult:
     if not isinstance(name, str) or not name:
         return CommandResult.fail("Missing or empty 'name' parameter")
     if name == "default":
-        return CommandResult.fail("Rejected ACL name 'default': reserved for the bootstrap user")
+        return CommandResult.fail("Rejected ACL name 'default': reserved built-in valkey user")
     if not _is_valid_name(name):
         return CommandResult.fail(
             f"Invalid ACL name: {name!r}. Must match ^[A-Za-z_][A-Za-z0-9_]{{0,63}}$"

--- a/src/rots/commands/sidecar/handlers/valkey.py
+++ b/src/rots/commands/sidecar/handlers/valkey.py
@@ -1,0 +1,654 @@
+# src/rots/commands/sidecar/handlers/valkey.py
+
+"""Valkey provisioning handlers (``valkey.*``).
+
+These handlers run on the **db sidecar** (``roles={"db"}``). They manage
+application ACL users and reload the ACL file after external edits.
+
+Auth model
+----------
+The sidecar reads the bootstrap ACL user + token from
+``/etc/valkey/users.acl`` — dropped in by cloud-init via
+``LoadCredentialEncrypted`` (see the parent issue #37). All commands are
+issued through ``valkey-cli`` to ``127.0.0.1:6379`` using the bootstrap
+user. No TCP credentials ship over the wire.
+
+Cross-host delivery
+-------------------
+Generated tokens travel to the web peer via ``secrets.deliver`` on the
+``peer_id`` sidecar. Same seam as postgres handlers:
+``_get_rpc_client()`` returns an :class:`RpcClient` that tests can
+monkeypatch.
+
+ACL file layout
+---------------
+Valkey's ACL config lives at :data:`ACL_FILE`. ``ACL SETUSER`` is natively
+idempotent *for the rules it spells out*, but persistence across restarts
+requires ``ACL SAVE``. Implementations MUST call ``ACL SAVE`` after
+every mutating operation.
+
+ACL GETUSER parsing
+-------------------
+``valkey-cli`` returns ``ACL GETUSER`` in a flat line-oriented form with
+known field names alternating with their values. Valkey 8.x emits:
+
+* ``flags``, ``passwords``, ``selectors`` as arrays (one entry per line;
+  an empty array is rendered as a single blank line).
+* ``commands``, ``keys``, ``channels`` as scalars (one line, possibly
+  blank).
+
+:func:`_parse_acl_getuser` walks lines using the known-field map to know
+whether the next lines are array elements or a scalar, stopping when
+``selectors`` is reached (nested selector content is not needed for
+idempotency).
+
+Rule comparison
+---------------
+ACL rules are order-sensitive: ``+@all -@admin`` grants all commands
+except the admin category, while ``-@admin +@all`` grants all commands
+(the second ``+@all`` supersedes the earlier ``-@admin``). The stored
+canonical form surfaced by ``ACL GETUSER`` preserves this order,
+normalised as follows:
+
+* A fresh user starts with no commands; Valkey prepends an implicit
+  ``-@all`` to the stored ``commands`` string unless ``+@all`` /
+  ``allcommands`` was specified **first** in the rule list.
+* ``allcommands`` / ``allkeys`` / ``nocommands`` / ``resetkeys`` are
+  spelled-out in stored form as ``+@all`` / ``~*`` / ``-@all`` / (cleared).
+* Command names are lowercased (``+GET`` → ``+get``); category tags
+  keep their case (``+@READ`` remains uppercase — but in practice callers
+  always write categories lowercase).
+
+:func:`_normalise_input_rules` applies the above transforms to produce
+an **ordered list** of expected ``command_tokens`` and an ordered list
+of ``key_tokens``. The handler compares these lists to the stored
+``commands`` / ``keys`` from ``ACL GETUSER`` (also split on whitespace
+into ordered lists). Equality means the caller asked for the same rules
+in the same order as last time.
+
+Limitation (documented, accepted): Valkey may collapse certain
+adjacent rules when they are fully superseded (e.g. ``+get +@all`` is
+stored as just ``+@all`` — ``+get`` was redundant). In those rare
+cases our normalisation would disagree with the stored form, triggering
+an unnecessary token rotation. Operators should not pass redundant
+rules; the token-rotation "over-change" is the safe failure mode.
+"""
+
+from __future__ import annotations
+
+import logging
+import secrets
+import subprocess
+from typing import Any
+
+from rots.sidecar.commands import Command, CommandResult, register_handler
+
+from ._transport import RpcClient
+from ._types import ValkeyCreateAclUserData, ValkeyReloadAclData
+
+__all__ = [
+    "ACL_FILE",
+    "VALKEY_CLI",
+    "RpcClient",
+    "ValkeyCreateAclUserData",
+    "ValkeyReloadAclData",
+    "handle_create_acl_user",
+    "handle_reload_acl",
+]
+
+logger = logging.getLogger(__name__)
+
+# ACL file path on Debian/Ubuntu valkey package. Implementations MUST NOT
+# accept an override — this is fixed by the package.
+ACL_FILE: str = "/etc/valkey/users.acl"
+
+# valkey-cli invocation. Implementations build on this with `-a` and the
+# bootstrap user loaded from the env file.
+VALKEY_CLI: tuple[str, ...] = ("valkey-cli", "-h", "127.0.0.1", "-p", "6379")
+
+# Timeout for valkey-cli subprocess calls. Short — a healthy local daemon
+# answers in milliseconds.
+_VALKEY_CLI_TIMEOUT = 10
+
+# Name validation: same identifier shape as Postgres roles. Valkey also rejects
+# the literal ``default`` (reserved for the bootstrap user), handled separately.
+_NAME_MAX_LEN = 64
+
+# Known ACL GETUSER field names and whether the value is an array (True) or
+# scalar (False). Order of insertion matches Valkey 8.x output order; the
+# parser uses membership to decide when a new field begins, not this order.
+_GETUSER_ARRAY_FIELDS: frozenset[str] = frozenset({"flags", "passwords", "selectors"})
+_GETUSER_SCALAR_FIELDS: frozenset[str] = frozenset({"commands", "keys", "channels"})
+_GETUSER_ALL_FIELDS: frozenset[str] = _GETUSER_ARRAY_FIELDS | _GETUSER_SCALAR_FIELDS
+
+
+def _get_rpc_client() -> RpcClient:
+    """Return an :class:`RpcClient`. Test seam — see postgres.py docstring."""
+    from ._transport import RabbitMqRpcClient
+
+    return RabbitMqRpcClient()
+
+
+# --- helpers ---------------------------------------------------------------
+
+
+def _is_valid_name(name: str) -> bool:
+    """Validate ACL username shape.
+
+    Matches ``^[A-Za-z_][A-Za-z0-9_]{0,63}$``. ``default`` is rejected at
+    the handler level with a clearer error (not here).
+    """
+    if not name or len(name) > _NAME_MAX_LEN:
+        return False
+    first = name[0]
+    if not (first.isalpha() or first == "_"):
+        return False
+    for c in name[1:]:
+        if not (c.isalnum() or c == "_"):
+            return False
+    return True
+
+
+def _run_valkey_cli(*args: str) -> subprocess.CompletedProcess[str]:
+    """Run ``valkey-cli`` with the supplied args. Arguments are passed through
+    as a tuple — never shell-interpolated.
+
+    ``check=True`` will raise ``CalledProcessError`` on non-zero exit (the
+    connection-refused case). A logical error (``ERR ...``) still comes back
+    with exit 0; callers MUST inspect stdout.
+    """
+    return subprocess.run(
+        VALKEY_CLI + args,
+        check=True,
+        capture_output=True,
+        text=True,
+        timeout=_VALKEY_CLI_TIMEOUT,
+    )
+
+
+def _is_err_response(stdout: str) -> bool:
+    """Return True when ``valkey-cli`` printed a server error on stdout.
+
+    valkey-cli exits 0 on logical errors — the only reliable signal is the
+    ``ERR `` prefix on stdout (``WRONGTYPE``, ``NOAUTH``, etc. start with
+    an all-caps code followed by space; this covers the subset we care
+    about in this handler).
+    """
+    stripped = stdout.lstrip()
+    return stripped.startswith("ERR ") or stripped.startswith("NOAUTH ")
+
+
+def _parse_acl_getuser(stdout: str) -> dict[str, Any] | None:
+    """Parse the flat ``ACL GETUSER`` output into a dict.
+
+    Returns ``None`` when the user does not exist (valkey-cli emits an
+    empty response). Otherwise returns a dict with keys matching
+    :data:`_GETUSER_ALL_FIELDS` and whatever shape is documented in the
+    module docstring.
+
+    This does NOT parse ``selectors`` contents — we stop at the
+    ``selectors`` field name. The top-level ``commands`` + ``keys`` are
+    sufficient for the idempotency guard.
+    """
+    if not stdout.strip():
+        return None
+
+    # splitlines() discards the terminator. We keep empty lines because they
+    # are the scalar-empty and empty-array markers.
+    lines = stdout.splitlines()
+    result: dict[str, Any] = {}
+    i = 0
+    n = len(lines)
+    while i < n:
+        key = lines[i]
+        if key not in _GETUSER_ALL_FIELDS:
+            # Unknown token at top level — skip. Defensive: newer Valkey
+            # versions could add fields; we ignore them rather than crashing.
+            i += 1
+            continue
+
+        if key == "selectors":
+            # Stop here; we don't need selector contents for idempotency.
+            result.setdefault("selectors", [])
+            break
+
+        if key in _GETUSER_SCALAR_FIELDS:
+            # Next line is the scalar value (may be empty).
+            value = lines[i + 1] if i + 1 < n else ""
+            result[key] = value
+            i += 2
+            continue
+
+        # Array field: consume lines until we hit another known field name
+        # or run out of input. Empty arrays surface as a single blank line
+        # (one consumed, zero elements captured).
+        entries: list[str] = []
+        i += 1
+        while i < n and lines[i] not in _GETUSER_ALL_FIELDS:
+            if lines[i] != "" or entries:
+                # Skip the leading blank that represents an empty array,
+                # but keep blanks that appear inside non-empty arrays
+                # (defensive — shouldn't happen in practice).
+                entries.append(lines[i])
+            i += 1
+        result[key] = entries
+
+    return result
+
+
+def _normalise_input_rules(rules: list[str]) -> tuple[list[str], list[str]]:
+    """Reduce input ``rules`` to ``(command_tokens, key_tokens)`` as ordered lists.
+
+    Mirrors Valkey's canonical normalisation so the result can be
+    compared to the stored ``commands`` / ``keys`` from ``ACL GETUSER``
+    via list equality. See the module docstring's "Rule comparison"
+    section for the full specification, including the documented
+    collapse-of-redundant-rules limitation.
+    """
+    cmd_tokens: list[str] = []
+    key_tokens: list[str] = []
+    first_cmd_is_plus_all = False
+
+    for raw in rules:
+        # ``rules`` tokens are validated elsewhere to be non-empty and
+        # whitespace-free; we still skip the empty-string case defensively.
+        if not raw:
+            continue
+
+        if raw == "allcommands":
+            if not cmd_tokens:
+                first_cmd_is_plus_all = True
+            cmd_tokens.append("+@all")
+            continue
+        if raw == "nocommands":
+            cmd_tokens.append("-@all")
+            continue
+        if raw == "allkeys":
+            key_tokens.append("~*")
+            continue
+        if raw == "resetkeys":
+            key_tokens.clear()
+            continue
+
+        if raw.startswith(("+", "-")):
+            # Category rules (``+@read`` / ``-@admin``) keep their case;
+            # plain commands (``+GET``) are lowercased by Valkey.
+            if len(raw) >= 2 and raw[1] == "@":
+                normalised = raw
+            else:
+                normalised = raw[0] + raw[1:].lower()
+            if not cmd_tokens and normalised == "+@all":
+                first_cmd_is_plus_all = True
+            cmd_tokens.append(normalised)
+            continue
+
+        if raw.startswith("~") or raw.startswith("%"):
+            key_tokens.append(raw)
+            continue
+
+        # Auth / selector / unknown tokens (``on``, ``off``, ``>pw``,
+        # ``<pw``, ``#hash``, ``!hash``, ``nopass``, ``resetpass``,
+        # ``(...)``) don't participate in the commands/keys comparison.
+        continue
+
+    # Apply Valkey's implicit ``-@all``: a fresh user starts with no
+    # commands, so unless the very first command-shaping rule was
+    # ``+@all`` / ``allcommands``, Valkey renders the stored form with
+    # a leading ``-@all``. Only add when there are command-shaping
+    # rules — a user with zero ``+X``/``-X`` tokens has an empty
+    # ``commands`` field in GETUSER.
+    if cmd_tokens and not first_cmd_is_plus_all:
+        cmd_tokens.insert(0, "-@all")
+
+    return cmd_tokens, key_tokens
+
+
+def _stored_rule_tokens(getuser: dict[str, Any]) -> tuple[list[str], list[str]]:
+    """Extract ``(command_tokens, key_tokens)`` from a parsed GETUSER dict."""
+    commands_raw = getuser.get("commands", "")
+    keys_raw = getuser.get("keys", "")
+    commands_str = commands_raw if isinstance(commands_raw, str) else ""
+    keys_str = keys_raw if isinstance(keys_raw, str) else ""
+    return commands_str.split(), keys_str.split()
+
+
+@register_handler(Command.VALKEY_CREATE_ACL_USER, roles={"db"})
+def handle_create_acl_user(params: dict[str, Any]) -> CommandResult:
+    """Create (or update) an ACL user, generate a token, deliver it.
+
+    Params:
+        name (str, required): ACL username. MUST match
+            ``^[A-Za-z_][A-Za-z0-9_]{0,63}$``. Valkey rejects ``default``
+            as a name — reject it here with a clearer error.
+        rules (list[str], required): Valkey ACL rule strings, passed
+            through to ``ACL SETUSER <name> <rules...> ><token>``.
+            Implementations MUST NOT sort or dedupe — ACL rules are order-
+            sensitive (``allcommands`` before ``-@admin`` differs from the
+            reverse). Validate: every rule is a non-empty string, no rule
+            contains whitespace inside itself (each rule is one token).
+        peer_id (str, required): Web sidecar ``host_id`` to receive the
+            generated token.
+
+    Behaviour (idempotent on rules, always rotates on token):
+
+    1. Validate name + rules.
+    2. Check existing user: ``ACL GETUSER <name>``. Parse the response's
+       ``commands`` and ``keys`` fields into a rule list.
+    3. Compare current rules against ``rules``. If identical, DO NOT
+       rotate the token — return early with ``changed=False`` and
+       ``delivered_to=peer_id`` as an informational echo.
+    4. If different (or the user does not exist), generate a fresh token
+       (``secrets.token_urlsafe(40)``) and issue
+       ``ACL SETUSER <name> on >token <rules...>`` (``on`` enables login).
+    5. ``ACL SAVE`` to persist.
+    6. Publish ``secrets.deliver`` at ``peer_id`` with
+       ``{"name": "VALKEY_PASSWORD", "value": <token>}``. On failure, undo
+       with ``ACL DELUSER <name>`` (best-effort) and return
+       :class:`CommandResult.fail`.
+
+    Idempotency guard: parsed-rule comparison between ``ACL GETUSER``
+    output and ``rules``.
+
+    Side effects (first run / changed rules):
+
+    * Issues ``ACL SETUSER``.
+    * Issues ``ACL SAVE``.
+    * Publishes ``secrets.deliver`` at ``peer_id``.
+
+    Side effects (re-run with same rules): none.
+
+    Return data matches :class:`ValkeyCreateAclUserData`. ``changed`` is
+    ``True`` iff rules differed and a new token was delivered.
+
+    Error mapping:
+
+    * Validation failure → :class:`CommandResult.fail`, no valkey-cli
+      call runs.
+    * Non-zero exit from ``valkey-cli`` → :class:`CommandResult.fail`
+      (``"valkey-cli failed: <stderr>"``).
+    * :class:`TimeoutError` from RpcClient → ``ACL DELUSER`` rollback +
+      :class:`CommandResult.fail`.
+    """
+    # --- validate params --------------------------------------------------
+    name = params.get("name")
+    if not isinstance(name, str) or not name:
+        return CommandResult.fail("Missing or empty 'name' parameter")
+    if name == "default":
+        return CommandResult.fail("Rejected ACL name 'default': reserved for the bootstrap user")
+    if not _is_valid_name(name):
+        return CommandResult.fail(
+            f"Invalid ACL name: {name!r}. Must match ^[A-Za-z_][A-Za-z0-9_]{{0,63}}$"
+        )
+
+    rules = params.get("rules")
+    if not isinstance(rules, list) or not rules:
+        return CommandResult.fail("Missing or empty 'rules' parameter (list required)")
+    for idx, rule in enumerate(rules):
+        if not isinstance(rule, str) or not rule:
+            return CommandResult.fail(f"rules[{idx}] must be a non-empty string; got {rule!r}")
+        if any(c.isspace() for c in rule):
+            return CommandResult.fail(
+                f"rules[{idx}] must not contain whitespace (each rule is one token): {rule!r}"
+            )
+
+    peer_id = params.get("peer_id")
+    if not isinstance(peer_id, str) or not peer_id:
+        return CommandResult.fail("Missing or empty 'peer_id' parameter")
+
+    # --- existence + rule comparison -------------------------------------
+    try:
+        getuser_proc = _run_valkey_cli("ACL", "GETUSER", name)
+    except FileNotFoundError as exc:
+        return CommandResult.fail(f"valkey-cli not found on PATH: {exc}")
+    except subprocess.TimeoutExpired as exc:
+        return CommandResult.fail(f"valkey-cli timed out running ACL GETUSER: {exc}")
+    except subprocess.CalledProcessError as exc:
+        return CommandResult.fail(f"valkey-cli failed: {exc.stderr.strip() or exc}")
+
+    if _is_err_response(getuser_proc.stdout):
+        return CommandResult.fail(f"valkey-cli ACL GETUSER returned: {getuser_proc.stdout.strip()}")
+
+    stored = _parse_acl_getuser(getuser_proc.stdout)
+
+    if stored is not None:
+        input_cmds, input_keys = _normalise_input_rules(rules)
+        stored_cmds, stored_keys = _stored_rule_tokens(stored)
+        logger.debug(
+            "valkey.create_acl_user idempotency check for %s: input_cmds=%s stored_cmds=%s "
+            "input_keys=%s stored_keys=%s",
+            name,
+            input_cmds,
+            stored_cmds,
+            input_keys,
+            stored_keys,
+        )
+        if input_cmds == stored_cmds and input_keys == stored_keys:
+            logger.info("valkey.create_acl_user no-op for %s: rules match stored state", name)
+            data: ValkeyCreateAclUserData = {
+                "delivered_to": peer_id,
+                "changed": False,
+            }
+            return CommandResult.ok(data)
+
+    # --- apply: token + SETUSER + SAVE ----------------------------------
+    token = secrets.token_urlsafe(40)
+    # Rule layout: ``on >token <rules...>`` — matches the behaviour spec.
+    # ``rules`` is validated above as list[str]; cast silences the pyright
+    # unpack-of-Unknown complaint without changing runtime behaviour.
+    rules_strs: list[str] = [str(r) for r in rules]
+    try:
+        setuser_proc = _run_valkey_cli(
+            "ACL",
+            "SETUSER",
+            name,
+            "on",
+            f">{token}",
+            *rules_strs,
+        )
+    except subprocess.TimeoutExpired as exc:
+        return CommandResult.fail(f"valkey-cli timed out running ACL SETUSER: {exc}")
+    except subprocess.CalledProcessError as exc:
+        return CommandResult.fail(f"valkey-cli failed: {exc.stderr.strip() or exc}")
+
+    if _is_err_response(setuser_proc.stdout):
+        return CommandResult.fail(f"valkey-cli ACL SETUSER returned: {setuser_proc.stdout.strip()}")
+
+    warnings: list[str] = []
+
+    # ACL SAVE — persist. Failure is non-fatal but surfaces as a warning
+    # per spec: "On failure of SAVE, still return success but add a warning
+    # in CommandResult.warnings that the change is in-memory only."
+    try:
+        save_proc = _run_valkey_cli("ACL", "SAVE")
+        if _is_err_response(save_proc.stdout):
+            warnings.append(
+                f"ACL SAVE failed; change is in-memory only: {save_proc.stdout.strip()}"
+            )
+    except subprocess.TimeoutExpired:
+        warnings.append("ACL SAVE timed out; change is in-memory only")
+    except subprocess.CalledProcessError as exc:
+        warnings.append(f"ACL SAVE failed; change is in-memory only: {exc.stderr.strip() or exc}")
+
+    # --- deliver token to web peer --------------------------------------
+    # secrets.deliver is cross-host; wrap the rollback in best-effort so a
+    # broker or target-handler failure leaves no orphaned user behind.
+    client = _get_rpc_client()
+    try:
+        delivery = client.publish(
+            peer_id,
+            Command.SECRETS_DELIVER.value,
+            {"name": "VALKEY_PASSWORD", "value": token},
+        )
+    except TimeoutError as exc:
+        _rollback_deluser(name, warnings)
+        logger.warning(
+            "valkey.create_acl_user: secrets.deliver timed out for %s at peer %s",
+            name,
+            peer_id,
+        )
+        del exc  # token value may be in exc; avoid re-raising
+        return CommandResult(
+            success=False,
+            error="secrets.deliver timed out",
+            warnings=warnings,
+        )
+    except Exception as exc:  # noqa: BLE001 — transport errors vary
+        _rollback_deluser(name, warnings)
+        logger.warning(
+            "valkey.create_acl_user: secrets.deliver raised for %s at peer %s: %s",
+            name,
+            peer_id,
+            exc.__class__.__name__,
+        )
+        return CommandResult(
+            success=False,
+            error=f"secrets.deliver transport error: {exc.__class__.__name__}",
+            warnings=warnings,
+        )
+
+    if not delivery.success:
+        _rollback_deluser(name, warnings)
+        logger.warning(
+            "valkey.create_acl_user: secrets.deliver failed for %s at peer %s: %s",
+            name,
+            peer_id,
+            delivery.error,
+        )
+        return CommandResult(
+            success=False,
+            error=f"secrets.deliver failed: {delivery.error}",
+            warnings=warnings,
+        )
+
+    logger.info(
+        "valkey.create_acl_user: user=%s rules_applied=%d delivered_to=%s",
+        name,
+        len(rules),
+        peer_id,
+    )
+    data: ValkeyCreateAclUserData = {
+        "delivered_to": peer_id,
+        "changed": True,
+    }
+    return CommandResult(success=True, data=data, warnings=warnings)
+
+
+def _rollback_deluser(name: str, warnings: list[str]) -> None:
+    """Best-effort ``ACL DELUSER`` rollback.
+
+    Per spec: ``ACL DELUSER`` rollback on delivery failure is best-effort;
+    wrap in try/except and surface as warnings.
+    """
+    try:
+        proc = _run_valkey_cli("ACL", "DELUSER", name)
+        if _is_err_response(proc.stdout):
+            warnings.append(f"Rollback ACL DELUSER failed: {proc.stdout.strip()}")
+            return
+        # Try to persist the rollback too — same forgiving policy.
+        try:
+            save_proc = _run_valkey_cli("ACL", "SAVE")
+            if _is_err_response(save_proc.stdout):
+                warnings.append(f"Rollback ACL SAVE failed: {save_proc.stdout.strip()}")
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            warnings.append(f"Rollback ACL SAVE failed: {exc}")
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired, OSError) as exc:
+        warnings.append(f"Rollback ACL DELUSER failed: {exc}")
+
+
+@register_handler(Command.VALKEY_RELOAD_ACL, roles={"db"})
+def handle_reload_acl(params: dict[str, Any]) -> CommandResult:
+    """Re-read :data:`ACL_FILE` after an external edit.
+
+    Params:
+        None. The handler ignores any params supplied.
+
+    Behaviour:
+
+    1. Before reloading, snapshot the current in-memory ACL via
+       ``ACL LIST``. Compute a sha256 of the sorted output.
+    2. Issue ``ACL LOAD``. If it returns an error (``ERR There is a
+       problem with your ACLs ...``), return
+       :class:`CommandResult.fail` with the error text. The in-memory
+       state is unchanged in this case.
+    3. Snapshot again. If the two hashes differ, ``changed=True``.
+
+    Side effects: ``ACL LOAD`` always runs (this is the point of the
+    command). Only observable state-change flips ``changed`` to ``True``.
+
+    Return data matches :class:`ValkeyReloadAclData`. ``ok`` mirrors
+    ``CommandResult.success``.
+
+    Error mapping:
+
+    * Non-zero exit from ``valkey-cli`` → :class:`CommandResult.fail`.
+    * ACL syntax error (``ERR`` response) → :class:`CommandResult.fail`.
+      The error text from valkey is surfaced directly.
+    """
+    del params  # handler ignores params — spec
+
+    # --- pre-reload snapshot --------------------------------------------
+    pre_hash, err = _snapshot_acl_hash()
+    if err is not None:
+        return CommandResult.fail(err)
+
+    # --- ACL LOAD -------------------------------------------------------
+    try:
+        load_proc = _run_valkey_cli("ACL", "LOAD")
+    except FileNotFoundError as exc:
+        return CommandResult.fail(f"valkey-cli not found on PATH: {exc}")
+    except subprocess.TimeoutExpired as exc:
+        return CommandResult.fail(f"valkey-cli timed out running ACL LOAD: {exc}")
+    except subprocess.CalledProcessError as exc:
+        return CommandResult.fail(f"valkey-cli failed: {exc.stderr.strip() or exc}")
+
+    # valkey-cli exits 0 on logical errors; the first line carries the
+    # server's ERR text. Per spec: "if the first line is ERR ..., fail."
+    stdout = load_proc.stdout
+    first_line = stdout.splitlines()[0] if stdout.strip() else ""
+    if first_line.startswith("ERR ") or first_line.startswith("NOAUTH "):
+        return CommandResult.fail(f"ACL LOAD failed: {first_line}")
+
+    # --- post-reload snapshot -------------------------------------------
+    post_hash, err = _snapshot_acl_hash()
+    if err is not None:
+        return CommandResult.fail(err)
+
+    changed = pre_hash != post_hash
+    logger.info(
+        "valkey.reload_acl: ACL LOAD ok changed=%s (pre=%s post=%s)",
+        changed,
+        pre_hash[:12] if pre_hash else "<empty>",
+        post_hash[:12] if post_hash else "<empty>",
+    )
+    data: ValkeyReloadAclData = {
+        "ok": True,
+        "changed": changed,
+    }
+    return CommandResult.ok(data)
+
+
+def _snapshot_acl_hash() -> tuple[str, str | None]:
+    """Return ``(sha256_of_sorted_acl_list, error_message_or_None)``.
+
+    On any ``valkey-cli`` failure, the second element is populated and the
+    first is an empty string. The hash is computed over the **sorted**
+    ``ACL LIST`` lines so ordering changes between snapshots do not
+    produce spurious ``changed=True``.
+    """
+    import hashlib
+
+    try:
+        proc = _run_valkey_cli("ACL", "LIST")
+    except FileNotFoundError as exc:
+        return "", f"valkey-cli not found on PATH: {exc}"
+    except subprocess.TimeoutExpired as exc:
+        return "", f"valkey-cli timed out running ACL LIST: {exc}"
+    except subprocess.CalledProcessError as exc:
+        return "", f"valkey-cli failed: {exc.stderr.strip() or exc}"
+
+    if _is_err_response(proc.stdout):
+        return "", f"valkey-cli ACL LIST returned: {proc.stdout.strip()}"
+
+    lines = sorted(line for line in proc.stdout.splitlines() if line)
+    digest = hashlib.sha256("\n".join(lines).encode("utf-8")).hexdigest()
+    return digest, None

--- a/src/rots/commands/sidecar/handlers/valkey.py
+++ b/src/rots/commands/sidecar/handlers/valkey.py
@@ -7,11 +7,20 @@ application ACL users and reload the ACL file after external edits.
 
 Auth model
 ----------
-The sidecar reads the bootstrap ACL user + token from
-``/etc/valkey/users.acl`` — dropped in by cloud-init via
-``LoadCredentialEncrypted`` (see the parent issue #37). All commands are
-issued through ``valkey-cli`` to ``127.0.0.1:6379`` using the bootstrap
-user. No TCP credentials ship over the wire.
+The sidecar authenticates to local valkey as the fixed bootstrap user
+``bootstrap`` (provisioned by upstream cloud-init, lots #41, which also
+disables the ``default`` user). The bootstrap token is sealed into the
+systemd credstore and mounted into the sidecar unit's runtime credential
+directory via ``LoadCredentialEncrypted=valkey-bootstrap-token:…``.
+systemd decrypts the token at service start and exposes it at
+``$CREDENTIALS_DIRECTORY/valkey-bootstrap-token``; this handler reads
+that path per-invocation (no caching, so rotations are picked up).
+Callers running outside a systemd unit (tests, interactive debugging)
+have no ``CREDENTIALS_DIRECTORY`` set and fall through to unauthenticated
+loopback. The on-disk ``/etc/valkey/users.acl`` is root/valkey-owned
+mode 0640 and is never read by this handler. All commands are issued
+through ``valkey-cli`` to ``127.0.0.1:6379``; no TCP credentials ship
+over the wire.
 
 Cross-host delivery
 -------------------
@@ -77,8 +86,10 @@ rules; the token-rotation "over-change" is the safe failure mode.
 from __future__ import annotations
 
 import logging
+import os
 import secrets
 import subprocess
+from pathlib import Path
 from typing import Any
 
 from rots.sidecar.commands import Command, CommandResult, register_handler
@@ -102,9 +113,19 @@ logger = logging.getLogger(__name__)
 # accept an override — this is fixed by the package.
 ACL_FILE: str = "/etc/valkey/users.acl"
 
-# valkey-cli invocation. Implementations build on this with `-a` and the
-# bootstrap user loaded from the env file.
+# valkey-cli invocation. :func:`_run_valkey_cli` extends this with
+# ``--user <bootstrap>`` and ``REDISCLI_AUTH=<token>`` (both sourced from
+# the systemd credstore) when available.
 VALKEY_CLI: tuple[str, ...] = ("valkey-cli", "-h", "127.0.0.1", "-p", "6379")
+
+# Bootstrap auth is delivered via the systemd credstore. lots #41 seals
+# the token into the sidecar unit with
+# ``LoadCredentialEncrypted=valkey-bootstrap-token:…``; systemd decrypts
+# at service start and points ``$CREDENTIALS_DIRECTORY`` at the runtime
+# credential directory. The username is a fixed literal provisioned in
+# ``/etc/valkey/users.acl`` by the same cloud-init run.
+_BOOTSTRAP_USER = "bootstrap"
+_CREDENTIAL_NAME = "valkey-bootstrap-token"
 
 # Timeout for valkey-cli subprocess calls. Short — a healthy local daemon
 # answers in milliseconds.
@@ -149,6 +170,34 @@ def _is_valid_name(name: str) -> bool:
     return True
 
 
+def _load_bootstrap_auth() -> tuple[str, str] | None:
+    """Return ``(user, plaintext_token)`` from the systemd credstore, or ``None``.
+
+    systemd sets ``$CREDENTIALS_DIRECTORY`` for services started with
+    ``LoadCredential*=`` directives. The sidecar unit (wired by lots #41)
+    mounts the sealed bootstrap token as ``valkey-bootstrap-token`` inside
+    that directory. Callers running outside a systemd unit (tests,
+    interactive debugging) have no ``CREDENTIALS_DIRECTORY`` set and fall
+    through to unauthenticated loopback — safe in test fixtures where
+    valkey's ``default on nopass`` user still applies.
+
+    Called per-invocation (no caching) so a rotated token is picked up on
+    the next RPC without restarting the sidecar.
+    """
+    creds_dir = os.environ.get("CREDENTIALS_DIRECTORY")
+    if not creds_dir:
+        return None
+    token_path = Path(creds_dir) / _CREDENTIAL_NAME
+    try:
+        token = token_path.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        logger.debug("valkey: cannot read credstore token at %s: %s", token_path, exc)
+        return None
+    if not token:
+        return None
+    return (_BOOTSTRAP_USER, token)
+
+
 def _run_valkey_cli(*args: str) -> subprocess.CompletedProcess[str]:
     """Run ``valkey-cli`` with the supplied args. Arguments are passed through
     as a tuple — never shell-interpolated.
@@ -157,12 +206,25 @@ def _run_valkey_cli(*args: str) -> subprocess.CompletedProcess[str]:
     connection-refused case). A logical error (``ERR ...``) still comes back
     with exit 0; callers MUST inspect stdout.
     """
+    auth = _load_bootstrap_auth()
+    cli_args: tuple[str, ...] = VALKEY_CLI
+    env: dict[str, str] | None = None
+    if auth is not None:
+        user, token = auth
+        cli_args = cli_args + ("--user", user)
+        # Pass the token via REDISCLI_AUTH so it stays out of argv (ps(1)).
+        env = os.environ.copy()
+        env["REDISCLI_AUTH"] = token
+    else:
+        logger.debug("valkey: no bootstrap auth available; running without --user/-a")
+
     return subprocess.run(
-        VALKEY_CLI + args,
+        cli_args + args,
         check=True,
         capture_output=True,
         text=True,
         timeout=_VALKEY_CLI_TIMEOUT,
+        env=env,
     )
 
 

--- a/src/rots/infra_marker.py
+++ b/src/rots/infra_marker.py
@@ -1,0 +1,317 @@
+# src/rots/infra_marker.py
+
+"""`.otsinfra.yaml` discovery + schema for the bootstrap command.
+
+The bootstrap command (``rots env bootstrap``) is the first consumer of a
+per-repo YAML marker file that sits beside the long-standing
+``.otsinfra.env`` / ``.otsinfra-hosts.txt`` files. This module implements
+*only* the subset the bootstrap command needs:
+
+* walk-up discovery from CWD to either ``.git`` or ``$HOME`` (mirrors the
+  pattern used by :mod:`rots.deploy.manifest`);
+* parsing the ``envs.<env>`` block into a typed :class:`EnvConfig`;
+* validation of the required keys listed in the issue #55 spec.
+
+This is deliberately NOT a general-purpose marker-file library -- keeping it
+focused makes the failure modes easy to reason about. When a second caller
+lands, refactor rather than speculatively generalise.
+
+Example ``.otsinfra.yaml``::
+
+    envs:
+      eu-demo:
+        db:
+          host_id: eu-demo-db
+        web:
+          host_id: eu-demo-web
+          ip: 10.0.0.5
+        app:
+          name: onetimesecret
+          owner_role: onetimesecret
+        valkey:
+          rules:
+            - "+@read"
+            - "+@write"
+            - "-@admin"
+            - "~otsv1:*"
+        backup:
+          profile: db-daily
+          target: b2-ots:/eu-demo/db
+          schedule: "*-*-* 03:00:00"
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+INFRA_MARKER_FILENAME = ".otsinfra.yaml"
+
+
+class InfraMarkerError(Exception):
+    """Error loading, parsing, or validating ``.otsinfra.yaml``."""
+
+
+@dataclass(frozen=True)
+class DbTarget:
+    """Database sidecar target within an env block."""
+
+    host_id: str
+
+
+@dataclass(frozen=True)
+class WebTarget:
+    """Web sidecar target within an env block."""
+
+    host_id: str
+    ip: str
+
+
+@dataclass(frozen=True)
+class AppSpec:
+    """Application name + owner role."""
+
+    name: str
+    owner_role: str
+
+
+@dataclass(frozen=True)
+class ValkeySpec:
+    """Valkey ACL rules for the app user."""
+
+    rules: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BackupSpec:
+    """Optional backup job spec routed to ``backup.install``."""
+
+    profile: str
+    target: str
+    schedule: str
+
+
+@dataclass(frozen=True)
+class EnvConfig:
+    """Parsed + validated ``envs.<env>`` block.
+
+    Attributes:
+        env: The environment name (key under ``envs``).
+        db: Database sidecar target.
+        web: Web sidecar target (with private IP for pg_hba).
+        app: Application name + owner role.
+        valkey: Valkey ACL rules.
+        backup: Optional backup profile; ``None`` when the block is absent.
+        source: Path to the marker file the config was loaded from.
+    """
+
+    env: str
+    db: DbTarget
+    web: WebTarget
+    app: AppSpec
+    valkey: ValkeySpec
+    backup: BackupSpec | None = None
+    source: Path | None = field(default=None, repr=False)
+
+
+def find_marker_file(start: Path | None = None) -> Path | None:
+    """Walk up from *start* looking for a ``.otsinfra.yaml`` file.
+
+    Stops at the first directory containing ``.git`` or at the user's home
+    directory -- whichever is reached first. Returns ``None`` if not found.
+
+    Mirrors the walk-up discovery pattern used for ``.otsinfra.env``,
+    ``.otsinfra-hosts.txt``, and ``.ots-deploy.yaml``.
+    """
+    current = (start or Path.cwd()).resolve()
+    home = Path.home().resolve()
+
+    while True:
+        candidate = current / INFRA_MARKER_FILENAME
+        if candidate.is_file():
+            logger.debug("Found infra marker file: %s", candidate)
+            return candidate
+
+        # Stop at .git boundary (inclusive: check after the candidate lookup
+        # so a marker sitting next to .git is still discoverable).
+        if (current / ".git").exists():
+            logger.debug("Reached .git boundary at %s, no marker found", current)
+            return None
+
+        if current == home:
+            logger.debug("Reached home directory, no marker found")
+            return None
+
+        parent = current.parent
+        if parent == current:
+            # Filesystem root.
+            return None
+        current = parent
+
+
+def load_env_config(env: str, *, start: Path | None = None) -> EnvConfig:
+    """Discover ``.otsinfra.yaml`` and return the parsed ``envs.<env>`` block.
+
+    Args:
+        env: Environment name matching a key under ``envs:`` in the file.
+        start: Optional start directory for discovery. Defaults to CWD.
+
+    Returns:
+        Validated :class:`EnvConfig`.
+
+    Raises:
+        InfraMarkerError: when the file is missing, unreadable, is not valid
+            YAML, does not define ``envs.<env>``, or fails the required-keys
+            check from issue #55.
+    """
+    path = find_marker_file(start)
+    if path is None:
+        raise InfraMarkerError(
+            f"{INFRA_MARKER_FILENAME} not found. "
+            "Create it in the repo root (or any ancestor of the current directory)."
+        )
+    return load_env_config_from_file(env, path)
+
+
+def load_env_config_from_file(env: str, path: Path) -> EnvConfig:
+    """Load ``.otsinfra.yaml`` from an explicit path.
+
+    Separate entry-point so callers with their own discovery logic (and tests)
+    can bypass the walk-up without monkeypatching.
+    """
+    try:
+        import yaml
+    except ImportError as exc:
+        raise InfraMarkerError(
+            "PyYAML is required to read .otsinfra.yaml. Install with: pip install pyyaml"
+        ) from exc
+
+    if not path.is_file():
+        raise InfraMarkerError(f"{INFRA_MARKER_FILENAME} not found: {path}")
+
+    try:
+        text = path.read_text()
+    except OSError as exc:
+        raise InfraMarkerError(f"Cannot read {path}: {exc}") from exc
+
+    try:
+        raw = yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        raise InfraMarkerError(f"Invalid YAML in {path}: {exc}") from exc
+
+    if raw is None:
+        raise InfraMarkerError(f"{path} is empty")
+    if not isinstance(raw, dict):
+        raise InfraMarkerError(f"{path}: top-level must be a mapping, got {type(raw).__name__}")
+
+    envs_block = raw.get("envs")
+    if not isinstance(envs_block, dict):
+        raise InfraMarkerError(
+            f"{path}: missing or non-mapping 'envs' key (got {type(envs_block).__name__})"
+        )
+
+    env_block = envs_block.get(env)
+    if env_block is None:
+        available = sorted(str(k) for k in envs_block.keys())
+        raise InfraMarkerError(f"{path}: no block for env {env!r}. Available envs: {available}")
+    if not isinstance(env_block, dict):
+        raise InfraMarkerError(
+            f"{path}: envs.{env} must be a mapping, got {type(env_block).__name__}"
+        )
+
+    return _parse_env_block(env, env_block, source=path)
+
+
+def _parse_env_block(env: str, block: dict[str, Any], *, source: Path | None) -> EnvConfig:
+    """Validate and project ``envs.<env>`` into an :class:`EnvConfig`.
+
+    The required keys are the ones the bootstrap command actually consumes:
+    ``db.host_id``, ``web.host_id``, ``web.ip``, ``app.name``,
+    ``app.owner_role``, ``valkey.rules``. ``backup`` is optional but fully
+    validated when present.
+    """
+    db_raw = _require_mapping(block, "db", env)
+    db = DbTarget(host_id=_require_str(db_raw, "db.host_id", env))
+
+    web_raw = _require_mapping(block, "web", env)
+    web = WebTarget(
+        host_id=_require_str(web_raw, "web.host_id", env),
+        ip=_require_str(web_raw, "web.ip", env),
+    )
+
+    app_raw = _require_mapping(block, "app", env)
+    app = AppSpec(
+        name=_require_str(app_raw, "app.name", env),
+        owner_role=_require_str(app_raw, "app.owner_role", env),
+    )
+
+    valkey_raw = _require_mapping(block, "valkey", env)
+    rules_raw = valkey_raw.get("rules")
+    if not isinstance(rules_raw, list) or not rules_raw:
+        raise InfraMarkerError(f"envs.{env}.valkey.rules must be a non-empty list")
+    rules: list[str] = []
+    for idx, rule in enumerate(rules_raw):
+        if not isinstance(rule, str) or not rule:
+            raise InfraMarkerError(
+                f"envs.{env}.valkey.rules[{idx}] must be a non-empty string, got {rule!r}"
+            )
+        rules.append(rule)
+    valkey = ValkeySpec(rules=tuple(rules))
+
+    backup: BackupSpec | None = None
+    if "backup" in block and block["backup"] is not None:
+        backup_raw = _require_mapping(block, "backup", env)
+        backup = BackupSpec(
+            profile=_require_str(backup_raw, "backup.profile", env),
+            target=_require_str(backup_raw, "backup.target", env),
+            schedule=_require_str(backup_raw, "backup.schedule", env),
+        )
+
+    return EnvConfig(
+        env=env,
+        db=db,
+        web=web,
+        app=app,
+        valkey=valkey,
+        backup=backup,
+        source=source,
+    )
+
+
+def _require_mapping(block: dict[str, Any], key: str, env: str) -> dict[str, Any]:
+    value = block.get(key)
+    if value is None:
+        raise InfraMarkerError(f"envs.{env}.{key} is required")
+    if not isinstance(value, dict):
+        raise InfraMarkerError(f"envs.{env}.{key} must be a mapping, got {type(value).__name__}")
+    return value
+
+
+def _require_str(block: dict[str, Any], dotted: str, env: str) -> str:
+    # Last segment is the key within the local block.
+    key = dotted.rsplit(".", 1)[-1]
+    value = block.get(key)
+    if value is None:
+        raise InfraMarkerError(f"envs.{env}.{dotted} is required")
+    if not isinstance(value, str) or not value.strip():
+        raise InfraMarkerError(f"envs.{env}.{dotted} must be a non-empty string, got {value!r}")
+    return value
+
+
+__all__ = [
+    "INFRA_MARKER_FILENAME",
+    "AppSpec",
+    "BackupSpec",
+    "DbTarget",
+    "EnvConfig",
+    "InfraMarkerError",
+    "ValkeySpec",
+    "WebTarget",
+    "find_marker_file",
+    "load_env_config",
+    "load_env_config_from_file",
+]

--- a/src/rots/infra_marker.py
+++ b/src/rots/infra_marker.py
@@ -42,6 +42,7 @@ Example ``.otsinfra.yaml``::
 
 from __future__ import annotations
 
+import ipaddress
 import logging
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -238,9 +239,18 @@ def _parse_env_block(env: str, block: dict[str, Any], *, source: Path | None) ->
     db = DbTarget(host_id=_require_str(db_raw, "db.host_id", env))
 
     web_raw = _require_mapping(block, "web", env)
+    web_ip = _require_str(web_raw, "web.ip", env)
+    if "\n" in web_ip or "\r" in web_ip:
+        raise InfraMarkerError(f"envs.{env}.web.ip must not contain newlines")
+    try:
+        ipaddress.ip_address(web_ip)
+    except ValueError as exc:
+        raise InfraMarkerError(
+            f"envs.{env}.web.ip must be a valid IPv4 or IPv6 address: {exc}"
+        ) from exc
     web = WebTarget(
         host_id=_require_str(web_raw, "web.host_id", env),
-        ip=_require_str(web_raw, "web.ip", env),
+        ip=web_ip,
     )
 
     app_raw = _require_mapping(block, "app", env)

--- a/src/rots/sidecar/commands.py
+++ b/src/rots/sidecar/commands.py
@@ -67,6 +67,22 @@ class Command(StrEnum):
     PROVISION_SOCKS_KEY_READ = "provision.socks_key_read"
     PROVISION_SOCKS_KEY_WRITE = "provision.socks_key_write"
 
+    # Two-phase provisioning (issue #55) — postgres
+    POSTGRES_BOOTSTRAP_APP = "postgres.bootstrap_app"
+    POSTGRES_ADD_HBA = "postgres.add_hba"
+    POSTGRES_ROTATE_PASSWORD = "postgres.rotate_password"
+
+    # Two-phase provisioning (issue #55) — valkey
+    VALKEY_CREATE_ACL_USER = "valkey.create_acl_user"
+    VALKEY_RELOAD_ACL = "valkey.reload_acl"
+
+    # Two-phase provisioning (issue #55) — secrets delivery
+    SECRETS_DELIVER = "secrets.deliver"
+
+    # Two-phase provisioning (issue #55) — backup
+    BACKUP_INSTALL = "backup.install"
+    BACKUP_UNINSTALL = "backup.uninstall"
+
 
 @dataclass
 class CommandResult:
@@ -98,24 +114,70 @@ class CommandResult:
 # Type alias for handler functions
 Handler = Callable[[dict[str, Any]], CommandResult]
 
+# Known sidecar roles. Downstream agents filter handler registration by role
+# so that, e.g., a web sidecar only exposes secrets.deliver + container-lifecycle
+# commands but not postgres/valkey/backup handlers.
+ROLE_DB = "db"
+ROLE_WEB = "web"
+ALL_ROLES: frozenset[str] = frozenset({ROLE_DB, ROLE_WEB})
+
+# Default role set applied when a handler does not declare one. This preserves
+# behaviour for the handlers that predate role gating (lifecycle, config, etc.)
+# — they are generic enough to be useful on both sidecar roles.
+DEFAULT_ROLES: frozenset[str] = ALL_ROLES
+
+# Per-command role metadata. Populated by @register_handler. Used by
+# _import_handlers(role=...) to filter which handlers are actually installed
+# into the active dispatcher for a given sidecar role.
+_handler_roles: dict[Command, frozenset[str]] = {}
+
 # Registry of command handlers, populated by handler modules
 _handlers: dict[Command, Handler] = {}
 
 
-def register_handler(command: Command) -> Callable[[Handler], Handler]:
+def register_handler(
+    command: Command,
+    *,
+    roles: set[str] | frozenset[str] | None = None,
+) -> Callable[[Handler], Handler]:
     """Decorator to register a handler for a command.
+
+    Args:
+        command: The Command enum member this handler implements.
+        roles: Which sidecar roles should expose this handler. Defaults to
+            ``{"db", "web"}`` (``DEFAULT_ROLES``) so legacy handlers work
+            unchanged. New handlers that are role-specific must declare this
+            explicitly — e.g. postgres handlers pass ``roles={"db"}``.
 
     Usage:
         @register_handler(Command.RESTART_WEB)
         def handle_restart_web(params: dict[str, Any]) -> CommandResult:
             ...
+
+        @register_handler(Command.POSTGRES_BOOTSTRAP_APP, roles={"db"})
+        def handle_postgres_bootstrap(params: dict[str, Any]) -> CommandResult:
+            ...
     """
+
+    role_set: frozenset[str] = DEFAULT_ROLES if roles is None else frozenset(roles)
+
+    unknown = role_set - ALL_ROLES
+    if unknown:
+        raise ValueError(
+            f"Unknown role(s) for {command.value}: {sorted(unknown)}. "
+            f"Expected subset of {sorted(ALL_ROLES)}."
+        )
 
     def decorator(func: Handler) -> Handler:
         if command in _handlers:
             logger.warning("Overwriting handler for command: %s", command.value)
         _handlers[command] = func
-        logger.debug("Registered handler for command: %s", command.value)
+        _handler_roles[command] = role_set
+        logger.debug(
+            "Registered handler for command: %s (roles=%s)",
+            command.value,
+            sorted(role_set),
+        )
         return func
 
     return decorator
@@ -186,13 +248,37 @@ def get_all_commands() -> list[str]:
 # Import handlers to trigger registration
 # These imports happen at module load time so handlers are available
 # when the dispatcher is used
-def _import_handlers() -> None:
-    """Import handler modules to trigger registration.
+def _import_handlers(role: str | None = None) -> None:
+    """Import handler modules and filter the active dispatcher by role.
 
-    Called lazily to avoid circular imports. Handler modules use
-    the @register_handler decorator which populates _handlers.
+    Called lazily to avoid circular imports. Handler modules use the
+    ``@register_handler`` decorator which populates ``_handlers`` and
+    ``_handler_roles``.
+
+    Args:
+        role: If provided, the active dispatcher (``_handlers``) is filtered
+            after import so only commands whose declared roles include
+            ``role`` remain registered. If ``None`` (the default), every
+            registered handler stays in the dispatcher. Use ``None`` for
+            tests and tooling that need the full command surface; pass
+            ``"db"`` or ``"web"`` from the sidecar daemon's ``run``
+            command to install only the commands that role should expose.
+
+    Raises:
+        ValueError: if ``role`` is not a member of ``ALL_ROLES``.
     """
-    # Import handler modules to trigger @register_handler decorators
+    # Import existing handler modules to trigger @register_handler decorators
+    # Import new two-phase provisioning handler modules (issue #55). These live
+    # under the sibling commands tree because they carry heavier deps and share
+    # shared types (_types.py) / transport (_transport.py) with the operator
+    # command. Registration still lands in this module's _handlers registry.
+    from rots.commands.sidecar.handlers import (
+        backup,  # noqa: F401
+        postgres,  # noqa: F401
+        secrets,  # noqa: F401
+        valkey,  # noqa: F401
+    )
+
     from . import (
         handlers_config,  # noqa: F401
         handlers_discovery,  # noqa: F401
@@ -203,6 +289,27 @@ def _import_handlers() -> None:
         handlers_rots,  # noqa: F401
         handlers_status,  # noqa: F401
     )
+
+    if role is None:
+        return
+
+    if role not in ALL_ROLES:
+        raise ValueError(f"Unknown sidecar role: {role!r}. Expected one of {sorted(ALL_ROLES)}.")
+
+    # Filter: drop handlers whose declared role set excludes the active role.
+    # Handlers without declared roles default to DEFAULT_ROLES, which includes
+    # every role, so they stay registered.
+    to_remove = [
+        cmd for cmd in list(_handlers.keys()) if role not in _handler_roles.get(cmd, DEFAULT_ROLES)
+    ]
+    for cmd in to_remove:
+        logger.debug(
+            "Dropping handler %s for role=%s (declared roles=%s)",
+            cmd.value,
+            role,
+            sorted(_handler_roles.get(cmd, DEFAULT_ROLES)),
+        )
+        _handlers.pop(cmd, None)
 
 
 # Note: Handlers are registered when their modules are imported.

--- a/tests/commands/env/test_bootstrap.py
+++ b/tests/commands/env/test_bootstrap.py
@@ -1,0 +1,1036 @@
+# tests/commands/env/test_bootstrap.py
+
+"""Tests for the ``rots env bootstrap`` operator command (issue #55).
+
+Command contract (from :mod:`rots.commands.env.bootstrap`)::
+
+    rots env bootstrap --env <env> [--rotate] [--dry-run] [--json]
+
+Orchestrates, against ``db.host_id`` from the ``.otsinfra.yaml`` marker
+(``envs.<env>`` block):
+
+1. ``postgres.bootstrap_app`` (or ``postgres.rotate_password`` under
+   ``--rotate``)
+2. ``valkey.create_acl_user``
+3. ``postgres.add_hba``
+4. ``backup.install`` when a ``backup`` block is present under the env.
+
+Fails fast on the first step that fails. Exit codes follow the project
+convention:
+
+* ``0`` -- every step ok (or ``--dry-run`` printed its plan).
+* ``1`` (``EXIT_FAILURE``) -- an RPC failed, timed out, or the remote
+  returned an error.
+* ``3`` (``EXIT_PRECOND``) -- ``.otsinfra.yaml`` missing or
+  schema-invalid.
+
+The RPC client factory :func:`rots.commands.env.bootstrap._get_rpc_client`
+is the test seam.
+
+Import strategy
+---------------
+
+``rots.infra_marker`` and ``rots.commands.env.bootstrap`` land in parallel
+with this file. ``pytest.importorskip`` at module scope keeps collection
+green if either module is absent when the suite runs.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+# Modules under test — imported via importorskip so collection passes
+# before the impl agent has landed them.
+infra_marker = pytest.importorskip(
+    "rots.infra_marker",
+    reason="rots.infra_marker module not yet available (impl in flight)",
+)
+bootstrap_mod = pytest.importorskip(
+    "rots.commands.env.bootstrap",
+    reason="rots.commands.env.bootstrap module not yet available (impl in flight)",
+)
+
+# Handler modules (already landed) — safe to import directly.
+import rots.commands.sidecar.handlers.backup as backup_mod  # noqa: E402
+import rots.commands.sidecar.handlers.postgres as pg_mod  # noqa: E402
+import rots.commands.sidecar.handlers.secrets as secrets_mod  # noqa: E402
+import rots.commands.sidecar.handlers.valkey as valkey_mod  # noqa: E402
+from rots.commands.common import EXIT_FAILURE, EXIT_PRECOND, EXIT_SUCCESS  # noqa: E402
+from rots.sidecar.commands import CommandResult  # noqa: E402
+
+# =========================================================================
+# Marker fixture helpers
+# =========================================================================
+
+
+def _valid_marker_yaml(
+    *,
+    env_name: str = "eu-demo",
+    db_host_id: str = "db-host",
+    web_host_id: str = "web-host",
+    web_ip: str = "10.0.0.5",
+    app_name: str = "myapp",
+    owner_role: str = "myapp",
+    valkey_rules: tuple[str, ...] = ("on", "~*", "+@all"),
+    backup_block: bool = False,
+) -> str:
+    """Return the YAML body for a valid ``.otsinfra.yaml`` marker.
+
+    The impl expects an ``envs.<env>`` block shape (see
+    :func:`rots.infra_marker.load_env_config_from_file`)::
+
+        envs:
+          eu-demo:
+            db: {...}
+            web: {...}
+            app: {...}
+            valkey: {...}
+            backup: {...}   # optional
+    """
+    rules_block = "\n".join(f"      - {r!r}" for r in valkey_rules)
+    backup_section = (
+        "\n    backup:\n"
+        "      profile: db-daily\n"
+        "      target: b2-ots:/eu-demo/db\n"
+        "      schedule: daily\n"
+        if backup_block
+        else ""
+    )
+    return (
+        "envs:\n"
+        f"  {env_name}:\n"
+        "    db:\n"
+        f"      host_id: {db_host_id}\n"
+        "    web:\n"
+        f"      host_id: {web_host_id}\n"
+        f"      ip: {web_ip}\n"
+        "    app:\n"
+        f"      name: {app_name}\n"
+        f"      owner_role: {owner_role}\n"
+        "    valkey:\n"
+        "      rules:\n"
+        f"{rules_block}\n"
+        f"{backup_section}"
+    )
+
+
+def _write_marker(tmp_path: Path, body: str) -> Path:
+    marker = tmp_path / ".otsinfra.yaml"
+    marker.write_text(body, encoding="utf-8")
+    return marker
+
+
+# =========================================================================
+# EnvConfig / marker parsing
+# =========================================================================
+
+
+class TestEnvConfig:
+    """Coverage for ``rots.infra_marker`` marker loading + ``EnvConfig``.
+
+    The loader is :func:`rots.infra_marker.load_env_config`:
+
+        load_env_config(env, *, start=None) -> EnvConfig
+
+    ``EnvConfig`` is a frozen dataclass exposing:
+
+    * ``env: str``
+    * ``db.host_id``
+    * ``web.host_id`` / ``web.ip``
+    * ``app.name`` / ``app.owner_role``
+    * ``valkey.rules`` (tuple[str, ...])
+    * ``backup`` — ``None`` or a struct with ``profile`` / ``target`` /
+      ``schedule``.
+    * ``source: Path | None`` — path to the marker file.
+
+    All schema violations raise
+    :class:`rots.infra_marker.InfraMarkerError`.
+    """
+
+    pytestmark = pytest.mark.quick
+
+    @pytest.fixture
+    def marker_path(self, tmp_path: Path) -> Path:
+        return _write_marker(tmp_path, _valid_marker_yaml())
+
+    def test_valid_marker_parses_required_fields(
+        self,
+        marker_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """All required dotted keys populate ``EnvConfig``."""
+        monkeypatch.chdir(marker_path.parent)
+        cfg = infra_marker.load_env_config("eu-demo")
+
+        assert cfg.env == "eu-demo"
+        assert cfg.db.host_id == "db-host"
+        assert cfg.web.host_id == "web-host"
+        assert cfg.web.ip == "10.0.0.5"
+        assert cfg.app.name == "myapp"
+        assert cfg.app.owner_role == "myapp"
+        assert cfg.valkey.rules == ("on", "~*", "+@all")
+        assert cfg.source == marker_path
+
+    def test_backup_absent_leaves_field_none(
+        self,
+        marker_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.chdir(marker_path.parent)
+        cfg = infra_marker.load_env_config("eu-demo")
+        assert cfg.backup is None
+
+    def test_backup_present_populates_struct(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        _write_marker(tmp_path, _valid_marker_yaml(backup_block=True))
+        monkeypatch.chdir(tmp_path)
+
+        cfg = infra_marker.load_env_config("eu-demo")
+        assert cfg.backup is not None
+        assert cfg.backup.profile == "db-daily"
+        assert cfg.backup.target == "b2-ots:/eu-demo/db"
+        assert cfg.backup.schedule == "daily"
+
+    @pytest.mark.parametrize(
+        "missing_dotted",
+        [
+            "db.host_id",
+            "web.host_id",
+            "web.ip",
+            "app.name",
+            "app.owner_role",
+            "valkey.rules",
+        ],
+    )
+    def test_missing_required_key_raises_descriptive_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        missing_dotted: str,
+    ):
+        """Each missing required key should name itself in the error.
+
+        The marker is built by parsing a valid YAML body and popping the
+        target key, then re-emitting. This leaves the parent block as an
+        empty mapping so the impl surfaces the *specific* missing leaf
+        (``envs.eu-demo.db.host_id is required``) rather than the
+        higher-level "envs.eu-demo.db is required".
+        """
+        import yaml
+
+        parts = missing_dotted.split(".")
+        parent, leaf = parts[0], parts[1]
+        data = yaml.safe_load(_valid_marker_yaml())
+        env_block = data["envs"]["eu-demo"]
+        # Pop the leaf key but keep the parent mapping so the loader can
+        # traverse to it and report the specific leaf as missing.
+        env_block[parent].pop(leaf, None)
+        _write_marker(tmp_path, yaml.safe_dump(data, sort_keys=False))
+        monkeypatch.chdir(tmp_path)
+
+        with pytest.raises(infra_marker.InfraMarkerError) as exc_info:
+            infra_marker.load_env_config("eu-demo")
+
+        # Error surfaces the dotted key path (impl uses ``envs.<env>.<key>``).
+        msg = str(exc_info.value)
+        assert missing_dotted in msg or leaf in msg, (
+            f"Expected {missing_dotted!r} (or its leaf {leaf!r}) in error; got: {msg!r}"
+        )
+
+    def test_unknown_env_name_raises_with_available_envs(
+        self,
+        marker_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.chdir(marker_path.parent)
+        with pytest.raises(infra_marker.InfraMarkerError) as exc_info:
+            infra_marker.load_env_config("this-env-does-not-exist")
+
+        msg = str(exc_info.value)
+        # Per impl: lists available envs in the message.
+        assert "this-env-does-not-exist" in msg or "eu-demo" in msg
+
+    def test_walk_up_discovery_from_nested_subdir(
+        self,
+        marker_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Walking up from a deep subdirectory finds the marker."""
+        nested = marker_path.parent / "a" / "b" / "c"
+        nested.mkdir(parents=True, exist_ok=True)
+        monkeypatch.chdir(nested)
+
+        cfg = infra_marker.load_env_config("eu-demo")
+        assert cfg.db.host_id == "db-host"
+
+    def test_extra_keys_tolerated_forward_compat(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Unknown top-level keys under envs.<env> must not break loading."""
+        body = _valid_marker_yaml().rstrip() + "\n    future_key: some-value\n"
+        _write_marker(tmp_path, body)
+        monkeypatch.chdir(tmp_path)
+
+        cfg = infra_marker.load_env_config("eu-demo")
+        assert cfg.db.host_id == "db-host"
+
+    def test_missing_marker_file_raises_infra_marker_error(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """No marker anywhere up the tree -> :class:`InfraMarkerError`."""
+        nested = tmp_path / "isolated"
+        nested.mkdir()
+        # Add a ``.git`` so walk-up does not escape to the ancestor where
+        # a real project marker could live.
+        (nested / ".git").mkdir()
+        monkeypatch.chdir(nested)
+
+        with pytest.raises(infra_marker.InfraMarkerError):
+            infra_marker.load_env_config("eu-demo")
+
+
+# =========================================================================
+# Bootstrap orchestration — shared helpers
+# =========================================================================
+
+
+def _psql_exec(container: str, db: str, sql: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["podman", "exec", container, "psql", "-U", "postgres", "-d", db, "-tA", "-c", sql],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _role_exists_in_container(container: str, role: str) -> bool:
+    result = _psql_exec(
+        container,
+        "postgres",
+        f"SELECT 1 FROM pg_roles WHERE rolname = '{role}'",
+    )
+    return result.stdout.strip() == "1"
+
+
+def _database_exists_in_container(container: str, db: str) -> bool:
+    result = _psql_exec(
+        container,
+        "postgres",
+        f"SELECT 1 FROM pg_database WHERE datname = '{db}'",
+    )
+    return result.stdout.strip() == "1"
+
+
+def _drop_role_best_effort(container: str, role: str) -> None:
+    _psql_exec(container, "postgres", f'DROP OWNED BY "{role}" CASCADE')
+    _psql_exec(container, "postgres", f'DROP ROLE IF EXISTS "{role}"')
+
+
+def _drop_database_best_effort(container: str, db: str) -> None:
+    _psql_exec(container, "postgres", f'DROP DATABASE IF EXISTS "{db}"')
+
+
+def _valkey_user_exists(valkey_container: str, name: str) -> bool:
+    proc = subprocess.run(
+        ["podman", "exec", valkey_container, "valkey-cli", "ACL", "GETUSER", name],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode == 0 and bool(proc.stdout.strip())
+
+
+def _acl_deluser_best_effort(valkey_container: str, name: str) -> None:
+    subprocess.run(
+        ["podman", "exec", valkey_container, "valkey-cli", "ACL", "DELUSER", name],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _call_bootstrap(**kwargs: Any) -> int:
+    """Invoke ``bootstrap`` and return its exit code.
+
+    The command always ends in ``sys.exit(...)``; direct-call pattern
+    mirrors ``tests/commands/test_env.py`` and
+    ``tests/commands/workflow/test_trigger.py``.
+    """
+    try:
+        bootstrap_mod.bootstrap(**kwargs)
+    except SystemExit as exc:
+        code = exc.code
+        if code is None or code is True:
+            return 0
+        if isinstance(code, int):
+            return code
+        return 1
+    return 0
+
+
+# =========================================================================
+# Bootstrap orchestration — fixtures
+# =========================================================================
+
+
+@pytest.fixture
+def unique_app_name() -> str:
+    """Return a cluster-unique identifier for role/database/ACL user.
+
+    Must satisfy the handlers' identifier regex
+    (``^[a-z][a-z0-9_]{0,62}$``) because postgres validates ``app`` and
+    ``owner_role`` against it. ``uuid.uuid4().hex`` is lowercase alnum.
+    """
+    return f"app_{uuid.uuid4().hex[:10]}"
+
+
+@pytest.fixture
+def patched_psql(
+    monkeypatch: pytest.MonkeyPatch,
+    postgres_service: dict[str, Any],
+) -> str:
+    """Redirect ``PSQL_PEER_CMD`` at the test container (mirrors test_postgres.py)."""
+    container = postgres_service["container"]
+    monkeypatch.setattr(
+        pg_mod,
+        "PSQL_PEER_CMD",
+        (
+            "podman",
+            "exec",
+            "-i",
+            container,
+            "psql",
+            "-U",
+            "postgres",
+            "-v",
+            "ON_ERROR_STOP=1",
+        ),
+    )
+    return container
+
+
+@pytest.fixture
+def patched_valkey_cli(
+    monkeypatch: pytest.MonkeyPatch,
+    valkey_service: dict[str, Any],
+) -> str:
+    """Redirect ``VALKEY_CLI`` at the test container (mirrors test_valkey.py)."""
+    container = valkey_service["container"]
+    monkeypatch.setattr(
+        valkey_mod,
+        "VALKEY_CLI",
+        ("podman", "exec", container, "valkey-cli"),
+    )
+    return container
+
+
+@pytest.fixture
+def patched_env_file(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_env_file: tuple[Path, Callable[[str], Path]],
+) -> Path:
+    """Point :data:`secrets.ALLOWED_ENV_FILE` at a tmp env file; seed empty."""
+    path, seed = fake_env_file
+    seed("")
+    monkeypatch.setattr(secrets_mod, "ALLOWED_ENV_FILE", str(path))
+    return path
+
+
+@pytest.fixture
+def patched_hba_dir(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> Path:
+    d = tmp_path / "pg_hba.d"
+    d.mkdir()
+    monkeypatch.setattr(pg_mod, "PG_HBA_D", str(d))
+    return d
+
+
+@pytest.fixture
+def patched_backup_dirs(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> dict[str, Path]:
+    """Redirect backup artefact directories at tmp_path."""
+    systemd_dir = tmp_path / "systemd"
+    systemd_dir.mkdir()
+    rclone_dir = tmp_path / "rclone"
+    rclone_dir.mkdir()
+    monkeypatch.setattr(backup_mod, "SYSTEMD_DIR", str(systemd_dir))
+    monkeypatch.setattr(backup_mod, "RCLONE_FRAGMENTS_DIR", str(rclone_dir))
+    return {"systemd": systemd_dir, "rclone": rclone_dir}
+
+
+@pytest.fixture
+def bound_bus(
+    monkeypatch: pytest.MonkeyPatch,
+    in_process_bus: Any,
+) -> Any:
+    """Wire the in-process bus into the operator command + handler seams.
+
+    * ``rots.commands.env.bootstrap._get_rpc_client`` drives the command's
+      publishes to ``db.host_id``.
+    * ``pg._get_rpc_client`` / ``valkey._get_rpc_client`` drive the
+      handler-internal ``secrets.deliver`` hop to the web peer.
+    """
+    monkeypatch.setattr(bootstrap_mod, "_get_rpc_client", lambda: in_process_bus)
+    monkeypatch.setattr(pg_mod, "_get_rpc_client", lambda: in_process_bus)
+    monkeypatch.setattr(valkey_mod, "_get_rpc_client", lambda: in_process_bus)
+    return in_process_bus
+
+
+@pytest.fixture
+def marker_at_cwd(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    unique_app_name: str,
+    request: pytest.FixtureRequest,
+) -> tuple[Path, str]:
+    """Place a valid ``.otsinfra.yaml`` under ``tmp_path`` and ``chdir``.
+
+    Returns ``(marker_path, env_name)``. Pass ``indirect=True`` with a
+    ``True`` param to include a ``backup`` block.
+    """
+    backup_block = bool(getattr(request, "param", False))
+    body = _valid_marker_yaml(
+        app_name=unique_app_name,
+        owner_role=unique_app_name,
+        backup_block=backup_block,
+    )
+    marker = _write_marker(tmp_path, body)
+    monkeypatch.chdir(tmp_path)
+    return marker, "eu-demo"
+
+
+# =========================================================================
+# Bootstrap orchestration — test class
+# =========================================================================
+
+
+class TestBootstrapOrchestration:
+    """End-to-end coverage for ``rots env bootstrap``.
+
+    Happy-path + failure-mode tests that mutate real services carry
+    ``pytest.mark.integration``; pure validation / dry-run cases carry
+    ``pytest.mark.quick``.
+    """
+
+    # ---- happy path -----------------------------------------------------
+
+    @pytest.mark.integration
+    def test_full_bootstrap_creates_role_db_acl_hba_and_delivers_secrets(
+        self,
+        patched_psql: str,
+        patched_valkey_cli: str,
+        patched_env_file: Path,
+        patched_hba_dir: Path,
+        patched_backup_dirs: dict[str, Path],
+        bound_bus: Any,
+        marker_at_cwd: tuple[Path, str],
+        unique_app_name: str,
+    ):
+        """The happy path mutates every expected step.
+
+        Postgres role + database present; valkey ACL user present;
+        ``pg_hba.d/10-web.conf`` written; env file has both
+        ``PG_PASSWORD`` and ``VALKEY_PASSWORD``.
+        """
+        pg_container = patched_psql
+        valkey_container = patched_valkey_cli
+        _, env_name = marker_at_cwd
+
+        try:
+            code = _call_bootstrap(env=env_name)
+            assert code == EXIT_SUCCESS
+
+            # Postgres state.
+            assert _role_exists_in_container(pg_container, unique_app_name)
+            assert _database_exists_in_container(pg_container, unique_app_name)
+
+            # Valkey state: the ACL user exists.
+            assert _valkey_user_exists(valkey_container, unique_app_name)
+
+            # pg_hba drop-in — impl hard-codes name ``10-web``.
+            target = patched_hba_dir / "10-web.conf"
+            assert target.exists(), f"add_hba did not write {target}"
+            # Content should mention the web IP and the role.
+            body = target.read_text()
+            assert "10.0.0.5" in body
+            assert unique_app_name in body
+
+            # Env file received both secrets.
+            env_body = patched_env_file.read_text()
+            assert "PG_PASSWORD=" in env_body, f"PG_PASSWORD missing; body={env_body!r}"
+            assert "VALKEY_PASSWORD=" in env_body, f"VALKEY_PASSWORD missing; body={env_body!r}"
+
+            # Backup absent from marker -> no backup artefacts.
+            assert list(patched_backup_dirs["systemd"].iterdir()) == []
+            assert list(patched_backup_dirs["rclone"].iterdir()) == []
+        finally:
+            _drop_database_best_effort(pg_container, unique_app_name)
+            _drop_role_best_effort(pg_container, unique_app_name)
+            _acl_deluser_best_effort(valkey_container, unique_app_name)
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("marker_at_cwd", [True], indirect=True)
+    def test_happy_path_with_backup_block_installs_backup(
+        self,
+        patched_psql: str,
+        patched_valkey_cli: str,
+        patched_env_file: Path,
+        patched_hba_dir: Path,
+        patched_backup_dirs: dict[str, Path],
+        bound_bus: Any,
+        marker_at_cwd: tuple[Path, str],
+        unique_app_name: str,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """With a ``backup`` block in the marker, the backup handler runs.
+
+        ``systemctl`` / ``systemd-analyze`` are stubbed to succeed
+        deterministically -- the handler fixtures only provide postgres +
+        valkey containers; the host may not have a live systemd.
+        """
+        pg_container = patched_psql
+        valkey_container = patched_valkey_cli
+        _, env_name = marker_at_cwd
+
+        real_run = subprocess.run
+
+        def fake_run(cmd: Any, *args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            if (
+                isinstance(cmd, list | tuple)
+                and cmd
+                and cmd[0]
+                in (
+                    "systemctl",
+                    "systemd-analyze",
+                )
+            ):
+                return subprocess.CompletedProcess(list(cmd), 0, "", "")
+            return real_run(cmd, *args, **kwargs)
+
+        monkeypatch.setattr(backup_mod.subprocess, "run", fake_run)
+
+        try:
+            code = _call_bootstrap(env=env_name)
+            assert code == EXIT_SUCCESS, "full bootstrap with backup block should succeed"
+
+            systemd_files = sorted(p.name for p in patched_backup_dirs["systemd"].iterdir())
+            assert any(f.endswith(".service") for f in systemd_files), systemd_files
+            assert any(f.endswith(".timer") for f in systemd_files), systemd_files
+        finally:
+            _drop_database_best_effort(pg_container, unique_app_name)
+            _drop_role_best_effort(pg_container, unique_app_name)
+            _acl_deluser_best_effort(valkey_container, unique_app_name)
+
+    @pytest.mark.integration
+    def test_happy_path_stdout_receipts_include_changed_markers(
+        self,
+        patched_psql: str,
+        patched_valkey_cli: str,
+        patched_env_file: Path,
+        patched_hba_dir: Path,
+        patched_backup_dirs: dict[str, Path],
+        bound_bus: Any,
+        marker_at_cwd: tuple[Path, str],
+        unique_app_name: str,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """Human-readable output surfaces a ``CHANGED`` marker per step.
+
+        Per impl's ``_print_results_text``: one ``[CHANGED]`` line per
+        mutating step (postgres, valkey, add_hba). Test asserts at least
+        two CHANGED markers — tolerates implementation wiggle (e.g. an
+        early step being non-mutating on an unusual path).
+        """
+        pg_container = patched_psql
+        valkey_container = patched_valkey_cli
+        _, env_name = marker_at_cwd
+
+        try:
+            code = _call_bootstrap(env=env_name)
+            assert code == EXIT_SUCCESS
+            captured = capsys.readouterr()
+            combined = captured.out + captured.err
+            # Impl emits "[CHANGED]" for mutating steps.
+            assert combined.count("CHANGED") >= 2 or combined.lower().count("changed") >= 2, (
+                f"Expected multiple change markers in output; got:\n{combined}"
+            )
+        finally:
+            _drop_database_best_effort(pg_container, unique_app_name)
+            _drop_role_best_effort(pg_container, unique_app_name)
+            _acl_deluser_best_effort(valkey_container, unique_app_name)
+
+    # ---- idempotency ----------------------------------------------------
+
+    @pytest.mark.integration
+    def test_second_run_is_idempotent_noop(
+        self,
+        patched_psql: str,
+        patched_valkey_cli: str,
+        patched_env_file: Path,
+        patched_hba_dir: Path,
+        patched_backup_dirs: dict[str, Path],
+        bound_bus: Any,
+        marker_at_cwd: tuple[Path, str],
+        unique_app_name: str,
+    ):
+        """Re-running bootstrap leaves state + env file unchanged.
+
+        * ``postgres.bootstrap_app`` short-circuits with ``changed=False``
+          when the owner role already exists (cannot re-derive the password).
+        * ``valkey.create_acl_user`` is idempotent on identical rules
+          (no token rotation).
+        * ``postgres.add_hba`` is byte-for-byte no-op on re-apply.
+
+        Env file mtime must not advance.
+        """
+        pg_container = patched_psql
+        valkey_container = patched_valkey_cli
+        _, env_name = marker_at_cwd
+
+        try:
+            assert _call_bootstrap(env=env_name) == EXIT_SUCCESS
+            env_mtime_first = os.stat(patched_env_file).st_mtime_ns
+            env_body_first = patched_env_file.read_text()
+
+            assert _call_bootstrap(env=env_name) == EXIT_SUCCESS
+            assert os.stat(patched_env_file).st_mtime_ns == env_mtime_first
+            assert patched_env_file.read_text() == env_body_first
+        finally:
+            _drop_database_best_effort(pg_container, unique_app_name)
+            _drop_role_best_effort(pg_container, unique_app_name)
+            _acl_deluser_best_effort(valkey_container, unique_app_name)
+
+    # ---- --dry-run ------------------------------------------------------
+
+    @pytest.mark.quick
+    def test_dry_run_publishes_nothing_and_mutates_nothing(
+        self,
+        patched_env_file: Path,
+        patched_hba_dir: Path,
+        patched_backup_dirs: dict[str, Path],
+        in_process_bus: Any,
+        marker_at_cwd: tuple[Path, str],
+        monkeypatch: pytest.MonkeyPatch,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """``--dry-run`` prints the plan without publishing any RPC.
+
+        The bus is replaced with one that raises on publish — if the
+        command publishes anything under dry-run, the test fails.
+        """
+        _, env_name = marker_at_cwd
+
+        def refusing_publish(*args: Any, **kwargs: Any) -> CommandResult:
+            raise AssertionError(
+                f"RPC publish must not happen under --dry-run; args={args} kwargs={kwargs}"
+            )
+
+        monkeypatch.setattr(in_process_bus, "publish", refusing_publish)
+        monkeypatch.setattr(bootstrap_mod, "_get_rpc_client", lambda: in_process_bus)
+        monkeypatch.setattr(pg_mod, "_get_rpc_client", lambda: in_process_bus)
+        monkeypatch.setattr(valkey_mod, "_get_rpc_client", lambda: in_process_bus)
+
+        env_mtime_before = (
+            os.stat(patched_env_file).st_mtime_ns if patched_env_file.exists() else None
+        )
+
+        code = _call_bootstrap(env=env_name, dry_run=True)
+        assert code == EXIT_SUCCESS
+
+        if env_mtime_before is None:
+            assert not patched_env_file.exists() or patched_env_file.read_text() == ""
+        else:
+            assert os.stat(patched_env_file).st_mtime_ns == env_mtime_before
+        assert list(patched_hba_dir.iterdir()) == []
+        assert list(patched_backup_dirs["systemd"].iterdir()) == []
+        assert list(patched_backup_dirs["rclone"].iterdir()) == []
+
+        captured = capsys.readouterr()
+        combined = (captured.out + captured.err).lower()
+        # Impl emits ``Dry-run plan for env=...`` and lists each step's
+        # command name. Each step keyword should be visible.
+        assert "dry-run" in combined or "plan" in combined
+        for keyword in ("postgres", "valkey"):
+            assert keyword in combined, (
+                f"Dry-run output missing keyword {keyword!r}; output was:\n{combined}"
+            )
+
+    # ---- --json ---------------------------------------------------------
+
+    @pytest.mark.integration
+    def test_json_output_is_parseable_with_per_step_receipts(
+        self,
+        patched_psql: str,
+        patched_valkey_cli: str,
+        patched_env_file: Path,
+        patched_hba_dir: Path,
+        patched_backup_dirs: dict[str, Path],
+        bound_bus: Any,
+        marker_at_cwd: tuple[Path, str],
+        unique_app_name: str,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """``--json`` prints a single JSON object covering every step."""
+        pg_container = patched_psql
+        valkey_container = patched_valkey_cli
+        _, env_name = marker_at_cwd
+
+        try:
+            code = _call_bootstrap(env=env_name, json_output=True)
+            assert code == EXIT_SUCCESS
+            captured = capsys.readouterr()
+            out = captured.out.strip()
+            assert out, "expected JSON payload on stdout"
+
+            data = json.loads(out)
+            assert isinstance(data, dict), f"expected object at top level; got {type(data)}"
+
+            # Impl shape (from ``_print_results_json``): keys include
+            # ``env``, ``rotate``, ``dry_run``, ``steps``, ``success``.
+            assert data.get("env") == env_name
+            assert data.get("dry_run") is False
+            assert data.get("success") is True
+            steps = data.get("steps")
+            assert isinstance(steps, list) and steps, (
+                f"expected non-empty steps list; got {steps!r}"
+            )
+            step_names = [s.get("name") for s in steps]
+            assert "postgres.bootstrap_app" in step_names
+            assert "valkey.create_acl_user" in step_names
+            assert "postgres.add_hba" in step_names
+            # Each step carries changed / success.
+            for step in steps:
+                assert "changed" in step
+                assert "success" in step
+        finally:
+            _drop_database_best_effort(pg_container, unique_app_name)
+            _drop_role_best_effort(pg_container, unique_app_name)
+            _acl_deluser_best_effort(valkey_container, unique_app_name)
+
+    # ---- --rotate -------------------------------------------------------
+
+    @pytest.mark.integration
+    def test_rotate_delivers_new_pg_password(
+        self,
+        patched_psql: str,
+        patched_valkey_cli: str,
+        patched_env_file: Path,
+        patched_hba_dir: Path,
+        patched_backup_dirs: dict[str, Path],
+        bound_bus: Any,
+        marker_at_cwd: tuple[Path, str],
+        unique_app_name: str,
+    ):
+        """After a base bootstrap, ``--rotate`` mints a new PG_PASSWORD.
+
+        Per impl: ``rotate`` swaps ``postgres.bootstrap_app`` for
+        ``postgres.rotate_password``. ``rotate_password`` requires the
+        role to already exist (ensured by the prior base run).
+        """
+        pg_container = patched_psql
+        valkey_container = patched_valkey_cli
+        _, env_name = marker_at_cwd
+
+        def _read_pg_password(env_file: Path) -> str | None:
+            for line in env_file.read_text().splitlines():
+                if line.startswith("PG_PASSWORD="):
+                    return line.split("=", 1)[1].strip().strip('"')
+            return None
+
+        try:
+            assert _call_bootstrap(env=env_name) == EXIT_SUCCESS
+            first_pw = _read_pg_password(patched_env_file)
+            assert first_pw, "base run must land a PG_PASSWORD"
+
+            assert _call_bootstrap(env=env_name, rotate=True) == EXIT_SUCCESS
+            second_pw = _read_pg_password(patched_env_file)
+            assert second_pw, "rotate run must land a PG_PASSWORD"
+            assert second_pw != first_pw, "rotate must produce a different PG_PASSWORD"
+        finally:
+            _drop_database_best_effort(pg_container, unique_app_name)
+            _drop_role_best_effort(pg_container, unique_app_name)
+            _acl_deluser_best_effort(valkey_container, unique_app_name)
+
+    # ---- failure short-circuit ------------------------------------------
+
+    @pytest.mark.integration
+    def test_postgres_delivery_failure_short_circuits_before_valkey(
+        self,
+        patched_psql: str,
+        patched_valkey_cli: str,
+        patched_env_file: Path,
+        patched_hba_dir: Path,
+        patched_backup_dirs: dict[str, Path],
+        in_process_bus: Any,
+        monkeypatch: pytest.MonkeyPatch,
+        marker_at_cwd: tuple[Path, str],
+        unique_app_name: str,
+    ):
+        """A failed postgres step stops the orchestrator before valkey runs.
+
+        The web-host peer is overridden to refuse ``secrets.deliver``. The
+        postgres handler's rollback drops the freshly-created role; the
+        operator command sees ``success=False`` from the first step and
+        exits ``EXIT_FAILURE`` before publishing the valkey step.
+        """
+        pg_container = patched_psql
+        valkey_container = patched_valkey_cli
+        _, env_name = marker_at_cwd
+
+        # Only web-host peer fails on secrets.deliver. db-host continues
+        # through the real local dispatcher so the operator command's
+        # db-host publishes reach real handlers; the handler-internal hop
+        # to web-host is what fails.
+        in_process_bus.register(
+            "web-host",
+            lambda cmd, p: CommandResult.fail("delivery failed: broker down"),
+        )
+        monkeypatch.setattr(bootstrap_mod, "_get_rpc_client", lambda: in_process_bus)
+        monkeypatch.setattr(pg_mod, "_get_rpc_client", lambda: in_process_bus)
+        monkeypatch.setattr(valkey_mod, "_get_rpc_client", lambda: in_process_bus)
+
+        try:
+            code = _call_bootstrap(env=env_name)
+            assert code == EXIT_FAILURE, f"bootstrap must fail with EXIT_FAILURE; got {code}"
+
+            # Postgres rollback: role absent.
+            assert not _role_exists_in_container(pg_container, unique_app_name)
+
+            # Valkey step did NOT fire — no ACL user created on the real
+            # valkey container. This is the test of orchestrator
+            # short-circuit semantics.
+            assert not _valkey_user_exists(valkey_container, unique_app_name)
+        finally:
+            _drop_database_best_effort(pg_container, unique_app_name)
+            _drop_role_best_effort(pg_container, unique_app_name)
+            _acl_deluser_best_effort(valkey_container, unique_app_name)
+
+    @pytest.mark.integration
+    def test_timeout_on_deliver_surfaces_failing_step_name(
+        self,
+        patched_psql: str,
+        patched_valkey_cli: str,
+        patched_env_file: Path,
+        patched_hba_dir: Path,
+        patched_backup_dirs: dict[str, Path],
+        in_process_bus: Any,
+        monkeypatch: pytest.MonkeyPatch,
+        marker_at_cwd: tuple[Path, str],
+        unique_app_name: str,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """Delivery-side ``TimeoutError`` yields EXIT_FAILURE; step name visible."""
+        pg_container = patched_psql
+        valkey_container = patched_valkey_cli
+        _, env_name = marker_at_cwd
+
+        def timeout_on_deliver(cmd: str, params: dict[str, Any]) -> CommandResult:
+            if cmd == "secrets.deliver":
+                raise TimeoutError("simulated broker timeout")
+            from rots.sidecar.commands import dispatch
+
+            return dispatch(cmd, params)
+
+        in_process_bus.register("web-host", timeout_on_deliver)
+        monkeypatch.setattr(bootstrap_mod, "_get_rpc_client", lambda: in_process_bus)
+        monkeypatch.setattr(pg_mod, "_get_rpc_client", lambda: in_process_bus)
+        monkeypatch.setattr(valkey_mod, "_get_rpc_client", lambda: in_process_bus)
+
+        try:
+            code = _call_bootstrap(env=env_name)
+            assert code == EXIT_FAILURE
+            captured = capsys.readouterr()
+            combined = (captured.out + captured.err).lower()
+            # Step name (``postgres.bootstrap_app``) should be in the
+            # receipt output.
+            assert "postgres.bootstrap_app" in combined or "postgres" in combined, (
+                f"Expected step name in error output; got:\n{combined}"
+            )
+        finally:
+            _drop_database_best_effort(pg_container, unique_app_name)
+            _drop_role_best_effort(pg_container, unique_app_name)
+            _acl_deluser_best_effort(valkey_container, unique_app_name)
+
+    # ---- invalid invocation --------------------------------------------
+
+    @pytest.mark.quick
+    def test_missing_env_kwarg_raises_type_error(self):
+        """Calling the function without ``env`` raises TypeError.
+
+        Cyclopts owns the CLI-layer missing-arg error (exit 2 conventional)
+        but direct-function call produces a plain ``TypeError`` because
+        ``env`` is a required keyword parameter on the impl.
+        """
+        with pytest.raises(TypeError):
+            bootstrap_mod.bootstrap()
+
+    @pytest.mark.quick
+    def test_nonexistent_env_name_exits_precond(
+        self,
+        marker_at_cwd: tuple[Path, str],
+        caplog: pytest.LogCaptureFixture,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """Unknown env name exits ``EXIT_PRECOND`` with available-envs hint.
+
+        The impl emits the precond error via ``logger.error`` (text mode)
+        or via a JSON payload on stdout (json mode). In text mode the
+        operator sees the message on stderr once the logging handler is
+        attached; ``caplog`` captures the record directly.
+        """
+        import logging
+
+        caplog.set_level(logging.ERROR, logger="rots.commands.env.bootstrap")
+        code = _call_bootstrap(env="not-a-real-env")
+        assert code == EXIT_PRECOND, (
+            f"expected EXIT_PRECOND ({EXIT_PRECOND}) for unknown env; got {code}"
+        )
+
+        captured = capsys.readouterr()
+        combined = ((captured.out + captured.err) + caplog.text).lower()
+        assert "not-a-real-env" in combined or "eu-demo" in combined, (
+            f"Expected attempted-env or available-envs in error; got:\n{combined}"
+        )
+
+    @pytest.mark.quick
+    def test_missing_marker_file_exits_precond(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+        capsys: pytest.CaptureFixture[str],
+    ):
+        """No ``.otsinfra.yaml`` anywhere up the tree -> EXIT_PRECOND."""
+        import logging
+
+        nested = tmp_path / "no-marker"
+        nested.mkdir()
+        (nested / ".git").mkdir()
+        monkeypatch.chdir(nested)
+
+        caplog.set_level(logging.ERROR, logger="rots.commands.env.bootstrap")
+        code = _call_bootstrap(env="eu-demo")
+        assert code == EXIT_PRECOND
+
+        captured = capsys.readouterr()
+        combined = ((captured.out + captured.err) + caplog.text).lower()
+        assert ".otsinfra.yaml" in combined or "marker" in combined or "not found" in combined

--- a/tests/commands/sidecar/handlers/_fixtures.py
+++ b/tests/commands/sidecar/handlers/_fixtures.py
@@ -1,0 +1,373 @@
+# tests/commands/sidecar/handlers/_fixtures.py
+
+"""Shared fixtures for two-phase provisioning handler tests.
+
+Registered as a pytest plugin from the rootdir ``tests/conftest.py`` via
+``pytest_plugins = ["tests.commands.sidecar.handlers._fixtures"]``. Pytest
+9 forbids ``pytest_plugins`` declarations outside the rootdir conftest,
+so a plain module imported as a plugin is the portable mechanism to
+share these fixtures across sibling directories (notably
+``tests/commands/env``).
+
+Downstream impl + test agents (postgres, valkey, backup) consume the
+fixtures registered here. The contract is stable:
+
+* ``in_process_bus``  — :class:`InProcessRpcClient` with two peers
+  (``"db-host"``, ``"web-host"``) both pointing at the local dispatcher.
+  Use it to drive cross-host calls (e.g. ``postgres.bootstrap_app`` →
+  ``secrets.deliver`` at ``web-host``) without a broker.
+* ``fake_env_file``   — ``(path, seed)`` tuple pointing at a throwaway
+  env file under ``tmp_path``. ``seed`` is a helper that writes initial
+  content.
+* ``postgres_service`` / ``valkey_service`` — session-scoped real
+  services started via podman. Skipped when podman is not on PATH.
+  Per-test isolation comes from sibling fixtures ``postgres_db`` and
+  ``valkey_acl_prefix``.
+
+**Test-services approach**: session-scoped ``podman run``. Rationale:
+
+* The project is already podman-centric (production deploys via Quadlet);
+  test agents working here are already familiar with the tooling.
+* No new Python test dependencies (testcontainers would add a dep and
+  couple tests to an extra library).
+* Skips gracefully on dev machines without podman (``pytest.skip`` at
+  fixture time), matching ``docs/testing.md``'s "don't assume specific
+  podman/systemd state" rule.
+* CI provisions podman in the runner, so full coverage still runs there.
+
+Alternative approaches considered and rejected:
+
+* **testcontainers-python** — adds a dependency; the marginal ergonomic
+  win is small when we already manage container lifecycle elsewhere in
+  the codebase.
+* **CI-provided socket** — would require coordinating environment
+  variables between the CI config and the fixture; rejected because the
+  coordination overhead exceeds the benefit and local test runs would
+  need a doc trail to stand up the services by hand.
+
+Tests that do NOT need a real service (the ``secrets.deliver`` worked
+example is the canonical case) should skip the service fixtures.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import time
+import uuid
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from rots.commands.sidecar.handlers._transport import InProcessRpcClient
+from rots.sidecar.commands import CommandResult, _import_handlers, dispatch
+
+# --- env file helper ------------------------------------------------------
+
+
+@pytest.fixture
+def fake_env_file(tmp_path: Path) -> tuple[Path, Callable[[str], Path]]:
+    """Return ``(path, seed)`` for a throwaway ``/etc/default/onetimesecret``.
+
+    The path is ``<tmp_path>/etc/default/onetimesecret`` and its parent is
+    pre-created. ``seed(content)`` writes ``content`` to the file and
+    returns the path.
+
+    Use for tests that need a concrete env file under a writable tmp path.
+    The ``secrets.deliver`` allowlist hard-codes
+    ``/etc/default/onetimesecret`` — those tests must patch
+    ``rots.commands.sidecar.handlers.secrets.ALLOWED_ENV_FILE`` to point
+    at this tmp location. See ``test_secrets.py`` for the pattern.
+    """
+    parent = tmp_path / "etc" / "default"
+    parent.mkdir(parents=True, exist_ok=True)
+    path = parent / "onetimesecret"
+
+    def seed(content: str) -> Path:
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    return path, seed
+
+
+# --- in-process bus -------------------------------------------------------
+
+
+@pytest.fixture
+def in_process_bus() -> InProcessRpcClient:
+    """A fresh :class:`InProcessRpcClient` with ``db-host`` + ``web-host`` peers.
+
+    Both peers dispatch through :func:`rots.sidecar.commands.dispatch`.
+    Tests that want to intercept only one side can register a custom
+    callable via ``bus.register(host_id, my_fn)`` to override.
+
+    Handlers under test must be imported first so the dispatcher knows
+    about them. This fixture calls ``_import_handlers()`` with no role
+    filter (full surface) to guarantee that.
+    """
+    _import_handlers()
+
+    def local(command: str, params: dict[str, Any]) -> CommandResult:
+        return dispatch(command, params)
+
+    return InProcessRpcClient({"db-host": local, "web-host": local})
+
+
+# --- service fixtures: postgres ------------------------------------------
+
+
+def _podman_available() -> bool:
+    return shutil.which("podman") is not None
+
+
+def _wait_for_port(host: str, port: int, timeout: float) -> bool:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            with socket.create_connection((host, port), timeout=1.0):
+                return True
+        except OSError:
+            time.sleep(0.2)
+    return False
+
+
+def _wait_for_postgres_ready(container: str, timeout: float) -> bool:
+    """Wait until ``psql -U postgres`` succeeds inside ``container``.
+
+    The ``postgres:16-alpine`` init script double-restarts postgres: the
+    first start is an internal init over the Unix socket, then it shuts
+    down and restarts with the final listener config. During that gap the
+    TCP port may already be open (a previous listener was still bound
+    briefly) while the final Unix socket is not yet ready, so TCP-only
+    probes return too early. Use the same invocation the handler uses —
+    ``psql`` inside the container — to decide readiness.
+    """
+    deadline = time.monotonic() + timeout
+    last_stderr = ""
+    while time.monotonic() < deadline:
+        proc = subprocess.run(
+            [
+                "podman",
+                "exec",
+                container,
+                "psql",
+                "-U",
+                "postgres",
+                "-tA",
+                "-c",
+                "SELECT 1",
+            ],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode == 0 and proc.stdout.strip() == "1":
+            return True
+        last_stderr = proc.stderr
+        time.sleep(0.3)
+    # Preserve last error for the caller's diagnostics.
+    raise RuntimeError(
+        f"postgres in container {container!r} did not become ready: {last_stderr.strip()}"
+    )
+
+
+@pytest.fixture(scope="session")
+def postgres_service() -> Iterator[dict[str, Any]]:
+    """Session-scoped real postgres via ``podman run``.
+
+    Skipped if ``podman`` is not on PATH. The container is removed at
+    session teardown. Returns a dict::
+
+        {"host": "127.0.0.1", "port": <int>, "user": "postgres",
+         "password": "postgres", "container": "<name>"}
+
+    Per-test isolation: use the ``postgres_db`` fixture, which creates
+    and drops a uniquely-named database inside this shared service.
+    Implementations of the postgres handlers under test MUST NOT assume
+    they own the default ``postgres`` database.
+
+    Requires podman. CI provisions podman in the runner.
+    """
+    if not _podman_available():
+        pytest.skip("podman not available on PATH — skipping real-postgres fixture")
+
+    name = f"rots-test-postgres-{uuid.uuid4().hex[:8]}"
+    port = _pick_port()
+    image = os.environ.get("ROTS_TEST_POSTGRES_IMAGE", "docker.io/library/postgres:16-alpine")
+
+    subprocess.run(
+        [
+            "podman",
+            "run",
+            "-d",
+            "--name",
+            name,
+            "-e",
+            "POSTGRES_PASSWORD=postgres",
+            "-e",
+            "POSTGRES_USER=postgres",
+            "-p",
+            f"{port}:5432",
+            image,
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    try:
+        if not _wait_for_port("127.0.0.1", port, timeout=30.0):
+            raise RuntimeError(f"postgres in container {name!r} did not start within 30s")
+        # TCP-open is not enough for the alpine image's double-restart init;
+        # block until psql actually answers over the in-container socket.
+        _wait_for_postgres_ready(name, timeout=30.0)
+        yield {
+            "host": "127.0.0.1",
+            "port": port,
+            "user": "postgres",
+            "password": "postgres",
+            "container": name,
+        }
+    finally:
+        subprocess.run(
+            ["podman", "rm", "-f", name],
+            check=False,
+            capture_output=True,
+        )
+
+
+@pytest.fixture
+def postgres_db(postgres_service: dict[str, Any]) -> Iterator[str]:
+    """Create and drop a uniquely-named database for one test.
+
+    Yields the database name. Intended use::
+
+        def test_bootstrap(postgres_service, postgres_db):
+            # connect to postgres_service + postgres_db
+            ...
+
+    Uses ``podman exec`` via ``psql`` to avoid requiring psycopg in the
+    test deps.
+    """
+    db_name = f"rots_{uuid.uuid4().hex[:12]}"
+    container = postgres_service["container"]
+    subprocess.run(
+        [
+            "podman",
+            "exec",
+            container,
+            "psql",
+            "-U",
+            "postgres",
+            "-c",
+            f'CREATE DATABASE "{db_name}"',
+        ],
+        check=True,
+        capture_output=True,
+    )
+    try:
+        yield db_name
+    finally:
+        subprocess.run(
+            [
+                "podman",
+                "exec",
+                container,
+                "psql",
+                "-U",
+                "postgres",
+                "-c",
+                f'DROP DATABASE IF EXISTS "{db_name}"',
+            ],
+            check=False,
+            capture_output=True,
+        )
+
+
+# --- service fixtures: valkey --------------------------------------------
+
+
+@pytest.fixture(scope="session")
+def valkey_service() -> Iterator[dict[str, Any]]:
+    """Session-scoped real valkey via ``podman run``.
+
+    Skipped if ``podman`` is not on PATH. Returns a dict::
+
+        {"host": "127.0.0.1", "port": <int>, "container": "<name>"}
+
+    Per-test isolation: use the ``valkey_acl_prefix`` fixture to derive a
+    unique ACL-user prefix. Tests MUST add+remove their own users —
+    there is no state reset between tests.
+
+    Requires podman. CI provisions podman in the runner.
+    """
+    if not _podman_available():
+        pytest.skip("podman not available on PATH — skipping real-valkey fixture")
+
+    name = f"rots-test-valkey-{uuid.uuid4().hex[:8]}"
+    port = _pick_port()
+    image = os.environ.get("ROTS_TEST_VALKEY_IMAGE", "docker.io/valkey/valkey:8-alpine")
+
+    # Start valkey-server with ``--aclfile`` set so ``ACL SAVE`` / ``ACL LOAD``
+    # work. Valkey 8.x treats ``aclfile`` as immutable at runtime — it cannot
+    # be enabled via ``CONFIG SET`` after startup. Valkey refuses to start
+    # when the aclfile is missing, so touch it first via a wrapping ``sh``
+    # entrypoint. ``/data`` is the image's default working dir and is
+    # writable by the valkey user.
+    subprocess.run(
+        [
+            "podman",
+            "run",
+            "-d",
+            "--name",
+            name,
+            "-p",
+            f"{port}:6379",
+            "--entrypoint",
+            "sh",
+            image,
+            "-c",
+            "touch /data/users.acl && exec valkey-server --aclfile /data/users.acl",
+        ],
+        check=True,
+        capture_output=True,
+    )
+
+    try:
+        if not _wait_for_port("127.0.0.1", port, timeout=30.0):
+            raise RuntimeError(f"valkey in container {name!r} did not start within 30s")
+        yield {
+            "host": "127.0.0.1",
+            "port": port,
+            "container": name,
+        }
+    finally:
+        subprocess.run(
+            ["podman", "rm", "-f", name],
+            check=False,
+            capture_output=True,
+        )
+
+
+@pytest.fixture
+def valkey_acl_prefix() -> str:
+    """Return a unique ACL-user prefix for a single test.
+
+    Example: ``acl_f3a9b2c1``. Tests build full names as
+    ``f"{prefix}_app"`` etc. and are responsible for cleanup via
+    ``ACL DELUSER``.
+    """
+    return f"acl_{uuid.uuid4().hex[:8]}"
+
+
+# --- helpers --------------------------------------------------------------
+
+
+def _pick_port() -> int:
+    """Return an ephemeral port by binding to 0 and reading the assignment."""
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]

--- a/tests/commands/sidecar/handlers/test_backup.py
+++ b/tests/commands/sidecar/handlers/test_backup.py
@@ -45,6 +45,7 @@ import pytest
 import rots.commands.sidecar.handlers.backup as backup_mod
 from rots.commands.sidecar.handlers.backup import (
     ALLOWED_PROFILES,
+    _validate_target,
     handle_install,
     handle_uninstall,
 )
@@ -940,3 +941,102 @@ class TestAllowedProfilesExported:
 
     def test_allowlist_members(self):
         assert ALLOWED_PROFILES == frozenset({"db-daily", "valkey-hourly"})
+
+
+# --- unsafe shell characters in target path ------------------------------
+
+
+class TestValidateTargetShellChars:
+    """`_validate_target` rejects shell metacharacters in the path half.
+
+    The render path interpolates ``target`` into a ``/bin/bash -c`` script
+    (inside double quotes). A ``$``, backtick, quote, or backslash in the
+    path would break out of the quoting and enable command substitution
+    or injection. The validator must refuse these before the handler ever
+    writes a unit file.
+    """
+
+    @pytest.mark.parametrize(
+        "bad_char",
+        ["$", "`", '"', "'", "\\"],
+    )
+    def test_rejects_path_with_shell_metachar(self, bad_char: str):
+        target = f"remote1:backups/evil{bad_char}leak"
+        err = _validate_target(target)
+        assert err is not None
+        assert "unsafe shell characters" in err
+
+    def test_rejects_command_substitution(self):
+        # The canonical attack: `$(whoami)` in the path half yields
+        # command substitution once the bash -c wrapper evaluates it.
+        err = _validate_target("remote1:backups/$(whoami)")
+        assert err is not None
+        assert "unsafe shell characters" in err
+
+    def test_rejects_backtick_command_substitution(self):
+        err = _validate_target("remote1:backups/`id`")
+        assert err is not None
+        assert "unsafe shell characters" in err
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "remote1:backups/db",
+            "remote-1:backups/db.daily",
+            "remote_1:path/with/slashes",
+            "r1:plain",
+            "remote:2024-01-01/snapshot",
+            "remote:path-with_dashes_and.dots/123",
+        ],
+    )
+    def test_accepts_benign_paths(self, target: str):
+        # Characters used: letters, digits, `-`, `_`, `/`, `.`.
+        assert _validate_target(target) is None
+
+
+class TestInstallShellInjectionRejected:
+    """End-to-end: the unsafe-chars gate is wired through to ``handle_install``.
+
+    Proves the validator is invoked by the handler entry point — not just
+    callable in isolation — and that the rejection happens before any
+    filesystem write or subprocess shell-out. This is the reviewer-facing
+    regression test for the fix.
+    """
+
+    def test_command_substitution_target_fails_handler(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        result = handle_install(_valid_params(target="remote1:backups/$(whoami)"))
+
+        assert result.success is False
+        assert "unsafe shell characters" in (result.error or "")
+
+        # No subprocess call: the gate fires before systemd-analyze or
+        # systemctl would have been invoked.
+        assert fake_world.calls == []
+        # No unit files or rclone fragments landed on disk.
+        assert list(systemd_dir.iterdir()) == []
+        assert list(rclone_dir.iterdir()) == []
+
+    @pytest.mark.parametrize(
+        "target",
+        [
+            "remote1:backups/with`backtick",
+            'remote1:backups/with"dquote',
+            "remote1:backups/with'squote",
+            "remote1:backups/with\\backslash",
+        ],
+    )
+    def test_other_shell_chars_also_rejected_at_handler(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+        target: str,
+    ):
+        result = handle_install(_valid_params(target=target))
+        assert result.success is False
+        assert "unsafe shell characters" in (result.error or "")
+        assert fake_world.calls == []

--- a/tests/commands/sidecar/handlers/test_backup.py
+++ b/tests/commands/sidecar/handlers/test_backup.py
@@ -1,0 +1,942 @@
+# tests/commands/sidecar/handlers/test_backup.py
+
+"""Tests for the ``backup.install`` and ``backup.uninstall`` handlers.
+
+These handlers provision systemd ``.service`` + ``.timer`` units and rclone
+config fragments on the db sidecar. They do NOT touch any real network
+service — they write unit files and shell out to ``systemctl`` /
+``systemd-analyze``. Per docs/testing.md and the task brief, real
+``/etc/systemd/system`` must never be written to and the real systemd
+daemon must never be reloaded.
+
+Testing strategy:
+
+* :data:`backup.SYSTEMD_DIR` and :data:`backup.RCLONE_FRAGMENTS_DIR` are
+  monkeypatched to tmp_path subdirectories per test (see ``backup_dirs``
+  fixture).
+* ``subprocess.run`` is patched to a stateful dispatcher
+  (``_FakeSystemdWorld``) that routes on argv tokens:
+  ``systemd-analyze calendar``, ``systemctl daemon-reload``,
+  ``systemctl enable --now``, ``systemctl disable --now``,
+  ``systemctl is-enabled``, ``systemctl is-active``. The dispatcher is
+  stateful so that ``enable --now`` flips a timer's recorded state, which
+  subsequent ``is-enabled`` / ``is-active`` probes read back. This models
+  the spec's "changed iff any file rewrote OR the timer was not already
+  enabled+active" idempotency rule without tying tests to a particular
+  call order.
+
+Assertions deliberately avoid peeking at rendered unit-file text — the
+spec treats ``_render_service`` / ``_render_timer`` as impl-agent
+territory. Tests assert file existence, mode, mtime stability on
+idempotent re-runs, and recorded subprocess calls.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import rots.commands.sidecar.handlers.backup as backup_mod
+from rots.commands.sidecar.handlers.backup import (
+    ALLOWED_PROFILES,
+    handle_install,
+    handle_uninstall,
+)
+
+pytestmark = pytest.mark.quick
+
+
+# --- fake systemd / systemd-analyze world --------------------------------
+
+
+# Schedules the fake `systemd-analyze calendar` treats as valid.
+_VALID_SCHEDULES: frozenset[str] = frozenset(
+    {
+        "daily",
+        "hourly",
+        "weekly",
+        "*-*-* 03:30:00",
+        "Mon *-*-* 02:00:00",
+        "*:0/15",
+    }
+)
+
+
+@dataclass
+class _Call:
+    """One recorded invocation of the patched ``subprocess.run``."""
+
+    argv: tuple[str, ...]
+    kwargs: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class _FakeSystemdWorld:
+    """Stateful fake for ``subprocess.run``.
+
+    Models just enough of systemd for the backup handler's idempotency
+    contract:
+
+    * A per-timer ``enabled_and_active`` flag.
+    * ``systemctl enable --now <timer>`` flips it on.
+    * ``systemctl disable --now <timer>`` flips it off, and returns
+      non-zero if the timer was never enabled (spec says the handler
+      catches+ignores that).
+    * ``systemctl is-enabled`` / ``is-active`` probes read it back.
+    * ``systemd-analyze calendar <expr>`` returns 0 iff ``expr`` is in
+      :data:`_VALID_SCHEDULES`.
+    * ``systemctl daemon-reload`` is always a no-op success.
+    """
+
+    calls: list[_Call] = field(default_factory=list)
+    timer_enabled: dict[str, bool] = field(default_factory=dict)
+    # When set, any call to daemon-reload raises CalledProcessError; used
+    # by the "enable failure" scenario — not daemon-reload specifically,
+    # but the same hook exists for enable.
+    fail_on: set[str] = field(default_factory=set)
+
+    # --- drive function for mocker.patch --------------------------------
+    def run(self, argv, *args, **kwargs):
+        # Normalise argv to a tuple of strings. subprocess.run accepts
+        # either a list or a single string; the backup handler will use
+        # a list of strings for systemctl/systemd-analyze.
+        if isinstance(argv, list | tuple):
+            argv_t = tuple(str(x) for x in argv)
+        else:
+            argv_t = (str(argv),)
+        self.calls.append(_Call(argv=argv_t, kwargs=dict(kwargs)))
+
+        exe = argv_t[0] if argv_t else ""
+
+        # Match on the *suffix* of the executable so both "systemctl" and
+        # "/usr/bin/systemctl" work.
+        def _is(name: str) -> bool:
+            return exe == name or exe.endswith("/" + name)
+
+        if _is("systemd-analyze"):
+            return self._handle_analyze(argv_t, kwargs)
+        if _is("systemctl"):
+            return self._handle_systemctl(argv_t, kwargs)
+
+        # Any other subprocess.run call the handler might make is a
+        # spec violation for this module — fail loudly.
+        raise AssertionError(f"Unexpected subprocess.run call: {argv_t!r}")
+
+    # --- systemd-analyze ------------------------------------------------
+    def _handle_analyze(self, argv: tuple[str, ...], kwargs: dict[str, Any]):
+        # Expected shape: ("systemd-analyze", "calendar", "<expr>")
+        # Be lenient about additional flags — grab the last positional arg
+        # as the schedule expression.
+        if "calendar" not in argv:
+            return self._completed(argv, kwargs, 0, "", "")
+        schedule = argv[-1]
+        if schedule in _VALID_SCHEDULES:
+            return self._completed(argv, kwargs, 0, f"Normalized form: {schedule}\n", "")
+        return self._completed(
+            argv,
+            kwargs,
+            1,
+            "",
+            f"Failed to parse calendar specification '{schedule}': Invalid value\n",
+        )
+
+    # --- systemctl ------------------------------------------------------
+    def _handle_systemctl(self, argv: tuple[str, ...], kwargs: dict[str, Any]):
+        # Extract the verb + any unit argument. systemctl argv tends to
+        # look like ("systemctl", "enable", "--now", "ots-backup-x.timer")
+        # or ("systemctl", "is-enabled", "ots-backup-x.timer") etc.
+        verb = argv[1] if len(argv) > 1 else ""
+        # Locate the unit argument (first token that ends with a known
+        # unit suffix).
+        unit = next(
+            (a for a in argv[2:] if a.endswith((".timer", ".service"))),
+            None,
+        )
+
+        if verb == "daemon-reload":
+            return self._completed(argv, kwargs, 0, "", "")
+
+        if verb == "enable":
+            # "enable --now <timer>"
+            assert unit is not None, f"enable missing unit arg: {argv!r}"
+            if "enable" in self.fail_on:
+                return self._completed(argv, kwargs, 1, "", "enable failed\n")
+            self.timer_enabled[unit] = True
+            return self._completed(argv, kwargs, 0, "", "")
+
+        if verb == "disable":
+            assert unit is not None, f"disable missing unit arg: {argv!r}"
+            was_enabled = self.timer_enabled.pop(unit, False)
+            if not was_enabled:
+                # Mirrors the real systemctl behaviour when a unit is
+                # not loaded: non-zero exit, message on stderr. The
+                # spec says the handler catches and ignores this.
+                return self._completed(
+                    argv,
+                    kwargs,
+                    1,
+                    "",
+                    f"Failed to disable unit: Unit {unit} not loaded.\n",
+                )
+            return self._completed(argv, kwargs, 0, "", "")
+
+        if verb == "is-enabled":
+            assert unit is not None
+            enabled = self.timer_enabled.get(unit, False)
+            return self._completed(
+                argv,
+                kwargs,
+                0 if enabled else 1,
+                "enabled\n" if enabled else "disabled\n",
+                "",
+            )
+
+        if verb == "is-active":
+            assert unit is not None
+            active = self.timer_enabled.get(unit, False)
+            return self._completed(
+                argv,
+                kwargs,
+                0 if active else 3,
+                "active\n" if active else "inactive\n",
+                "",
+            )
+
+        # Unknown systemctl verb used by the handler — test will fail.
+        raise AssertionError(f"Unexpected systemctl verb: {argv!r}")
+
+    # --- CompletedProcess helper --------------------------------------
+    def _completed(
+        self,
+        argv: tuple[str, ...],
+        kwargs: dict[str, Any],
+        returncode: int,
+        stdout: str,
+        stderr: str,
+    ) -> subprocess.CompletedProcess:
+        # Respect the check= kwarg like real subprocess.run.
+        check = bool(kwargs.get("check", False))
+        if check and returncode != 0:
+            raise subprocess.CalledProcessError(
+                returncode,
+                list(argv),
+                output=stdout,
+                stderr=stderr,
+            )
+        # Respect capture_output / text kwargs superficially — return
+        # str stdout/stderr which is what both text=True and
+        # universal_newlines=True handlers expect.
+        return subprocess.CompletedProcess(
+            args=list(argv),
+            returncode=returncode,
+            stdout=stdout,
+            stderr=stderr,
+        )
+
+    # --- convenience lookups for assertions -----------------------------
+    def argv_list(self) -> list[tuple[str, ...]]:
+        return [c.argv for c in self.calls]
+
+    def verbs(self) -> list[str]:
+        """Return a flat list of (tool, action) strings for quick checks.
+
+        Example: ``["systemd-analyze calendar", "systemctl daemon-reload",
+        "systemctl enable --now"]``.
+        """
+        out: list[str] = []
+        for argv in self.argv_list():
+            if not argv:
+                continue
+            exe = argv[0].rsplit("/", 1)[-1]
+            if exe == "systemd-analyze":
+                out.append(f"systemd-analyze {argv[1]}" if len(argv) > 1 else "systemd-analyze")
+            elif exe == "systemctl":
+                verb = argv[1] if len(argv) > 1 else ""
+                if verb in {"enable", "disable"} and "--now" in argv:
+                    out.append(f"systemctl {verb} --now")
+                else:
+                    out.append(f"systemctl {verb}")
+            else:
+                out.append(" ".join(argv))
+        return out
+
+    def daemon_reload_count(self) -> int:
+        return sum(1 for v in self.verbs() if v == "systemctl daemon-reload")
+
+    def enable_now_count(self) -> int:
+        return sum(1 for v in self.verbs() if v == "systemctl enable --now")
+
+    def disable_now_count(self) -> int:
+        return sum(1 for v in self.verbs() if v == "systemctl disable --now")
+
+
+# --- fixtures -------------------------------------------------------------
+
+
+@pytest.fixture
+def systemd_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "etc" / "systemd" / "system"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@pytest.fixture
+def rclone_dir(tmp_path: Path) -> Path:
+    d = tmp_path / "etc" / "rclone" / "conf.d"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+@pytest.fixture
+def backup_dirs(
+    systemd_dir: Path,
+    rclone_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Path, Path]:
+    """Redirect the module constants to tmp_path subdirectories.
+
+    Returns ``(systemd_dir, rclone_dir)``.
+    """
+    monkeypatch.setattr(backup_mod, "SYSTEMD_DIR", str(systemd_dir))
+    monkeypatch.setattr(backup_mod, "RCLONE_FRAGMENTS_DIR", str(rclone_dir))
+    return systemd_dir, rclone_dir
+
+
+@pytest.fixture
+def fake_world(monkeypatch: pytest.MonkeyPatch) -> _FakeSystemdWorld:
+    """Patch ``subprocess.run`` with the stateful systemd fake.
+
+    Patches at two import sites:
+
+    * ``subprocess.run`` globally — works if impl does
+      ``import subprocess; subprocess.run(...)``.
+    * ``rots.commands.sidecar.handlers.backup.subprocess.run`` — works
+      for the same usage but is a no-op if the impl used
+      ``from subprocess import run`` (in which case the global patch
+      above is what actually intercepts).
+
+    Either style the impl picks is covered.
+    """
+    world = _FakeSystemdWorld()
+    monkeypatch.setattr(subprocess, "run", world.run)
+    # Module-local patch (best-effort; only applies if handler imported
+    # subprocess as a module). If the attribute doesn't exist on the
+    # handler module we let the global patch do the work.
+    if hasattr(backup_mod, "subprocess"):
+        monkeypatch.setattr(backup_mod.subprocess, "run", world.run)
+    return world
+
+
+# --- helpers -------------------------------------------------------------
+
+
+def _unit_names(profile: str) -> tuple[str, str, str]:
+    """Return ``(service_name, timer_name, rclone_fragment_name)``."""
+    service = f"ots-backup-{profile}.service"
+    timer = f"ots-backup-{profile}.timer"
+    fragment = f"{profile}.conf"
+    return service, timer, fragment
+
+
+def _profile_files(systemd_dir: Path, rclone_dir: Path, profile: str) -> tuple[Path, Path, Path]:
+    service, timer, fragment = _unit_names(profile)
+    return (
+        systemd_dir / service,
+        systemd_dir / timer,
+        rclone_dir / fragment,
+    )
+
+
+def _valid_params(**overrides: Any) -> dict[str, Any]:
+    """Baseline params that should pass validation."""
+    base: dict[str, Any] = {
+        "profile": "db-daily",
+        "target": "remote1:backups/db",
+        "schedule": "daily",
+    }
+    base.update(overrides)
+    return base
+
+
+# --- happy path: install -------------------------------------------------
+
+
+class TestInstallHappyPath:
+    """First-run install creates three files, reloads, enables."""
+
+    def test_returns_success_with_expected_data(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        result = handle_install(_valid_params())
+        assert result.success is True, result.error
+        assert result.data is not None
+        assert result.data["unit"] == "ots-backup-db-daily.service"
+        assert result.data["timer"] == "ots-backup-db-daily.timer"
+        assert result.data["changed"] is True
+
+    def test_writes_three_files(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        service, timer, fragment = _profile_files(systemd_dir, rclone_dir, "db-daily")
+
+        handle_install(_valid_params())
+
+        assert service.exists()
+        assert timer.exists()
+        assert fragment.exists()
+
+    def test_file_modes(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        service, timer, fragment = _profile_files(systemd_dir, rclone_dir, "db-daily")
+
+        handle_install(_valid_params())
+
+        # Unit files are 0644 (readable by systemd).
+        assert stat.S_IMODE(os.stat(service).st_mode) == 0o644
+        assert stat.S_IMODE(os.stat(timer).st_mode) == 0o644
+        # rclone fragment is 0640 — it carries credentials.
+        assert stat.S_IMODE(os.stat(fragment).st_mode) == 0o640
+
+    def test_calls_daemon_reload_and_enable(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        handle_install(_valid_params())
+        assert fake_world.daemon_reload_count() == 1
+        assert fake_world.enable_now_count() == 1
+
+    def test_enable_targets_timer_not_service(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        handle_install(_valid_params())
+        # Spec: `systemctl enable --now ots-backup-<profile>.timer`.
+        enable_calls = [
+            c.argv
+            for c in fake_world.calls
+            if len(c.argv) >= 2 and c.argv[0].endswith("systemctl") and c.argv[1] == "enable"
+        ]
+        assert len(enable_calls) == 1
+        argv = enable_calls[0]
+        assert "ots-backup-db-daily.timer" in argv
+        assert "ots-backup-db-daily.service" not in argv
+
+    def test_accepts_valkey_hourly_profile(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        service, timer, fragment = _profile_files(systemd_dir, rclone_dir, "valkey-hourly")
+
+        result = handle_install(_valid_params(profile="valkey-hourly", schedule="hourly"))
+
+        assert result.success is True, result.error
+        assert service.exists()
+        assert timer.exists()
+        assert fragment.exists()
+
+
+# --- idempotency ---------------------------------------------------------
+
+
+class TestInstallIdempotency:
+    """Re-running with identical inputs must not mutate state."""
+
+    def test_rerun_reports_changed_false(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        first = handle_install(_valid_params())
+        assert first.data["changed"] is True
+
+        second = handle_install(_valid_params())
+        assert second.success is True, second.error
+        assert second.data["changed"] is False
+
+    def test_rerun_does_not_rewrite_files(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        service, timer, fragment = _profile_files(systemd_dir, rclone_dir, "db-daily")
+
+        handle_install(_valid_params())
+        # Snapshot mtimes after the first call.
+        service_mtime = os.stat(service).st_mtime_ns
+        timer_mtime = os.stat(timer).st_mtime_ns
+        fragment_mtime = os.stat(fragment).st_mtime_ns
+
+        handle_install(_valid_params())
+
+        # No file should have been rewritten.
+        assert os.stat(service).st_mtime_ns == service_mtime
+        assert os.stat(timer).st_mtime_ns == timer_mtime
+        assert os.stat(fragment).st_mtime_ns == fragment_mtime
+
+    def test_rerun_skips_daemon_reload(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        handle_install(_valid_params())
+        # Snapshot call counts after the first install.
+        reloads_after_first = fake_world.daemon_reload_count()
+        assert reloads_after_first == 1
+
+        handle_install(_valid_params())
+
+        # Second run: no file changed, so daemon-reload must NOT run
+        # again. Spec: "If any file changed, systemctl daemon-reload".
+        assert fake_world.daemon_reload_count() == reloads_after_first
+
+
+# --- config change (schedule only) --------------------------------------
+
+
+class TestInstallConfigChange:
+    """Changing only the schedule rewrites only the timer."""
+
+    def test_schedule_change_reports_changed_true(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        handle_install(_valid_params(schedule="daily"))
+        result = handle_install(_valid_params(schedule="hourly"))
+        assert result.success is True, result.error
+        assert result.data["changed"] is True
+
+    def test_schedule_change_rewrites_only_timer(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        service, timer, fragment = _profile_files(systemd_dir, rclone_dir, "db-daily")
+
+        handle_install(_valid_params(schedule="daily"))
+        service_mtime = os.stat(service).st_mtime_ns
+        timer_mtime = os.stat(timer).st_mtime_ns
+        fragment_mtime = os.stat(fragment).st_mtime_ns
+
+        handle_install(_valid_params(schedule="hourly"))
+
+        # Service and rclone fragment are inputs-equivalent; their
+        # mtimes must not advance.
+        assert os.stat(service).st_mtime_ns == service_mtime
+        assert os.stat(fragment).st_mtime_ns == fragment_mtime
+        # Timer content is schedule-dependent; its mtime must advance.
+        assert os.stat(timer).st_mtime_ns != timer_mtime
+
+    def test_schedule_change_calls_daemon_reload(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        handle_install(_valid_params(schedule="daily"))
+        reloads_before = fake_world.daemon_reload_count()
+
+        handle_install(_valid_params(schedule="hourly"))
+
+        # At least one more daemon-reload — the timer file changed.
+        assert fake_world.daemon_reload_count() == reloads_before + 1
+
+
+# --- validation failures ------------------------------------------------
+
+
+class TestInstallValidation:
+    """Validation failures fail early, before any filesystem or subprocess work."""
+
+    def test_unknown_profile_fails(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        result = handle_install(_valid_params(profile="nonexistent"))
+        assert result.success is False
+        assert "nonexistent" in (result.error or "") or "profile" in (result.error or "").lower()
+
+        # No subprocess call — validation rejects before any shell-out.
+        assert fake_world.calls == []
+        # No files written either.
+        assert list(systemd_dir.iterdir()) == []
+        assert list(rclone_dir.iterdir()) == []
+
+    def test_missing_profile_fails(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        params = _valid_params()
+        params.pop("profile")
+        result = handle_install(params)
+        assert result.success is False
+        assert fake_world.calls == []
+
+    def test_profile_not_in_allowlist_even_if_spelled_close(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        # Typo profiles (close enough to fool a dumb substring check)
+        # must still fail.
+        result = handle_install(_valid_params(profile="db_daily"))
+        assert result.success is False
+        assert fake_world.calls == []
+
+    def test_invalid_schedule_rejected_by_analyze(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        # "never" is not in _VALID_SCHEDULES so the fake
+        # systemd-analyze returns non-zero.
+        result = handle_install(_valid_params(schedule="never"))
+        assert result.success is False
+
+        # systemd-analyze calendar may have been invoked to validate;
+        # no enable / daemon-reload after that rejection.
+        assert fake_world.enable_now_count() == 0
+        assert fake_world.daemon_reload_count() == 0
+
+        # No files written.
+        assert list(systemd_dir.iterdir()) == []
+        assert list(rclone_dir.iterdir()) == []
+
+    def test_empty_schedule_rejected(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        result = handle_install(_valid_params(schedule=""))
+        assert result.success is False
+
+    def test_whitespace_only_schedule_rejected(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        result = handle_install(_valid_params(schedule="   "))
+        assert result.success is False
+
+    def test_empty_target_rejected(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        result = handle_install(_valid_params(target=""))
+        assert result.success is False
+        assert list(systemd_dir.iterdir()) == []
+        assert list(rclone_dir.iterdir()) == []
+
+    def test_target_with_newline_rejected(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        # Newline in remote name (colon-style). Spec regex
+        # ^[A-Za-z0-9_-]+$ excludes \n.
+        systemd_dir, rclone_dir = backup_dirs
+        result = handle_install(_valid_params(target="rem\note:path"))
+        assert result.success is False
+        assert list(systemd_dir.iterdir()) == []
+        assert list(rclone_dir.iterdir()) == []
+
+    def test_target_with_invalid_remote_chars_rejected(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        # Spaces not allowed in colon-style remote name.
+        result = handle_install(_valid_params(target="bad remote:path"))
+        assert result.success is False
+
+    def test_missing_target_rejected(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        params = _valid_params()
+        params.pop("target")
+        result = handle_install(params)
+        assert result.success is False
+        assert fake_world.calls == []
+
+
+# --- OS errors during atomic write --------------------------------------
+
+
+class TestInstallWriteFailures:
+    """Write failures surface as fail() and leave no partial tempfiles."""
+
+    def test_os_rename_failure_returns_fail(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        def boom(src: Any, dst: Any, *args: Any, **kwargs: Any) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(os, "rename", boom)
+
+        result = handle_install(_valid_params())
+        assert result.success is False
+
+    def test_os_rename_failure_leaves_no_tempfiles(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+
+        def boom(src: Any, dst: Any, *args: Any, **kwargs: Any) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(os, "rename", boom)
+        handle_install(_valid_params())
+
+        # Verify no leftover files in either directory. tempfile.NamedTemporaryFile
+        # with delete=False would be cleaned up by the handler on rename failure;
+        # any other half-open state is a bug.
+        systemd_leftovers = list(systemd_dir.iterdir())
+        rclone_leftovers = list(rclone_dir.iterdir())
+        # The final unit/fragment file MUST NOT exist (rename never succeeded).
+        service, timer, fragment = _profile_files(systemd_dir, rclone_dir, "db-daily")
+        assert not service.exists()
+        assert not timer.exists()
+        assert not fragment.exists()
+        # No stray hidden files either.
+        assert all(not p.name.startswith(".") for p in systemd_leftovers), systemd_leftovers
+        assert all(not p.name.startswith(".") for p in rclone_leftovers), rclone_leftovers
+
+
+# --- systemctl enable failure --------------------------------------------
+
+
+class TestInstallEnableFailure:
+    """A non-zero systemctl enable returns fail(); spec says no auto-rollback."""
+
+    def test_enable_failure_returns_fail(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        fake_world.fail_on.add("enable")
+        result = handle_install(_valid_params())
+        assert result.success is False
+
+    def test_enable_failure_does_not_rollback_files(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        service, timer, fragment = _profile_files(systemd_dir, rclone_dir, "db-daily")
+
+        fake_world.fail_on.add("enable")
+        handle_install(_valid_params())
+
+        # Per spec: "handler MUST NOT attempt automatic rollback".
+        # The unit files were written before the failed enable call
+        # and should remain on disk.
+        assert service.exists()
+        assert timer.exists()
+        assert fragment.exists()
+
+
+# --- uninstall -----------------------------------------------------------
+
+
+class TestUninstallHappyPath:
+    """Uninstalling a previously-installed profile cleans everything up."""
+
+    def test_removes_files_after_install(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        service, timer, fragment = _profile_files(systemd_dir, rclone_dir, "db-daily")
+
+        install = handle_install(_valid_params())
+        assert install.success is True, install.error
+        assert service.exists()
+        assert timer.exists()
+        assert fragment.exists()
+
+        result = handle_uninstall({"profile": "db-daily"})
+        assert result.success is True, result.error
+        assert result.data is not None
+        assert result.data["ok"] is True
+        assert result.data["changed"] is True
+
+        assert not service.exists()
+        assert not timer.exists()
+        assert not fragment.exists()
+
+    def test_calls_disable_and_daemon_reload(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        handle_install(_valid_params())
+        reloads_after_install = fake_world.daemon_reload_count()
+
+        handle_uninstall({"profile": "db-daily"})
+
+        assert fake_world.disable_now_count() == 1
+        # Spec: "If any file actually existed before step 3, run
+        # systemctl daemon-reload". An installed profile definitely
+        # had files to remove, so one more reload.
+        assert fake_world.daemon_reload_count() == reloads_after_install + 1
+
+    def test_disable_targets_timer(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        handle_install(_valid_params())
+        handle_uninstall({"profile": "db-daily"})
+
+        disable_calls = [
+            c.argv
+            for c in fake_world.calls
+            if len(c.argv) >= 2 and c.argv[0].endswith("systemctl") and c.argv[1] == "disable"
+        ]
+        assert len(disable_calls) == 1
+        assert "ots-backup-db-daily.timer" in disable_calls[0]
+
+
+class TestUninstallNotInstalled:
+    """Uninstalling a clean profile is a no-op that still runs `disable`."""
+
+    def test_reports_changed_false_when_not_installed(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        result = handle_uninstall({"profile": "db-daily"})
+        assert result.success is True, result.error
+        assert result.data["changed"] is False
+        assert result.data["ok"] is True
+
+    def test_disable_still_invoked_when_not_installed(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        # Spec: "systemctl disable --now still runs (harmless) but
+        # returns non-zero; catch and ignore."
+        handle_uninstall({"profile": "db-daily"})
+        assert fake_world.disable_now_count() == 1
+
+    def test_no_daemon_reload_when_nothing_removed(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        handle_uninstall({"profile": "db-daily"})
+        assert fake_world.daemon_reload_count() == 0
+
+    def test_no_file_removals_attempted_when_nothing_exists(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        handle_uninstall({"profile": "db-daily"})
+        # Directories still empty — nothing was created either.
+        assert list(systemd_dir.iterdir()) == []
+        assert list(rclone_dir.iterdir()) == []
+
+
+class TestUninstallValidation:
+    """Unknown profile fails before any systemctl call."""
+
+    def test_unknown_profile_fails(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        result = handle_uninstall({"profile": "nonexistent"})
+        assert result.success is False
+        # No systemctl invocation — spec: "Unknown profile →
+        # CommandResult.fail, no systemctl call."
+        assert fake_world.calls == []
+
+    def test_missing_profile_fails(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        result = handle_uninstall({})
+        assert result.success is False
+        assert fake_world.calls == []
+
+
+class TestUninstallPartialState:
+    """Partial leftover state (service present, timer absent) still cleans up."""
+
+    def test_partial_state_is_removed_and_reported_as_changed(
+        self,
+        backup_dirs: tuple[Path, Path],
+        fake_world: _FakeSystemdWorld,
+    ):
+        systemd_dir, rclone_dir = backup_dirs
+        service, timer, fragment = _profile_files(systemd_dir, rclone_dir, "db-daily")
+
+        # Simulate partial prior state: only the service file exists.
+        service.write_text("[Service]\nExecStart=/bin/true\n", encoding="utf-8")
+        os.chmod(service, 0o644)
+        assert service.exists()
+        assert not timer.exists()
+        assert not fragment.exists()
+
+        result = handle_uninstall({"profile": "db-daily"})
+        assert result.success is True, result.error
+        # At least one file existed → spec says changed=True and a
+        # daemon-reload runs.
+        assert result.data["changed"] is True
+        assert not service.exists()
+        assert fake_world.daemon_reload_count() == 1
+
+
+# --- allowlist sanity ----------------------------------------------------
+
+
+class TestAllowedProfilesExported:
+    """The allowlist constant exposes exactly the expected profiles.
+
+    Purely a guard against accidental widening of the allowlist — any
+    new entry here implies new ``_render_*`` templates, so the test
+    should be updated intentionally.
+    """
+
+    def test_allowlist_members(self):
+        assert ALLOWED_PROFILES == frozenset({"db-daily", "valkey-hourly"})

--- a/tests/commands/sidecar/handlers/test_postgres.py
+++ b/tests/commands/sidecar/handlers/test_postgres.py
@@ -1,0 +1,840 @@
+# tests/commands/sidecar/handlers/test_postgres.py
+
+"""Tests for the ``postgres.*`` handlers (issue #55).
+
+Structure mirrors ``test_secrets.py``: one class per concern. Validation
+tests (which must reject before issuing any SQL) carry no service fixture
+and run under the ``quick`` marker. State-mutating tests take the
+session-scoped ``postgres_service`` fixture plus the per-test
+``postgres_db`` fixture, and are marked ``integration`` — CI provisions
+podman, dev machines without podman will skip.
+
+Key conventions:
+
+* ``PSQL_PEER_CMD`` is swapped in each integration test so the handler
+  talks to the test container instead of the production peer-auth UNIX
+  socket. Requires the impl to read ``PSQL_PEER_CMD`` per-call; see the
+  report for the coordination note.
+* Role names are derived from a per-test uuid because
+  ``postgres_service`` is session-scoped and roles are cluster-global
+  (unlike databases, which are per-test via ``postgres_db``).
+* ``in_process_bus`` routes ``secrets.deliver`` to the in-process
+  dispatcher. End-to-end tests point :data:`secrets.ALLOWED_ENV_FILE`
+  at the ``fake_env_file`` tmp path.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import uuid
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import rots.commands.sidecar.handlers.postgres as pg
+import rots.commands.sidecar.handlers.secrets as secrets_mod
+from rots.sidecar.commands import CommandResult
+
+# --- helpers --------------------------------------------------------------
+
+
+def _psql_exec(container: str, db: str, sql: str) -> subprocess.CompletedProcess[str]:
+    """Run a SQL statement against the test container and return the result."""
+    return subprocess.run(
+        [
+            "podman",
+            "exec",
+            container,
+            "psql",
+            "-U",
+            "postgres",
+            "-d",
+            db,
+            "-tA",
+            "-c",
+            sql,
+        ],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _role_exists(container: str, role: str) -> bool:
+    """Return True iff ``role`` is present in ``pg_roles``."""
+    result = _psql_exec(
+        container,
+        "postgres",
+        f"SELECT 1 FROM pg_roles WHERE rolname = '{role}'",
+    )
+    return result.stdout.strip() == "1"
+
+
+def _database_exists(container: str, db: str) -> bool:
+    """Return True iff ``db`` is present in ``pg_database``."""
+    result = _psql_exec(
+        container,
+        "postgres",
+        f"SELECT 1 FROM pg_database WHERE datname = '{db}'",
+    )
+    return result.stdout.strip() == "1"
+
+
+def _role_password_is_null(container: str, role: str) -> bool:
+    """Return True iff the role's stored password is NULL.
+
+    Reads ``pg_authid`` which requires superuser; the test container
+    runs psql as the postgres superuser so this works.
+    """
+    result = _psql_exec(
+        container,
+        "postgres",
+        f"SELECT rolpassword IS NULL FROM pg_authid WHERE rolname = '{role}'",
+    )
+    return result.stdout.strip() == "t"
+
+
+def _drop_role_best_effort(container: str, role: str) -> None:
+    """Drop ``role`` ignoring errors. For fixture teardown only."""
+    _psql_exec(container, "postgres", f'DROP OWNED BY "{role}" CASCADE')
+    _psql_exec(container, "postgres", f'DROP ROLE IF EXISTS "{role}"')
+
+
+def _drop_database_best_effort(container: str, db: str) -> None:
+    """Drop ``db`` ignoring errors. For fixture teardown only."""
+    _psql_exec(container, "postgres", f'DROP DATABASE IF EXISTS "{db}"')
+
+
+# --- fixtures -------------------------------------------------------------
+
+
+@pytest.fixture
+def unique_role() -> str:
+    """Return a cluster-unique role name for one test."""
+    return f"app_{uuid.uuid4().hex[:12]}"
+
+
+@pytest.fixture
+def patched_psql(
+    monkeypatch: pytest.MonkeyPatch,
+    postgres_service: dict[str, Any],
+) -> Iterator[str]:
+    """Redirect ``PSQL_PEER_CMD`` at the test container.
+
+    Production uses ``sudo -u postgres psql`` over the local UNIX socket
+    (peer auth). Neither applies inside the test container, so we swap
+    the command so the handler speaks to the podman-hosted postgres via
+    ``podman exec``.
+    """
+    container = postgres_service["container"]
+    monkeypatch.setattr(
+        pg,
+        "PSQL_PEER_CMD",
+        (
+            "podman",
+            "exec",
+            "-i",
+            container,
+            "psql",
+            "-U",
+            "postgres",
+            "-v",
+            "ON_ERROR_STOP=1",
+        ),
+    )
+    yield container
+
+
+@pytest.fixture
+def patched_env_file(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_env_file: tuple[Path, Callable[[str], Path]],
+) -> Path:
+    """Point :data:`secrets.ALLOWED_ENV_FILE` at a tmp env file.
+
+    End-to-end tests call ``bootstrap_app`` which publishes
+    ``secrets.deliver`` at web-host via ``in_process_bus``. That handler
+    checks the target against ``ALLOWED_ENV_FILE`` — hard-coded to
+    ``/etc/default/onetimesecret`` in production. Repoint at tmp_path so
+    the end-to-end test is self-contained.
+    """
+    path, seed = fake_env_file
+    seed("")
+    monkeypatch.setattr(secrets_mod, "ALLOWED_ENV_FILE", str(path))
+    return path
+
+
+@pytest.fixture
+def bound_bus(
+    monkeypatch: pytest.MonkeyPatch,
+    in_process_bus: Any,
+) -> Any:
+    """Wire the in-process bus into the postgres handler factory.
+
+    The handler obtains its RPC client via ``_get_rpc_client``. Swap that
+    seam so cross-host calls (``secrets.deliver`` at ``peer_id``) route
+    to the in-process dispatcher.
+    """
+    monkeypatch.setattr(pg, "_get_rpc_client", lambda: in_process_bus)
+    return in_process_bus
+
+
+# =========================================================================
+# handle_bootstrap_app — validation (no SQL, no podman needed)
+# =========================================================================
+
+
+class TestBootstrapAppValidation:
+    """Validation rejects bad inputs before any SQL runs.
+
+    The ``no_subprocess`` monkeypatch asserts that ``subprocess.run`` is
+    never invoked. Assumes the impl uses ``pg.subprocess.run`` (module
+    import style) — the standard pattern.
+    """
+
+    pytestmark = pytest.mark.quick
+
+    @pytest.fixture
+    def no_subprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("subprocess.run must not be called for validation rejections")
+
+        monkeypatch.setattr(pg.subprocess, "run", boom)
+
+    def _valid(self) -> dict[str, Any]:
+        return {
+            "app": "myapp",
+            "owner_role": "myapp",
+            "peer_ip": "10.0.0.5",
+            "peer_id": "web-host",
+        }
+
+    @pytest.mark.parametrize("missing", ["app", "owner_role", "peer_ip", "peer_id"])
+    def test_missing_required_param(self, no_subprocess: None, missing: str):
+        params = self._valid()
+        del params[missing]
+        result = pg.handle_bootstrap_app(params)
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.parametrize(
+        "bad_app",
+        [
+            "Uppercase",
+            "1leading_digit",
+            "has-dash",
+            "has space",
+            "has;semi",
+            "x" * 64,  # over the 63-char tail cap
+            "",
+            "_underscore_lead",
+            "has.dot",
+            "..",
+        ],
+    )
+    def test_invalid_app_name(self, no_subprocess: None, bad_app: str):
+        params = self._valid()
+        params["app"] = bad_app
+        result = pg.handle_bootstrap_app(params)
+        assert result.success is False
+        assert result.error is not None
+
+    @pytest.mark.parametrize(
+        "bad_owner",
+        ["Uppercase", "1lead", "has-dash", "with;inj", "", ".."],
+    )
+    def test_invalid_owner_role(self, no_subprocess: None, bad_owner: str):
+        params = self._valid()
+        params["owner_role"] = bad_owner
+        result = pg.handle_bootstrap_app(params)
+        assert result.success is False
+
+    @pytest.mark.parametrize("bad_peer_ip", ["", 42, None, "   "])
+    def test_invalid_peer_ip(self, no_subprocess: None, bad_peer_ip: Any):
+        params = self._valid()
+        params["peer_ip"] = bad_peer_ip
+        result = pg.handle_bootstrap_app(params)
+        assert result.success is False
+
+    @pytest.mark.parametrize("bad_peer_id", ["", 0, None])
+    def test_invalid_peer_id(self, no_subprocess: None, bad_peer_id: Any):
+        params = self._valid()
+        params["peer_id"] = bad_peer_id
+        result = pg.handle_bootstrap_app(params)
+        assert result.success is False
+
+
+# =========================================================================
+# handle_bootstrap_app — state-mutating (real postgres)
+# =========================================================================
+
+
+class TestBootstrapAppHappyPath:
+    """Happy-path and idempotency tests against a real postgres container."""
+
+    pytestmark = pytest.mark.integration
+
+    def test_creates_role_database_and_delivers_password(
+        self,
+        patched_psql: str,
+        patched_env_file: Path,
+        bound_bus: Any,
+        unique_role: str,
+    ):
+        container = patched_psql
+        try:
+            result = pg.handle_bootstrap_app(
+                {
+                    "app": unique_role,
+                    "owner_role": unique_role,
+                    "peer_ip": "10.0.0.5",
+                    "peer_id": "web-host",
+                }
+            )
+
+            assert result.success is True, result.error
+            assert result.data["role"] == unique_role
+            assert result.data["database"] == unique_role
+            assert result.data["password_delivered_to"] == "web-host"
+            assert result.data["changed"] is True
+
+            # Verify real state in the container.
+            assert _role_exists(container, unique_role)
+            assert _database_exists(container, unique_role)
+
+            # Password landed in the env file via the in-process bus.
+            body = patched_env_file.read_text()
+            assert "PG_PASSWORD=" in body
+            # The value is non-empty (token_urlsafe(32) is ~43 chars).
+            for line in body.splitlines():
+                if line.startswith("PG_PASSWORD="):
+                    assert len(line) > len("PG_PASSWORD=") + 8
+                    break
+            else:
+                pytest.fail("PG_PASSWORD line not found in env file")
+        finally:
+            _drop_database_best_effort(container, unique_role)
+            _drop_role_best_effort(container, unique_role)
+
+    def test_idempotent_rerun_is_noop(
+        self,
+        patched_psql: str,
+        patched_env_file: Path,
+        bound_bus: Any,
+        unique_role: str,
+    ):
+        """Second call with same params returns changed=False and mutates nothing.
+
+        The env file mtime is captured after the first run and compared
+        after the second — the docstring specifies "No queries beyond
+        the two existence checks run" and no delivery on re-run.
+        """
+        container = patched_psql
+        params = {
+            "app": unique_role,
+            "owner_role": unique_role,
+            "peer_ip": "10.0.0.5",
+            "peer_id": "web-host",
+        }
+        try:
+            first = pg.handle_bootstrap_app(params)
+            assert first.success is True
+            assert first.data["changed"] is True
+
+            env_mtime_after_first = os.stat(patched_env_file).st_mtime_ns
+            body_after_first = patched_env_file.read_text()
+
+            second = pg.handle_bootstrap_app(params)
+            assert second.success is True, second.error
+            assert second.data["changed"] is False
+            assert second.data["role"] == unique_role
+            assert second.data["database"] == unique_role
+            assert second.data["password_delivered_to"] == "web-host"
+
+            # Env file untouched.
+            assert os.stat(patched_env_file).st_mtime_ns == env_mtime_after_first
+            assert patched_env_file.read_text() == body_after_first
+
+            # State unchanged.
+            assert _role_exists(container, unique_role)
+            assert _database_exists(container, unique_role)
+        finally:
+            _drop_database_best_effort(container, unique_role)
+            _drop_role_best_effort(container, unique_role)
+
+
+class TestBootstrapAppExistingRole:
+    """When the role already exists, no rotation occurs; receipt is echoed.
+
+    Spec (bootstrap_app step 3, verbatim):
+
+        "In the already-exists case the handler cannot deliver a password
+        (it doesn't know one); it MUST still publish a delivery receipt
+        so the operator can verify the web peer has what it needs.
+        Strategy: when the role exists, skip step 4 and return
+        changed=False with password_delivered_to=peer_id as an
+        informational echo."
+
+    Interpreted here as: skip step 4 entirely (no bus publish, env file
+    untouched) and only echo ``password_delivered_to`` in the data
+    payload. Flagged in the report.
+    """
+
+    pytestmark = pytest.mark.integration
+
+    def test_existing_role_is_not_rotated(
+        self,
+        patched_psql: str,
+        patched_env_file: Path,
+        bound_bus: Any,
+        unique_role: str,
+    ):
+        container = patched_psql
+        # Pre-create the role. Test owns cleanup.
+        _psql_exec(
+            container,
+            "postgres",
+            f"CREATE ROLE \"{unique_role}\" LOGIN PASSWORD 'preexisting'",
+        )
+        try:
+            env_before = patched_env_file.read_text()
+
+            result = pg.handle_bootstrap_app(
+                {
+                    "app": unique_role,
+                    "owner_role": unique_role,
+                    "peer_ip": "10.0.0.5",
+                    "peer_id": "web-host",
+                }
+            )
+
+            assert result.success is True, result.error
+            assert result.data["changed"] is False
+            assert result.data["role"] == unique_role
+            assert result.data["password_delivered_to"] == "web-host"
+
+            # Env file untouched: no rotation happened.
+            assert patched_env_file.read_text() == env_before
+        finally:
+            _drop_database_best_effort(container, unique_role)
+            _drop_role_best_effort(container, unique_role)
+
+
+class TestBootstrapAppDeliveryFailureRollback:
+    """If ``secrets.deliver`` fails, the freshly-created role is dropped."""
+
+    pytestmark = pytest.mark.integration
+
+    def test_delivery_failure_drops_role(
+        self,
+        patched_psql: str,
+        patched_env_file: Path,
+        in_process_bus: Any,
+        monkeypatch: pytest.MonkeyPatch,
+        unique_role: str,
+    ):
+        container = patched_psql
+        # Override the web-host peer to return failure; db-host continues
+        # to route through the real local dispatcher.
+        in_process_bus.register(
+            "web-host",
+            lambda cmd, p: CommandResult.fail("delivery failed: broker down"),
+        )
+        monkeypatch.setattr(pg, "_get_rpc_client", lambda: in_process_bus)
+
+        try:
+            result = pg.handle_bootstrap_app(
+                {
+                    "app": unique_role,
+                    "owner_role": unique_role,
+                    "peer_ip": "10.0.0.5",
+                    "peer_id": "web-host",
+                }
+            )
+
+            assert result.success is False
+            assert result.error is not None
+
+            # Rollback: role must not exist, database must not exist
+            # (database creation is step 5, after delivery).
+            assert not _role_exists(container, unique_role)
+            assert not _database_exists(container, unique_role)
+
+            # Env file untouched (delivery failed, nothing was written).
+            assert patched_env_file.read_text() == ""
+        finally:
+            _drop_database_best_effort(container, unique_role)
+            _drop_role_best_effort(container, unique_role)
+
+
+# =========================================================================
+# handle_add_hba
+# =========================================================================
+
+
+class TestAddHbaValidation:
+    """Name and content validation reject before filesystem work."""
+
+    pytestmark = pytest.mark.quick
+
+    @pytest.fixture
+    def tmp_hba_dir(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> Path:
+        d = tmp_path / "pg_hba.d"
+        d.mkdir()
+        monkeypatch.setattr(pg, "PG_HBA_D", str(d))
+        return d
+
+    @pytest.fixture
+    def no_subprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("subprocess.run must not be called for validation rejections")
+
+        monkeypatch.setattr(pg.subprocess, "run", boom)
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "/absolute",
+            "../escape",
+            "dir/sub",
+            ".hidden",
+            "",
+            "x" * 65,  # > 64 char cap
+        ],
+    )
+    def test_rejects_bad_name(
+        self,
+        tmp_hba_dir: Path,
+        no_subprocess: None,
+        bad_name: str,
+    ):
+        result = pg.handle_add_hba({"name": bad_name, "content": "host all all 10.0.0.0/24 md5\n"})
+        assert result.success is False
+        # No file was created anywhere.
+        assert list(tmp_hba_dir.iterdir()) == []
+
+    def test_rejects_empty_content(
+        self,
+        tmp_hba_dir: Path,
+        no_subprocess: None,
+    ):
+        result = pg.handle_add_hba({"name": "10-web", "content": ""})
+        assert result.success is False
+        assert list(tmp_hba_dir.iterdir()) == []
+
+    @pytest.mark.parametrize(
+        "bad_content",
+        [
+            "garbage line\n",
+            "DROP DATABASE\n",
+            "evil\n",
+        ],
+    )
+    def test_rejects_content_without_hba_verb(
+        self,
+        tmp_hba_dir: Path,
+        no_subprocess: None,
+        bad_content: str,
+    ):
+        result = pg.handle_add_hba({"name": "10-web", "content": bad_content})
+        assert result.success is False
+        assert list(tmp_hba_dir.iterdir()) == []
+
+    def test_missing_params(self, tmp_hba_dir: Path, no_subprocess: None):
+        assert pg.handle_add_hba({"content": "host all all 10/24 md5\n"}).success is False
+        assert pg.handle_add_hba({"name": "10-web"}).success is False
+
+
+class TestAddHbaHappyPath:
+    """Write, reload, idempotency, and content-change behaviour."""
+
+    pytestmark = pytest.mark.integration
+
+    @pytest.fixture
+    def tmp_hba_dir(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> Path:
+        d = tmp_path / "pg_hba.d"
+        d.mkdir()
+        monkeypatch.setattr(pg, "PG_HBA_D", str(d))
+        return d
+
+    def test_writes_file_and_reloads(
+        self,
+        patched_psql: str,
+        tmp_hba_dir: Path,
+    ):
+        content = "host all all 10.0.0.0/24 md5\n"
+        result = pg.handle_add_hba({"name": "10-web", "content": content})
+
+        assert result.success is True, result.error
+        assert result.data["changed"] is True
+        assert result.data["reloaded"] is True
+
+        target = tmp_hba_dir / "10-web.conf"
+        assert target.exists()
+        assert target.read_text() == content
+
+    def test_appends_conf_suffix_if_missing(
+        self,
+        patched_psql: str,
+        tmp_hba_dir: Path,
+    ):
+        pg.handle_add_hba({"name": "20-app", "content": "host all all 10.0.0.0/24 md5\n"})
+        assert (tmp_hba_dir / "20-app.conf").exists()
+
+    def test_idempotent_rerun_is_noop(
+        self,
+        patched_psql: str,
+        tmp_hba_dir: Path,
+    ):
+        content = "host all all 10.0.0.0/24 md5\n"
+        first = pg.handle_add_hba({"name": "10-web", "content": content})
+        assert first.data["changed"] is True
+
+        target = tmp_hba_dir / "10-web.conf"
+        mtime_after_first = os.stat(target).st_mtime_ns
+
+        second = pg.handle_add_hba({"name": "10-web", "content": content})
+        assert second.success is True, second.error
+        assert second.data["changed"] is False
+        assert second.data["reloaded"] is False
+        assert os.stat(target).st_mtime_ns == mtime_after_first
+
+    def test_content_change_rewrites(
+        self,
+        patched_psql: str,
+        tmp_hba_dir: Path,
+    ):
+        pg.handle_add_hba({"name": "10-web", "content": "host all all 10.0.0.0/24 md5\n"})
+        result = pg.handle_add_hba(
+            {"name": "10-web", "content": "host all all 192.168.0.0/24 md5\n"}
+        )
+        assert result.success is True, result.error
+        assert result.data["changed"] is True
+        assert result.data["reloaded"] is True
+
+        target = tmp_hba_dir / "10-web.conf"
+        assert "192.168.0.0/24" in target.read_text()
+        assert "10.0.0.0/24" not in target.read_text()
+
+
+class TestAddHbaReloadFailure:
+    """If the reload call fails, the file is NOT rolled back.
+
+    Spec (add_hba error mapping, verbatim):
+
+        "the file is already written, but the reload failed. Return
+        CommandResult.fail with a warning that the file exists and
+        manual systemctl reload postgresql is needed. Do NOT
+        auto-rollback the file."
+
+    The "warning" placement is ambiguous — it could live in
+    ``result.error`` or ``result.warnings``. This test accepts either.
+    Flagged in the report.
+    """
+
+    pytestmark = pytest.mark.quick
+
+    def test_reload_failure_leaves_file_in_place(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        hba_dir = tmp_path / "pg_hba.d"
+        hba_dir.mkdir()
+        monkeypatch.setattr(pg, "PG_HBA_D", str(hba_dir))
+
+        def failing_run(*args: Any, **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            raise subprocess.CalledProcessError(
+                1,
+                list(args[0]) if args else [],
+                stderr="pg_reload_conf failed",
+            )
+
+        monkeypatch.setattr(pg.subprocess, "run", failing_run)
+
+        result = pg.handle_add_hba({"name": "10-web", "content": "host all all 10.0.0.0/24 md5\n"})
+
+        assert result.success is False
+
+        # File MUST be on disk — no rollback per spec.
+        target = hba_dir / "10-web.conf"
+        assert target.exists(), "Per spec, the file is NOT rolled back on reload failure"
+
+        # Warning about reload / manual reload surfaced somewhere.
+        err_lower = (result.error or "").lower()
+        warn_joined = " ".join(result.warnings).lower()
+        surfaced = "reload" in err_lower or "reload" in warn_joined
+        assert surfaced, (
+            f"Expected a reload-related warning in error={result.error!r} "
+            f"or warnings={result.warnings!r}"
+        )
+
+
+# =========================================================================
+# handle_rotate_password
+# =========================================================================
+
+
+class TestRotatePasswordValidation:
+    """Identifier validation rejects before any ALTER ROLE."""
+
+    pytestmark = pytest.mark.quick
+
+    @pytest.fixture
+    def no_subprocess(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        def boom(*args: Any, **kwargs: Any) -> Any:
+            raise AssertionError("subprocess.run must not be called for validation rejections")
+
+        monkeypatch.setattr(pg.subprocess, "run", boom)
+
+    @pytest.mark.parametrize(
+        "bad_role",
+        [
+            "Uppercase",
+            "1lead",
+            "has-dash",
+            "has space",
+            "inj;drop",
+            "",
+            "..",
+        ],
+    )
+    def test_rejects_bad_role(self, no_subprocess: None, bad_role: str):
+        result = pg.handle_rotate_password({"role": bad_role, "peer_id": "web-host"})
+        assert result.success is False
+
+    @pytest.mark.parametrize("missing", ["role", "peer_id"])
+    def test_missing_param(self, no_subprocess: None, missing: str):
+        params = {"role": "myapp", "peer_id": "web-host"}
+        del params[missing]
+        result = pg.handle_rotate_password(params)
+        assert result.success is False
+
+
+class TestRotatePasswordHappyPath:
+    """Rotate generates a new password and delivers it via the bus."""
+
+    pytestmark = pytest.mark.integration
+
+    def test_rotate_delivers_new_password(
+        self,
+        patched_psql: str,
+        patched_env_file: Path,
+        bound_bus: Any,
+        unique_role: str,
+    ):
+        container = patched_psql
+        # Pre-create role. rotate_password is NOT idempotent; spec says
+        # the role must already exist.
+        _psql_exec(
+            container,
+            "postgres",
+            f"CREATE ROLE \"{unique_role}\" LOGIN PASSWORD 'original'",
+        )
+        try:
+            # Seed the env file with an existing PG_PASSWORD so we can
+            # verify it changed.
+            patched_env_file.write_text("PG_PASSWORD=original_delivered\n")
+
+            result = pg.handle_rotate_password({"role": unique_role, "peer_id": "web-host"})
+
+            assert result.success is True, result.error
+            assert result.data["delivered_to"] == "web-host"
+            assert result.data["changed"] is True
+
+            body = patched_env_file.read_text()
+            assert "PG_PASSWORD=" in body
+            assert "original_delivered" not in body
+        finally:
+            _drop_role_best_effort(container, unique_role)
+
+
+class TestRotatePasswordMissingRole:
+    """Rotate fails cleanly when the role does not exist."""
+
+    pytestmark = pytest.mark.integration
+
+    def test_missing_role_fails_without_alter(
+        self,
+        patched_psql: str,
+        patched_env_file: Path,
+        bound_bus: Any,
+        unique_role: str,
+    ):
+        container = patched_psql
+        # Role deliberately NOT created.
+        seeded = "PG_PASSWORD=leave_me_alone\n"
+        patched_env_file.write_text(seeded)
+
+        result = pg.handle_rotate_password({"role": unique_role, "peer_id": "web-host"})
+
+        assert result.success is False
+        assert result.error is not None
+
+        # Env file untouched.
+        assert patched_env_file.read_text() == seeded
+
+        # Role still absent.
+        assert not _role_exists(container, unique_role)
+
+
+class TestRotatePasswordDeliveryFailure:
+    """Delivery failure triggers a best-effort revoke via ALTER ROLE ... PASSWORD NULL."""
+
+    pytestmark = pytest.mark.integration
+
+    def test_delivery_failure_revokes_password(
+        self,
+        patched_psql: str,
+        patched_env_file: Path,
+        in_process_bus: Any,
+        monkeypatch: pytest.MonkeyPatch,
+        unique_role: str,
+    ):
+        container = patched_psql
+        _psql_exec(
+            container,
+            "postgres",
+            f"CREATE ROLE \"{unique_role}\" LOGIN PASSWORD 'original'",
+        )
+        try:
+            in_process_bus.register(
+                "web-host",
+                lambda cmd, p: CommandResult.fail("delivery failed: broker down"),
+            )
+            monkeypatch.setattr(pg, "_get_rpc_client", lambda: in_process_bus)
+
+            result = pg.handle_rotate_password({"role": unique_role, "peer_id": "web-host"})
+
+            assert result.success is False
+
+            # Revoke best-effort: the role's stored password is now NULL.
+            # Requires postgres superuser, which the test container uses.
+            assert _role_password_is_null(container, unique_role), (
+                "Delivery failure must trigger ALTER ROLE ... PASSWORD NULL"
+            )
+
+            # Both the delivery failure and any revoke issues surface
+            # somewhere — spec says "surface both errors in warnings"
+            # but the outer result is fail. Loose check either way.
+            err_lower = (result.error or "").lower()
+            warn_joined = " ".join(result.warnings).lower()
+            assert (
+                "deliver" in err_lower
+                or "deliver" in warn_joined
+                or "broker" in err_lower
+                or "broker" in warn_joined
+            )
+        finally:
+            _drop_role_best_effort(container, unique_role)

--- a/tests/commands/sidecar/handlers/test_role_gating.py
+++ b/tests/commands/sidecar/handlers/test_role_gating.py
@@ -1,0 +1,110 @@
+# tests/commands/sidecar/handlers/test_role_gating.py
+
+"""Tests for the role-based handler filtering on ``@register_handler``.
+
+The role gate lives on the ``@register_handler(roles={...})`` decorator.
+At registration time every handler declares which sidecar roles should
+expose it. At startup, ``_import_handlers(role=...)`` filters the active
+dispatcher so a web sidecar only sees web-applicable commands.
+
+These tests avoid importlib reloads (which have ugly knock-on effects on
+other tests that patch the ``secrets`` module object). Instead they
+assert:
+
+* Every handler has a declared role set after ``_import_handlers()``.
+* The expected role sets match the spec.
+* ``register_handler`` validates its ``roles`` argument.
+* ``_import_handlers`` validates its ``role`` argument.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from rots.sidecar.commands import (
+    ALL_ROLES,
+    DEFAULT_ROLES,
+    Command,
+    _handler_roles,
+    _import_handlers,
+    register_handler,
+)
+
+pytestmark = pytest.mark.quick
+
+
+class TestRoleMetadata:
+    """Every handler module registers with the expected role set."""
+
+    def setup_method(self) -> None:
+        # Populate the registry on demand. Safe to call repeatedly —
+        # module imports are idempotent.
+        _import_handlers()
+
+    def test_secrets_deliver_is_db_and_web(self):
+        assert _handler_roles[Command.SECRETS_DELIVER] == frozenset({"db", "web"})
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            Command.POSTGRES_BOOTSTRAP_APP,
+            Command.POSTGRES_ADD_HBA,
+            Command.POSTGRES_ROTATE_PASSWORD,
+            Command.VALKEY_CREATE_ACL_USER,
+            Command.VALKEY_RELOAD_ACL,
+            Command.BACKUP_INSTALL,
+            Command.BACKUP_UNINSTALL,
+        ],
+    )
+    def test_db_only_handlers_declare_db_role(self, cmd: Command):
+        assert _handler_roles[cmd] == frozenset({"db"})
+
+    @pytest.mark.parametrize(
+        "cmd",
+        [
+            Command.RESTART_WEB,
+            Command.CONFIG_STAGE,
+            Command.HEALTH,
+            Command.DISCOVER_PING,
+        ],
+    )
+    def test_legacy_handlers_default_to_all_roles(self, cmd: Command):
+        """Legacy handlers (registered without explicit roles) get DEFAULT_ROLES."""
+        assert _handler_roles[cmd] == DEFAULT_ROLES
+
+
+class TestRegisterHandlerValidation:
+    """``register_handler`` rejects unknown roles at decoration time."""
+
+    def test_rejects_unknown_role(self):
+        with pytest.raises(ValueError, match="Unknown role"):
+            # Attempt to register a bogus role — the decorator factory
+            # raises immediately, before ever being applied to a function.
+            register_handler(Command.HEALTH, roles={"saboteur"})
+
+    def test_accepts_known_roles(self):
+        # No exception — the returned decorator is callable.
+        deco_db = register_handler(Command.HEALTH, roles={"db"})
+        deco_web = register_handler(Command.HEALTH, roles={"web"})
+        deco_both = register_handler(Command.HEALTH, roles={"db", "web"})
+        assert callable(deco_db)
+        assert callable(deco_web)
+        assert callable(deco_both)
+
+
+class TestImportHandlersValidation:
+    """``_import_handlers`` rejects unknown roles."""
+
+    def test_unknown_role(self):
+        with pytest.raises(ValueError, match="Unknown sidecar role"):
+            _import_handlers(role="saboteur")
+
+
+class TestAllRolesConstant:
+    """``ALL_ROLES`` enumerates exactly the supported sidecar roles."""
+
+    def test_all_roles_is_db_and_web(self):
+        assert ALL_ROLES == frozenset({"db", "web"})
+
+    def test_default_roles_matches_all(self):
+        assert DEFAULT_ROLES == ALL_ROLES

--- a/tests/commands/sidecar/handlers/test_secrets.py
+++ b/tests/commands/sidecar/handlers/test_secrets.py
@@ -337,3 +337,142 @@ class TestInProcessBus:
         assert result.success is True
         assert result.data["changed"] is True
         assert "routed-through-bus" in env_path.read_text()
+
+
+# --- owner/group preservation across atomic rename ----------------------
+
+
+class TestOwnerGroupPreservation:
+    """After ``os.rename``, the handler must restore the pre-existing uid/gid.
+
+    Rationale: the tempfile is created by the sidecar process (typically
+    root). A naive rename would inherit root:root on the replaced file,
+    dropping the ``onetimesecret`` group bit that the container user
+    relies on via ``EnvironmentFile=``. The handler calls
+    ``os.chown(path, lst.st_uid, lst.st_gid)`` after rename — this class
+    proves that path is exercised and is best-effort.
+    """
+
+    def test_preserves_uid_gid_on_update(
+        self,
+        env_path: Path,
+        fake_env_file: tuple[Path, object],
+    ):
+        # Seed a pre-existing file owned by the current uid/gid. We use
+        # the process's own ids so no EPERM can occur on the later chown
+        # call — non-root test runs can't chown to arbitrary ids. The
+        # point isn't *which* ids are set, it's that the handler
+        # re-applied whatever was there before.
+        _, seed = fake_env_file
+        seed("PG_PASSWORD=old_value\n")  # type: ignore[operator]
+        pre_uid = os.stat(env_path).st_uid
+        pre_gid = os.stat(env_path).st_gid
+
+        result = handle_secrets_deliver({"name": "PG_PASSWORD", "value": "new_value"})
+        assert result.success is True, result.error
+        assert result.data["changed"] is True
+
+        post = os.stat(env_path)
+        assert post.st_uid == pre_uid
+        assert post.st_gid == pre_gid
+
+    def test_chown_called_with_original_uid_gid(
+        self,
+        env_path: Path,
+        fake_env_file: tuple[Path, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """Record the chown call to prove the preserved values flow through.
+
+        Patches ``os.chown`` at the secrets module's namespace (matches the
+        ``os.rename`` patching pattern used for atomicity) and captures
+        ``(path, uid, gid)``. This is the direct witness that the chown
+        restoration runs with the pre-rename stat values, not whatever
+        ``os.stat`` would return after rename.
+        """
+        _, seed = fake_env_file
+        seed("PG_PASSWORD=old\n")  # type: ignore[operator]
+        pre_uid = os.stat(env_path).st_uid
+        pre_gid = os.stat(env_path).st_gid
+
+        calls: list[tuple[str, int, int]] = []
+
+        def recording_chown(path: str, uid: int, gid: int) -> None:
+            calls.append((str(path), uid, gid))
+
+        monkeypatch.setattr(secrets_mod.os, "chown", recording_chown)
+
+        handle_secrets_deliver({"name": "PG_PASSWORD", "value": "brand_new"})
+
+        assert len(calls) == 1
+        recorded_path, recorded_uid, recorded_gid = calls[0]
+        assert recorded_path == str(env_path)
+        assert recorded_uid == pre_uid
+        assert recorded_gid == pre_gid
+
+    def test_fresh_write_skips_chown(
+        self,
+        env_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        """No prior file → no chown call. The guard is ``if lst is not None``.
+
+        Fresh-write already works (other tests exercise it); this test
+        specifically proves the chown-preservation call is *not* made
+        when there's no prior owner to copy. Failing to skip would mean
+        chown'ing to whatever ``os.stat`` captured before, which on a
+        missing file would raise.
+        """
+        # Sanity: env_path really does not exist yet.
+        assert not env_path.exists()
+
+        calls: list[tuple[str, int, int]] = []
+
+        def recording_chown(path: str, uid: int, gid: int) -> None:
+            calls.append((str(path), uid, gid))
+
+        monkeypatch.setattr(secrets_mod.os, "chown", recording_chown)
+
+        result = handle_secrets_deliver({"name": "PG_PASSWORD", "value": "v"})
+        assert result.success is True, result.error
+        assert env_path.exists()
+        # Fresh file: no preservation call is made.
+        assert calls == []
+
+    def test_chown_permission_error_logged_not_fatal(
+        self,
+        env_path: Path,
+        fake_env_file: tuple[Path, object],
+        monkeypatch: pytest.MonkeyPatch,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        """A chown that raises PermissionError must not fail the handler.
+
+        Best-effort semantics: the new file is already in place after
+        ``os.rename`` — losing the chown step is a degraded state, not a
+        corrupt one. Spec says log a warning and return success.
+        """
+        _, seed = fake_env_file
+        seed("PG_PASSWORD=old\n")  # type: ignore[operator]
+
+        def raising_chown(path: str, uid: int, gid: int) -> None:
+            raise PermissionError("operation not permitted")
+
+        monkeypatch.setattr(secrets_mod.os, "chown", raising_chown)
+        caplog.set_level("WARNING", logger="rots.commands.sidecar.handlers.secrets")
+
+        result = handle_secrets_deliver({"name": "PG_PASSWORD", "value": "new"})
+
+        # Handler still succeeds — rename already landed.
+        assert result.success is True, result.error
+        assert result.data["changed"] is True
+        # File content actually updated.
+        assert "new" in env_path.read_text()
+
+        # A WARNING-level record from the secrets logger was emitted.
+        warnings = [
+            r
+            for r in caplog.records
+            if r.name == "rots.commands.sidecar.handlers.secrets" and r.levelname == "WARNING"
+        ]
+        assert warnings, f"Expected a WARNING log, got: {caplog.records}"

--- a/tests/commands/sidecar/handlers/test_secrets.py
+++ b/tests/commands/sidecar/handlers/test_secrets.py
@@ -1,0 +1,339 @@
+# tests/commands/sidecar/handlers/test_secrets.py
+
+"""Tests for the ``secrets.deliver`` handler.
+
+This file is the worked-example test suite downstream impl+test agents copy
+when writing postgres/valkey/backup tests. Notice:
+
+* Filesystem-touching tests use ``tmp_path``, **not** real paths, per
+  ``docs/testing.md``.
+* The allowlist constant is patched so the handler treats the tmp env file
+  as the canonical target.
+* Both direct-call and via-dispatch paths are exercised.
+* The ``in_process_bus`` fixture shows how a cross-host RPC is modelled —
+  a test publishes ``secrets.deliver`` at ``web-host`` and the real
+  handler runs against tmp_path.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+import rots.commands.sidecar.handlers.secrets as secrets_mod
+from rots.commands.sidecar.handlers.secrets import (
+    ALLOWED_NAMES,
+    handle_secrets_deliver,
+)
+
+pytestmark = pytest.mark.quick
+
+
+# --- fixtures -------------------------------------------------------------
+
+
+@pytest.fixture
+def env_path(
+    fake_env_file: tuple[Path, object],
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """Point the allowlist at a tmp env file and return its path."""
+    path, _seed = fake_env_file
+    monkeypatch.setattr(secrets_mod, "ALLOWED_ENV_FILE", str(path))
+    return path
+
+
+# --- allowlist ------------------------------------------------------------
+
+
+class TestAllowlist:
+    """Allowlist gates must reject anything off-list before filesystem work."""
+
+    def test_missing_name(self, env_path: Path):
+        result = handle_secrets_deliver({"value": "v"})
+        assert result.success is False
+        assert "name" in (result.error or "")
+        assert not env_path.exists()
+
+    def test_empty_name(self, env_path: Path):
+        result = handle_secrets_deliver({"name": "", "value": "v"})
+        assert result.success is False
+        assert not env_path.exists()
+
+    def test_non_string_name(self, env_path: Path):
+        result = handle_secrets_deliver({"name": 42, "value": "v"})
+        assert result.success is False
+        assert not env_path.exists()
+
+    def test_rejects_unknown_name(self, env_path: Path):
+        result = handle_secrets_deliver({"name": "ARBITRARY_KEY", "value": "v"})
+        assert result.success is False
+        assert "ARBITRARY_KEY" in (result.error or "")
+        assert not env_path.exists()
+
+    def test_missing_value(self, env_path: Path):
+        result = handle_secrets_deliver({"name": "PG_PASSWORD"})
+        assert result.success is False
+        assert "value" in (result.error or "")
+
+    def test_non_string_value(self, env_path: Path):
+        result = handle_secrets_deliver({"name": "PG_PASSWORD", "value": 1234})
+        assert result.success is False
+
+    def test_rejects_non_allowlisted_env_file(self, env_path: Path, tmp_path: Path):
+        other = tmp_path / "somewhere-else"
+        result = handle_secrets_deliver(
+            {"name": "PG_PASSWORD", "value": "v", "env_file": str(other)}
+        )
+        assert result.success is False
+        assert not other.exists()
+        assert not env_path.exists()
+
+    @pytest.mark.parametrize("name", sorted(ALLOWED_NAMES))
+    def test_accepts_allowlisted_names(self, env_path: Path, name: str):
+        result = handle_secrets_deliver({"name": name, "value": "secret"})
+        assert result.success is True, result.error
+        assert result.data["changed"] is True
+        assert result.data["written"] is True
+        body = env_path.read_text().strip()
+        # Bare or double-quoted both acceptable; value must be present.
+        assert body in {f"{name}=secret", f'{name}="secret"'}
+
+
+# --- write + mode --------------------------------------------------------
+
+
+class TestWriteBehaviour:
+    """Write path produces a file with the right content, mode, and shape."""
+
+    def test_creates_file_with_content(self, env_path: Path):
+        result = handle_secrets_deliver({"name": "PG_PASSWORD", "value": "abcdef123456"})
+        assert result.success is True
+        assert env_path.exists()
+        body = env_path.read_text()
+        # Value quoted because it contains no shell specials but uses digits;
+        # in our formatter a bare-safe value stays bare. Accept both shapes.
+        assert "PG_PASSWORD=" in body
+        assert "abcdef123456" in body
+
+    def test_file_mode_0640(self, env_path: Path):
+        handle_secrets_deliver({"name": "PG_PASSWORD", "value": "v"})
+        mode = stat.S_IMODE(os.stat(env_path).st_mode)
+        assert mode == 0o640
+
+    def test_reports_changed_true_on_create(self, env_path: Path):
+        result = handle_secrets_deliver({"name": "PG_PASSWORD", "value": "v"})
+        assert result.data == {
+            "written": True,
+            "path": str(env_path),
+            "changed": True,
+        }
+
+
+# --- idempotency ---------------------------------------------------------
+
+
+class TestIdempotency:
+    """Second call with the same value must not mutate the file."""
+
+    def test_second_call_same_value_is_noop(self, env_path: Path):
+        first = handle_secrets_deliver({"name": "PG_PASSWORD", "value": "v"})
+        assert first.data["changed"] is True
+        mtime_after_first = os.stat(env_path).st_mtime_ns
+
+        # Sleep isn't necessary — we assert mtime did not advance by
+        # checking the exact ns value after the no-op.
+        second = handle_secrets_deliver({"name": "PG_PASSWORD", "value": "v"})
+        assert second.success is True
+        assert second.data == {
+            "written": False,
+            "path": str(env_path),
+            "changed": False,
+        }
+        assert os.stat(env_path).st_mtime_ns == mtime_after_first
+
+    def test_changed_value_rewrites(self, env_path: Path):
+        handle_secrets_deliver({"name": "PG_PASSWORD", "value": "old"})
+        result = handle_secrets_deliver({"name": "PG_PASSWORD", "value": "new"})
+        assert result.data["changed"] is True
+        assert "new" in env_path.read_text()
+        assert "old" not in env_path.read_text()
+
+
+# --- preservation of unrelated keys --------------------------------------
+
+
+class TestPreservation:
+    """Other keys, comments, and ordering survive a write."""
+
+    def test_preserves_unrelated_keys_and_ordering(
+        self,
+        env_path: Path,
+        fake_env_file: tuple[Path, object],
+    ):
+        _, seed = fake_env_file
+        original = "# Header comment\nFIRST=alpha\nSECOND=beta\n\n# Section\nTHIRD=gamma\n"
+        seed(original)  # type: ignore[operator]
+
+        handle_secrets_deliver({"name": "PG_PASSWORD", "value": "vv"})
+        body = env_path.read_text()
+
+        # All original lines survive with ordering.
+        for expected in [
+            "# Header comment",
+            "FIRST=alpha",
+            "SECOND=beta",
+            "# Section",
+            "THIRD=gamma",
+        ]:
+            assert expected in body
+
+        # Appended at the end (file existed previously; PG_PASSWORD is new).
+        lines = body.splitlines()
+        assert lines[-1].startswith("PG_PASSWORD=")
+        # The original THIRD=gamma must appear earlier than the appended line.
+        assert lines.index("THIRD=gamma") < lines.index(lines[-1])
+
+    def test_in_place_replacement_preserves_position(
+        self,
+        env_path: Path,
+        fake_env_file: tuple[Path, object],
+    ):
+        _, seed = fake_env_file
+        seed("FIRST=alpha\nPG_PASSWORD=old\nLAST=omega\n")  # type: ignore[operator]
+
+        handle_secrets_deliver({"name": "PG_PASSWORD", "value": "brand_new"})
+        lines = env_path.read_text().splitlines()
+        assert lines[0] == "FIRST=alpha"
+        assert lines[1].startswith("PG_PASSWORD=")
+        assert "brand_new" in lines[1]
+        assert lines[2] == "LAST=omega"
+
+
+# --- symlink defence -----------------------------------------------------
+
+
+class TestSymlinkRejection:
+    """A symlinked target must be refused before any write."""
+
+    def test_rejects_symlink_target(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        real = tmp_path / "real"
+        real.write_text("FIRST=alpha\n")
+
+        link = tmp_path / "link"
+        os.symlink(real, link)
+
+        monkeypatch.setattr(secrets_mod, "ALLOWED_ENV_FILE", str(link))
+
+        result = handle_secrets_deliver(
+            {"name": "PG_PASSWORD", "value": "v", "env_file": str(link)}
+        )
+        assert result.success is False
+        assert "symbolic link" in (result.error or "").lower()
+
+        # Real file is untouched.
+        assert real.read_text() == "FIRST=alpha\n"
+
+
+# --- atomic write --------------------------------------------------------
+
+
+class TestAtomicity:
+    """A crashed write must not leave a corrupt env file."""
+
+    def test_os_rename_failure_leaves_original_intact(
+        self,
+        env_path: Path,
+        fake_env_file: tuple[Path, object],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        _, seed = fake_env_file
+        seed("PG_PASSWORD=old_value\n")  # type: ignore[operator]
+        original_content = env_path.read_text()
+
+        def boom(src: str, dst: str) -> None:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(os, "rename", boom)
+
+        result = handle_secrets_deliver({"name": "PG_PASSWORD", "value": "new_value"})
+        assert result.success is False
+
+        # Original file content preserved.
+        assert env_path.read_text() == original_content
+
+        # No leftover tempfile in the directory.
+        leftovers = [p.name for p in env_path.parent.iterdir() if p.name.startswith(".")]
+        assert leftovers == []
+
+
+# --- logging (redaction) -------------------------------------------------
+
+
+class TestLogging:
+    """The secret value must never appear in logs."""
+
+    def test_info_log_excludes_value(
+        self,
+        env_path: Path,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        caplog.set_level("DEBUG", logger="rots.commands.sidecar.handlers.secrets")
+
+        secret = "super-secret-do-not-log-me"
+        handle_secrets_deliver({"name": "PG_PASSWORD", "value": secret})
+
+        for record in caplog.records:
+            assert secret not in record.getMessage()
+            assert secret not in str(record.args)
+
+
+# --- dispatch integration -----------------------------------------------
+
+
+class TestDispatchIntegration:
+    """The handler is reachable through the central dispatcher by command name."""
+
+    def test_dispatch_routes_secrets_deliver(
+        self,
+        env_path: Path,
+    ):
+        from rots.sidecar.commands import _import_handlers, dispatch
+
+        _import_handlers()
+        result = dispatch(
+            "secrets.deliver",
+            {"name": "PG_PASSWORD", "value": "from-dispatch"},
+        )
+        assert result.success is True
+        assert result.data["changed"] is True
+        assert "from-dispatch" in env_path.read_text()
+
+
+# --- cross-host via in-process bus --------------------------------------
+
+
+class TestInProcessBus:
+    """A db-host publishing secrets.deliver at web-host runs the handler."""
+
+    def test_publish_via_bus_writes_to_tmp(
+        self,
+        env_path: Path,
+        in_process_bus,  # fixture from conftest
+    ):
+        result = in_process_bus.publish(
+            "web-host",
+            "secrets.deliver",
+            {"name": "VALKEY_PASSWORD", "value": "routed-through-bus"},
+            timeout=5.0,
+        )
+        assert result.success is True
+        assert result.data["changed"] is True
+        assert "routed-through-bus" in env_path.read_text()

--- a/tests/commands/sidecar/handlers/test_valkey.py
+++ b/tests/commands/sidecar/handlers/test_valkey.py
@@ -1,0 +1,721 @@
+# tests/commands/sidecar/handlers/test_valkey.py
+
+"""Tests for the ``valkey.*`` handlers.
+
+Mirrors the shape of :mod:`test_secrets`: a class per concern, real
+podman-backed valkey for state-mutating cases, :class:`InProcessRpcClient`
+for cross-host delivery.
+
+Redirecting ``valkey-cli`` at the test port
+-------------------------------------------
+
+Production invokes ``valkey-cli -h 127.0.0.1 -p 6379 ...`` against a
+valkey bound inside the db sidecar. Our session-scoped fixture publishes
+valkey on an ephemeral host port and the container image already ships
+``valkey-cli``. Tests monkeypatch :data:`rots.commands.sidecar.handlers.valkey.VALKEY_CLI`
+to ``("podman", "exec", <container>, "valkey-cli")`` so every subprocess
+call runs inside the container against the loopback valkey. No host
+``valkey-cli`` binary is required.
+
+The spec reserves :data:`ACL_FILE` at ``/etc/valkey/users.acl`` for the
+impl to read the bootstrap token out of. In the alpine image that path
+does not exist, so we pre-seed a stub under ``tmp_path`` and monkeypatch
+:data:`valkey.ACL_FILE` to point at it. The stub is written in the
+standard ``user <name> on ><token> ...`` format so a line-based parser
+can find a token even if it tries. When the tests talk to a no-auth
+valkey the ``-a <token>`` argument (if the impl adds one) is ignored.
+
+``aclfile`` must be pre-configured on the server
+------------------------------------------------
+
+The spec requires impl to call ``ACL SAVE`` / ``ACL LOAD``. Valkey 8.x
+treats ``aclfile`` as immutable at runtime — ``CONFIG SET aclfile ...``
+returns ``ERR CONFIG SET failed (redis-server might be configured to
+refuse CONFIG SET for aclfile)``. The ``valkey_service`` session fixture
+in :mod:`conftest` therefore starts the container with
+``--aclfile /data/users.acl`` directly; tests neither need nor run a
+``CONFIG SET aclfile`` step.
+
+Auth handshake caveat
+---------------------
+
+If impl appends ``-a <token>`` to :data:`VALKEY_CLI`, the test container
+currently has no ``requirepass`` and no user password, so ``valkey-cli``
+may print ``WARNING: AUTH failed`` and still run the command (version-
+dependent). If impl tests start failing with spurious AUTH errors, the
+fix is to pass ``--requirepass`` on the ``valkey-server`` startup line
+in the ``valkey_service`` conftest fixture and update
+:func:`stub_acl_file` accordingly.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from collections.abc import Callable, Iterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import rots.commands.sidecar.handlers.secrets as secrets_mod
+import rots.commands.sidecar.handlers.valkey as valkey_mod
+from rots.commands.sidecar.handlers._transport import InProcessRpcClient
+from rots.commands.sidecar.handlers.valkey import (
+    handle_create_acl_user,
+    handle_reload_acl,
+)
+from rots.sidecar.commands import CommandResult
+
+pytestmark = [pytest.mark.integration, pytest.mark.slow]
+
+
+# --- helpers --------------------------------------------------------------
+
+
+def _run_cli(
+    cli: tuple[str, ...], *args: str, check: bool = True
+) -> subprocess.CompletedProcess[str]:
+    """Invoke the redirected ``valkey-cli`` tuple and return CompletedProcess."""
+    return subprocess.run(
+        [*cli, *args],
+        check=check,
+        capture_output=True,
+        text=True,
+    )
+
+
+def _acl_list(cli: tuple[str, ...]) -> list[str]:
+    """Return ``ACL LIST`` output as a list of lines."""
+    cp = _run_cli(cli, "ACL", "LIST")
+    return [line for line in cp.stdout.splitlines() if line.strip()]
+
+
+def _user_exists(cli: tuple[str, ...], name: str) -> bool:
+    """True if ``ACL GETUSER <name>`` has output (Valkey returns empty on miss)."""
+    cp = _run_cli(cli, "ACL", "GETUSER", name, check=False)
+    return cp.returncode == 0 and bool(cp.stdout.strip())
+
+
+def _acl_deluser(cli: tuple[str, ...], name: str) -> None:
+    """Best-effort delete — swallow errors so teardown never masks a real failure."""
+    _run_cli(cli, "ACL", "DELUSER", name, check=False)
+
+
+# --- fixtures -------------------------------------------------------------
+
+
+@pytest.fixture
+def valkey_cli(valkey_service: dict[str, Any]) -> tuple[str, ...]:
+    """``valkey-cli`` invocation targeting the test container via ``podman exec``.
+
+    The spec says the real handler calls ``valkey-cli -h 127.0.0.1 -p 6379``
+    against the sidecar's local valkey. In tests we route through
+    ``podman exec`` because:
+
+    * the image ships ``valkey-cli`` (host machine may not)
+    * inside the container, loopback + default port is already correct
+    * avoids any host firewall/port weirdness
+    """
+    if shutil.which("podman") is None:
+        pytest.skip("podman not available on PATH")
+    return ("podman", "exec", valkey_service["container"], "valkey-cli")
+
+
+# The aclfile path inside the valkey container. ``/data`` is the default
+# working dir for ``valkey:8-alpine`` and is writable by the valkey user.
+# Kept in sync with the ``--aclfile`` startup flag in the ``valkey_service``
+# conftest fixture.
+_CONTAINER_ACL_FILE = "/data/users.acl"
+
+
+@pytest.fixture
+def patched_valkey_cli(
+    valkey_cli: tuple[str, ...],
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[str, ...]:
+    """Monkeypatch :data:`valkey.VALKEY_CLI` to the test-container invocation."""
+    monkeypatch.setattr(valkey_mod, "VALKEY_CLI", valkey_cli)
+    return valkey_cli
+
+
+@pytest.fixture
+def stub_acl_file(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Seed a fake ACL file under tmp and point :data:`valkey.ACL_FILE` at it.
+
+    Required for impls that open :data:`ACL_FILE` per-call to pull the
+    bootstrap user/token. The real file lives at ``/etc/valkey/users.acl``
+    (root-owned, won't exist on dev machines). The stub format matches
+    what ``ACL LIST`` writes and what ``ACL LOAD`` expects — useful for
+    the reload-acl tests too.
+    """
+    acl_file = tmp_path / "users.acl"
+    acl_file.write_text(
+        # valkey's on-disk ACL format: one user per line.
+        "user ots-bootstrap on >bootstraptok ~* &* +@all\nuser default on nopass ~* &* +@all\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(valkey_mod, "ACL_FILE", str(acl_file))
+    return acl_file
+
+
+@pytest.fixture
+def env_path(
+    fake_env_file: tuple[Path, Callable[[str], Path]],
+    monkeypatch: pytest.MonkeyPatch,
+) -> Path:
+    """Redirect :data:`secrets.ALLOWED_ENV_FILE` at a tmp path and return it.
+
+    Needed because ``secrets.deliver`` is the handler the bus dispatches
+    to; its allowlist defaults to ``/etc/default/onetimesecret``.
+    """
+    path, _seed = fake_env_file
+    monkeypatch.setattr(secrets_mod, "ALLOWED_ENV_FILE", str(path))
+    return path
+
+
+@pytest.fixture
+def bus_routing(
+    in_process_bus: InProcessRpcClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> InProcessRpcClient:
+    """Wire :func:`valkey._get_rpc_client` to return the in-process bus."""
+    monkeypatch.setattr(valkey_mod, "_get_rpc_client", lambda: in_process_bus)
+    return in_process_bus
+
+
+@pytest.fixture
+def cleanup_acl(
+    patched_valkey_cli: tuple[str, ...],
+    valkey_acl_prefix: str,
+) -> Iterator[Callable[[str], None]]:
+    """Return a teardown-registering deleter for ACL usernames.
+
+    Usage inside a test::
+
+        cleanup_acl(f"{valkey_acl_prefix}_app")
+        # later assertions ...
+
+    Names collected here are deleted in the fixture finalizer. The
+    session-scoped valkey service means we cannot rely on restart to
+    drop state.
+    """
+    created: list[str] = []
+
+    def register(name: str) -> None:
+        created.append(name)
+
+    yield register
+
+    for name in created:
+        _acl_deluser(patched_valkey_cli, name)
+
+
+# --- handle_create_acl_user: happy path ----------------------------------
+
+
+class TestCreateAclUserHappyPath:
+    """First-time creation flows state + token through the bus."""
+
+    def test_creates_user_delivers_token_returns_changed_true(
+        self,
+        patched_valkey_cli: tuple[str, ...],
+        stub_acl_file: Path,
+        bus_routing: InProcessRpcClient,
+        env_path: Path,
+        valkey_acl_prefix: str,
+        cleanup_acl: Callable[[str], None],
+    ):
+        name = f"{valkey_acl_prefix}_app"
+        cleanup_acl(name)
+
+        result = handle_create_acl_user(
+            {
+                "name": name,
+                "rules": ["on", "~*", "+@read"],
+                "peer_id": "web-host",
+            }
+        )
+        assert result.success is True, result.error
+        assert result.data["changed"] is True
+        assert result.data["delivered_to"] == "web-host"
+
+        # Valkey knows about the user.
+        assert _user_exists(patched_valkey_cli, name)
+
+        # secrets.deliver landed in the env file.
+        body = env_path.read_text()
+        assert "VALKEY_PASSWORD=" in body
+
+    def test_env_file_contains_token_value_not_empty(
+        self,
+        patched_valkey_cli: tuple[str, ...],
+        stub_acl_file: Path,
+        bus_routing: InProcessRpcClient,
+        env_path: Path,
+        valkey_acl_prefix: str,
+        cleanup_acl: Callable[[str], None],
+    ):
+        name = f"{valkey_acl_prefix}_app"
+        cleanup_acl(name)
+        handle_create_acl_user(
+            {"name": name, "rules": ["on", "~*", "+@read"], "peer_id": "web-host"}
+        )
+        # spec: secrets.token_urlsafe(40) -> >50 chars url-safe
+        body = env_path.read_text()
+        for line in body.splitlines():
+            if line.startswith("VALKEY_PASSWORD="):
+                value = line.split("=", 1)[1].strip().strip('"')
+                assert len(value) >= 40
+                break
+        else:
+            pytest.fail("VALKEY_PASSWORD not written to env file")
+
+
+# --- handle_create_acl_user: idempotency ---------------------------------
+
+
+class TestCreateAclUserIdempotency:
+    """Second call with identical rules is a no-op; env + deliveries unchanged."""
+
+    def test_same_rules_reports_unchanged_and_skips_delivery(
+        self,
+        patched_valkey_cli: tuple[str, ...],
+        stub_acl_file: Path,
+        in_process_bus: InProcessRpcClient,
+        env_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        valkey_acl_prefix: str,
+        cleanup_acl: Callable[[str], None],
+    ):
+        from rots.sidecar.commands import dispatch
+
+        # Wrap web-host dispatch to count secrets.deliver invocations.
+        deliver_calls: list[dict[str, Any]] = []
+
+        def counting_dispatch(command: str, params: dict[str, Any]) -> CommandResult:
+            if command == "secrets.deliver":
+                deliver_calls.append(params)
+            return dispatch(command, params)
+
+        in_process_bus.register("web-host", counting_dispatch)
+        monkeypatch.setattr(valkey_mod, "_get_rpc_client", lambda: in_process_bus)
+
+        name = f"{valkey_acl_prefix}_app"
+        cleanup_acl(name)
+        params = {
+            "name": name,
+            "rules": ["on", "~*", "+@read"],
+            "peer_id": "web-host",
+        }
+
+        first = handle_create_acl_user(params)
+        assert first.success is True
+        assert first.data["changed"] is True
+        assert len(deliver_calls) == 1
+        env_after_first = env_path.read_text()
+        mtime_after_first = env_path.stat().st_mtime_ns
+
+        second = handle_create_acl_user(params)
+        assert second.success is True
+        # spec: return early with changed=False and delivered_to=peer_id as echo
+        assert second.data["changed"] is False
+        assert second.data["delivered_to"] == "web-host"
+        # No new token minted / delivered.
+        assert len(deliver_calls) == 1
+        # Env file content and mtime unchanged.
+        assert env_path.read_text() == env_after_first
+        assert env_path.stat().st_mtime_ns == mtime_after_first
+
+
+# --- handle_create_acl_user: rule-set updates ----------------------------
+
+
+class TestCreateAclUserRuleUpdate:
+    """Changed rules rotate the token and deliver the new value."""
+
+    def test_rules_change_triggers_new_token(
+        self,
+        patched_valkey_cli: tuple[str, ...],
+        stub_acl_file: Path,
+        in_process_bus: InProcessRpcClient,
+        env_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        valkey_acl_prefix: str,
+        cleanup_acl: Callable[[str], None],
+    ):
+        from rots.sidecar.commands import dispatch
+
+        deliver_calls: list[dict[str, Any]] = []
+
+        def counting_dispatch(command: str, params: dict[str, Any]) -> CommandResult:
+            if command == "secrets.deliver":
+                deliver_calls.append(params)
+            return dispatch(command, params)
+
+        in_process_bus.register("web-host", counting_dispatch)
+        monkeypatch.setattr(valkey_mod, "_get_rpc_client", lambda: in_process_bus)
+
+        name = f"{valkey_acl_prefix}_app"
+        cleanup_acl(name)
+
+        first = handle_create_acl_user(
+            {"name": name, "rules": ["on", "~*", "+@read"], "peer_id": "web-host"}
+        )
+        assert first.data["changed"] is True
+        token_a = deliver_calls[0]["value"]
+
+        second = handle_create_acl_user(
+            {"name": name, "rules": ["on", "~*", "+@read", "+@write"], "peer_id": "web-host"}
+        )
+        assert second.success is True
+        assert second.data["changed"] is True
+        assert len(deliver_calls) == 2
+        token_b = deliver_calls[1]["value"]
+        assert token_a != token_b
+        # Env file now carries the new token.
+        assert token_b in env_path.read_text()
+
+
+# --- handle_create_acl_user: rule-order sensitivity ----------------------
+
+
+class TestCreateAclUserRuleOrder:
+    """Spec: impl MUST NOT sort/dedupe — different order is a different rule set."""
+
+    def test_reordered_rules_treated_as_different(
+        self,
+        patched_valkey_cli: tuple[str, ...],
+        stub_acl_file: Path,
+        in_process_bus: InProcessRpcClient,
+        env_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        valkey_acl_prefix: str,
+        cleanup_acl: Callable[[str], None],
+    ):
+        from rots.sidecar.commands import dispatch
+
+        deliver_calls: list[dict[str, Any]] = []
+
+        def counting_dispatch(command: str, params: dict[str, Any]) -> CommandResult:
+            if command == "secrets.deliver":
+                deliver_calls.append(params)
+            return dispatch(command, params)
+
+        in_process_bus.register("web-host", counting_dispatch)
+        monkeypatch.setattr(valkey_mod, "_get_rpc_client", lambda: in_process_bus)
+
+        name = f"{valkey_acl_prefix}_app"
+        cleanup_acl(name)
+
+        first = handle_create_acl_user(
+            {"name": name, "rules": ["on", "~*", "+get", "-@admin"], "peer_id": "web-host"}
+        )
+        assert first.data["changed"] is True
+
+        # Same rule tokens, different order => must be detected as a change.
+        second = handle_create_acl_user(
+            {"name": name, "rules": ["on", "~*", "-@admin", "+get"], "peer_id": "web-host"}
+        )
+        assert second.success is True
+        assert second.data["changed"] is True
+        assert len(deliver_calls) == 2
+
+
+# --- handle_create_acl_user: validation ---------------------------------
+
+
+class TestCreateAclUserNameValidation:
+    """Bad names are rejected before any valkey-cli call is issued."""
+
+    @pytest.mark.parametrize(
+        "bad_name",
+        [
+            "default",  # reserved by valkey
+            "",  # empty
+            "^bad",  # leading punctuation — violates ^[A-Za-z_]
+            "has space",  # whitespace inside
+            " leading",
+            "trailing ",
+            "1starts_with_digit",
+        ],
+    )
+    def test_rejects_invalid_name(
+        self,
+        patched_valkey_cli: tuple[str, ...],
+        stub_acl_file: Path,
+        bus_routing: InProcessRpcClient,
+        env_path: Path,
+        bad_name: str,
+    ):
+        pre_users = set(_acl_list(patched_valkey_cli))
+
+        result = handle_create_acl_user(
+            {
+                "name": bad_name,
+                "rules": ["on", "~*", "+@read"],
+                "peer_id": "web-host",
+            }
+        )
+        assert result.success is False
+        # No state mutation.
+        post_users = set(_acl_list(patched_valkey_cli))
+        assert pre_users == post_users
+        # No secret delivered.
+        assert not env_path.exists() or "VALKEY_PASSWORD" not in env_path.read_text()
+
+
+class TestCreateAclUserRuleValidation:
+    """Bad rules are rejected before any valkey-cli call is issued."""
+
+    @pytest.mark.parametrize(
+        "bad_rules",
+        [
+            [""],  # empty rule
+            ["+@read", ""],  # mixed-in empty rule
+            ["+has space"],  # whitespace inside a single rule
+            ["on ~*"],  # two tokens smooshed into one string
+            "not-a-list",  # not a list at all (string)
+        ],
+    )
+    def test_rejects_invalid_rules(
+        self,
+        patched_valkey_cli: tuple[str, ...],
+        stub_acl_file: Path,
+        bus_routing: InProcessRpcClient,
+        env_path: Path,
+        valkey_acl_prefix: str,
+        bad_rules: Any,
+    ):
+        name = f"{valkey_acl_prefix}_app"
+        result = handle_create_acl_user({"name": name, "rules": bad_rules, "peer_id": "web-host"})
+        assert result.success is False
+        assert not _user_exists(patched_valkey_cli, name)
+        assert not env_path.exists() or "VALKEY_PASSWORD" not in env_path.read_text()
+
+
+# --- handle_create_acl_user: delivery failure / rollback ----------------
+
+
+class TestCreateAclUserDeliveryFailure:
+    """A failed secrets.deliver must roll back the ACL user."""
+
+    def test_failing_dispatcher_triggers_rollback(
+        self,
+        patched_valkey_cli: tuple[str, ...],
+        stub_acl_file: Path,
+        in_process_bus: InProcessRpcClient,
+        env_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+        valkey_acl_prefix: str,
+        cleanup_acl: Callable[[str], None],
+    ):
+        def failing_dispatch(command: str, params: dict[str, Any]) -> CommandResult:
+            return CommandResult.fail("simulated delivery failure")
+
+        in_process_bus.register("web-host", failing_dispatch)
+        monkeypatch.setattr(valkey_mod, "_get_rpc_client", lambda: in_process_bus)
+
+        name = f"{valkey_acl_prefix}_app"
+        cleanup_acl(name)  # safety net
+
+        result = handle_create_acl_user(
+            {"name": name, "rules": ["on", "~*", "+@read"], "peer_id": "web-host"}
+        )
+        assert result.success is False
+        # Rollback via ACL DELUSER must have removed the user.
+        assert not _user_exists(patched_valkey_cli, name)
+
+    def test_timeout_triggers_rollback(
+        self,
+        patched_valkey_cli: tuple[str, ...],
+        stub_acl_file: Path,
+        in_process_bus: InProcessRpcClient,
+        monkeypatch: pytest.MonkeyPatch,
+        valkey_acl_prefix: str,
+        cleanup_acl: Callable[[str], None],
+    ):
+        """Spec: TimeoutError from RpcClient -> ACL DELUSER rollback + fail."""
+
+        def timeout_dispatch(command: str, params: dict[str, Any]) -> CommandResult:
+            raise TimeoutError("simulated rpc timeout")
+
+        in_process_bus.register("web-host", timeout_dispatch)
+        monkeypatch.setattr(valkey_mod, "_get_rpc_client", lambda: in_process_bus)
+
+        name = f"{valkey_acl_prefix}_app"
+        cleanup_acl(name)
+
+        result = handle_create_acl_user(
+            {"name": name, "rules": ["on", "~*", "+@read"], "peer_id": "web-host"}
+        )
+        assert result.success is False
+        assert not _user_exists(patched_valkey_cli, name)
+
+
+# --- handle_create_acl_user: ACL SAVE failure ---------------------------
+
+
+class TestCreateAclUserAclSaveFailure:
+    """Best-effort coverage: flagged as skip per task guidance."""
+
+    @pytest.mark.skip(
+        reason=(
+            "Coaxing ACL SAVE into failing requires a read-only ACL mount or "
+            "valkey config tweak the podman fixture does not expose. Task "
+            "explicitly permits skipping this case; see spec."
+        )
+    )
+    def test_acl_save_failure_surfaces(self):
+        pass
+
+
+# --- handle_reload_acl ---------------------------------------------------
+
+
+class TestReloadAclHappyPath:
+    """External edit of the ACL file flips changed=True on the next reload."""
+
+    def test_reload_after_external_edit(
+        self,
+        valkey_service: dict[str, Any],
+        patched_valkey_cli: tuple[str, ...],
+        valkey_acl_prefix: str,
+        cleanup_acl: Callable[[str], None],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        # aclfile is already configured at container startup (see the
+        # ``valkey_service`` fixture). Point the handler's ACL_FILE
+        # constant at the container-side path.
+        monkeypatch.setattr(valkey_mod, "ACL_FILE", _CONTAINER_ACL_FILE)
+
+        # Externally append a new user by writing directly into the
+        # container-side ACL file.
+        name = f"{valkey_acl_prefix}_ext"
+        cleanup_acl(name)
+        subprocess.run(
+            [
+                "podman",
+                "exec",
+                valkey_service["container"],
+                "sh",
+                "-c",
+                f"echo 'user {name} on nopass ~* &* +@read' >> {_CONTAINER_ACL_FILE}",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        # Pre-condition: user not yet visible in the in-memory ACL.
+        assert not _user_exists(patched_valkey_cli, name)
+
+        result = handle_reload_acl({})
+        assert result.success is True, result.error
+        assert result.data["ok"] is True
+        assert result.data["changed"] is True
+        assert _user_exists(patched_valkey_cli, name)
+
+
+class TestReloadAclIdempotency:
+    """Second reload without external edits reports changed=False."""
+
+    def test_repeated_reload_noop(
+        self,
+        patched_valkey_cli: tuple[str, ...],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(valkey_mod, "ACL_FILE", _CONTAINER_ACL_FILE)
+
+        first = handle_reload_acl({})
+        assert first.success is True
+        # First call may or may not flip changed — depends on whether the
+        # current memory already matches the on-disk file. Exercise a
+        # *second* call immediately and assert it is observably a no-op.
+        second = handle_reload_acl({})
+        assert second.success is True
+        assert second.data["ok"] is True
+        assert second.data["changed"] is False
+
+
+class TestReloadAclInvalidFile:
+    """Malformed ACL file must surface valkey's ERR text verbatim."""
+
+    def test_bad_syntax_returns_fail_with_error(
+        self,
+        valkey_service: dict[str, Any],
+        patched_valkey_cli: tuple[str, ...],
+        monkeypatch: pytest.MonkeyPatch,
+    ):
+        monkeypatch.setattr(valkey_mod, "ACL_FILE", _CONTAINER_ACL_FILE)
+
+        # Overwrite with nonsense that fails ACL LOAD parsing. Snapshot
+        # the existing valid file first so we can restore it at teardown
+        # (the session-scoped valkey service shares state across tests).
+        snapshot = subprocess.run(
+            ["podman", "exec", valkey_service["container"], "cat", _CONTAINER_ACL_FILE],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout
+        subprocess.run(
+            [
+                "podman",
+                "exec",
+                valkey_service["container"],
+                "sh",
+                "-c",
+                f"echo 'this is not a valid acl line at all' > {_CONTAINER_ACL_FILE}",
+            ],
+            check=True,
+            capture_output=True,
+        )
+
+        try:
+            result = handle_reload_acl({})
+            assert result.success is False
+            # Spec: "The error text from valkey is surfaced directly." Valkey
+            # prefixes its ACL parse errors with "ERR".
+            assert result.error is not None
+            assert "ERR" in result.error or "problem" in result.error.lower()
+        finally:
+            # Restore the good ACL file so subsequent tests in the
+            # session see a valid on-disk state.
+            subprocess.run(
+                [
+                    "podman",
+                    "exec",
+                    "-i",
+                    valkey_service["container"],
+                    "sh",
+                    "-c",
+                    f"cat > {_CONTAINER_ACL_FILE}",
+                ],
+                input=snapshot,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+
+class TestReloadAclIgnoresParams:
+    """Spec: the handler ignores any params supplied."""
+
+    @pytest.mark.parametrize(
+        "params",
+        [
+            {},
+            {"irrelevant": 1},
+            {"name": "default", "rules": ["on"], "peer_id": "nobody"},
+        ],
+    )
+    def test_params_are_ignored(
+        self,
+        patched_valkey_cli: tuple[str, ...],
+        monkeypatch: pytest.MonkeyPatch,
+        params: dict[str, Any],
+    ):
+        monkeypatch.setattr(valkey_mod, "ACL_FILE", _CONTAINER_ACL_FILE)
+
+        result = handle_reload_acl(params)
+        assert result.success is True
+        assert result.data["ok"] is True

--- a/tests/commands/sidecar/handlers/test_valkey_auth.py
+++ b/tests/commands/sidecar/handlers/test_valkey_auth.py
@@ -1,0 +1,146 @@
+# tests/commands/sidecar/handlers/test_valkey_auth.py
+
+"""Unit tests for valkey bootstrap-auth wiring.
+
+The auth path is tested separately from the main :mod:`test_valkey` suite
+because it does not need a running valkey — only the credstore-reading
+seam and the subprocess invocation shape. Keeping these tests out of the
+podman-backed fixture lets them run in every environment, quickly.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+import rots.commands.sidecar.handlers.valkey as valkey_mod
+from rots.commands.sidecar.handlers.valkey import (
+    _BOOTSTRAP_USER,
+    _CREDENTIAL_NAME,
+    VALKEY_CLI,
+    _load_bootstrap_auth,
+    _run_valkey_cli,
+)
+
+
+class TestLoadBootstrapAuth:
+    """Direct coverage of the credstore reader."""
+
+    def test_returns_none_when_credentials_directory_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CREDENTIALS_DIRECTORY", raising=False)
+        assert _load_bootstrap_auth() is None
+
+    def test_returns_none_when_credentials_directory_empty_string(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CREDENTIALS_DIRECTORY", "")
+        assert _load_bootstrap_auth() is None
+
+    def test_returns_none_when_credential_file_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("CREDENTIALS_DIRECTORY", str(tmp_path))
+        # tmp_path exists but does not contain the credential file.
+        assert _load_bootstrap_auth() is None
+
+    def test_returns_none_when_credential_file_empty(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / _CREDENTIAL_NAME).write_text("", encoding="utf-8")
+        monkeypatch.setenv("CREDENTIALS_DIRECTORY", str(tmp_path))
+        assert _load_bootstrap_auth() is None
+
+    def test_returns_none_when_credential_file_only_whitespace(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / _CREDENTIAL_NAME).write_text("   \n\t\n", encoding="utf-8")
+        monkeypatch.setenv("CREDENTIALS_DIRECTORY", str(tmp_path))
+        assert _load_bootstrap_auth() is None
+
+    def test_returns_user_and_token_when_credential_file_present(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / _CREDENTIAL_NAME).write_text("s3cret-tok\n", encoding="utf-8")
+        monkeypatch.setenv("CREDENTIALS_DIRECTORY", str(tmp_path))
+        assert _load_bootstrap_auth() == (_BOOTSTRAP_USER, "s3cret-tok")
+
+    def test_strips_surrounding_whitespace_from_token(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        (tmp_path / _CREDENTIAL_NAME).write_text("  tok-with-pad  \n", encoding="utf-8")
+        monkeypatch.setenv("CREDENTIALS_DIRECTORY", str(tmp_path))
+        assert _load_bootstrap_auth() == (_BOOTSTRAP_USER, "tok-with-pad")
+
+    def test_never_reads_acl_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ACL_FILE is valkey-server's input, not this handler's — guard against regression."""
+        monkeypatch.delenv("CREDENTIALS_DIRECTORY", raising=False)
+        # Seed ACL_FILE with a plausible-looking bootstrap entry. If the
+        # implementation ever falls back to parsing it, this test flips.
+        fake_acl = tmp_path / "users.acl"
+        fake_acl.write_text("user bootstrap on >should-not-be-read ~*\n", encoding="utf-8")
+        monkeypatch.setattr(valkey_mod, "ACL_FILE", str(fake_acl))
+        assert _load_bootstrap_auth() is None
+
+
+class TestRunValkeyCliAuth:
+    """Coverage of argv/env shape produced by ``_run_valkey_cli``."""
+
+    @pytest.fixture
+    def capture_run(self, monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+        """Monkeypatch subprocess.run to capture args/kwargs and return a fake result."""
+        captured: dict[str, Any] = {}
+
+        def _fake_run(args: list[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
+            captured["args"] = args
+            captured["kwargs"] = kwargs
+            return subprocess.CompletedProcess(args=args, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(valkey_mod.subprocess, "run", _fake_run)
+        return captured
+
+    def test_unauthenticated_when_credstore_absent(
+        self, capture_run: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CREDENTIALS_DIRECTORY", raising=False)
+        _run_valkey_cli("PING")
+        assert tuple(capture_run["args"]) == (*VALKEY_CLI, "PING")
+        assert capture_run["kwargs"]["env"] is None
+
+    def test_adds_user_argv_and_redis_auth_env_when_credstore_present(
+        self,
+        capture_run: dict[str, Any],
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        (tmp_path / _CREDENTIAL_NAME).write_text("tok-42\n", encoding="utf-8")
+        monkeypatch.setenv("CREDENTIALS_DIRECTORY", str(tmp_path))
+
+        _run_valkey_cli("PING")
+
+        args = list(capture_run["args"])
+        kwargs = capture_run["kwargs"]
+        # --user bootstrap appears, followed by the command tail.
+        assert "--user" in args
+        assert args[args.index("--user") + 1] == _BOOTSTRAP_USER
+        assert args[-1] == "PING"
+        # Token is in env, not argv. This is the whole point of using
+        # REDISCLI_AUTH over -a: keep it out of /proc/<pid>/cmdline.
+        assert "tok-42" not in args
+        assert kwargs["env"] is not None
+        assert kwargs["env"].get("REDISCLI_AUTH") == "tok-42"
+
+    def test_subprocess_kwargs_preserve_check_capture_timeout(
+        self, capture_run: dict[str, Any], monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("CREDENTIALS_DIRECTORY", raising=False)
+        _run_valkey_cli("PING")
+        kwargs = capture_run["kwargs"]
+        assert kwargs["check"] is True
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert isinstance(kwargs["timeout"], int)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,15 @@ behavior should override with their own mocker.patch().
 
 import pytest
 
+# Re-export handler fixtures (postgres_service, valkey_service,
+# in_process_bus, fake_env_file, postgres_db, valkey_acl_prefix) so sibling
+# test directories (notably ``tests/commands/env``) can consume them without
+# duplicating fixture code. Pytest 9 makes ``pytest_plugins`` outside the
+# rootdir conftest a hard error, so the declaration lives here. Fixtures
+# are lazy — the podman-backed ones only start containers when a test
+# requests them.
+pytest_plugins = ["tests.commands.sidecar.handlers._fixtures"]
+
 
 @pytest.fixture(autouse=True)
 def _mock_secret_exists(mocker):

--- a/tests/test_infra_marker.py
+++ b/tests/test_infra_marker.py
@@ -1,0 +1,188 @@
+# tests/test_infra_marker.py
+
+"""Tests for ``rots.infra_marker`` — ``.otsinfra.yaml`` parsing + validation.
+
+The bootstrap command (`rots env bootstrap`) consumes ``envs.<env>`` out of
+the marker file. These tests focus on the parsing seams — especially the
+``web.ip`` field which must be a real IP address (v4 or v6) with no CR/LF
+injection, because that value flows directly into ``pg_hba.conf``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from rots.infra_marker import (
+    InfraMarkerError,
+    load_env_config_from_file,
+)
+
+pytestmark = pytest.mark.quick
+
+
+# --- helpers -------------------------------------------------------------
+
+
+def _write_marker(
+    path: Path,
+    *,
+    env: str = "eu-demo",
+    db_host_id: str = "eu-demo-db",
+    web_host_id: str = "eu-demo-web",
+    web_ip: str = "10.0.0.5",
+    app_name: str = "onetimesecret",
+    app_owner: str = "onetimesecret",
+    valkey_rules: tuple[str, ...] = ("+@read", "+@write"),
+) -> Path:
+    """Write a minimal valid ``.otsinfra.yaml`` to *path* and return it.
+
+    Uses hand-built YAML (no yaml dump) so IP strings carrying ``\\n`` and
+    other adversarial payloads round-trip intact. The ``web.ip`` value is
+    emitted as a double-quoted scalar so embedded newlines are preserved
+    by PyYAML's parser.
+    """
+    # Escape the value for a YAML double-quoted scalar. PyYAML's own emitter
+    # would quote/escape differently; we do it by hand so a test can inject
+    # exactly the bytes it wants.
+    escaped_ip = web_ip.replace("\\", "\\\\").replace('"', '\\"').replace("\n", "\\n")
+    rules_block = "\n".join(f'      - "{r}"' for r in valkey_rules)
+    text = (
+        "envs:\n"
+        f"  {env}:\n"
+        "    db:\n"
+        f"      host_id: {db_host_id}\n"
+        "    web:\n"
+        f"      host_id: {web_host_id}\n"
+        f'      ip: "{escaped_ip}"\n'
+        "    app:\n"
+        f"      name: {app_name}\n"
+        f"      owner_role: {app_owner}\n"
+        "    valkey:\n"
+        "      rules:\n"
+        f"{rules_block}\n"
+    )
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+# --- happy path ----------------------------------------------------------
+
+
+class TestWebIpValid:
+    """Valid IPv4 / IPv6 strings load without error."""
+
+    def test_ipv4_loads(self, tmp_path: Path):
+        marker = _write_marker(tmp_path / ".otsinfra.yaml", web_ip="10.0.0.5")
+        cfg = load_env_config_from_file("eu-demo", marker)
+        assert cfg.web.ip == "10.0.0.5"
+
+    def test_ipv6_loads(self, tmp_path: Path):
+        marker = _write_marker(tmp_path / ".otsinfra.yaml", web_ip="2001:db8::1")
+        cfg = load_env_config_from_file("eu-demo", marker)
+        assert cfg.web.ip == "2001:db8::1"
+
+    def test_ipv4_loopback_loads(self, tmp_path: Path):
+        # Loopback is a legal IPv4 address; accepted. Policy (rejecting
+        # loopback as a web peer) is a caller concern, not parser concern.
+        marker = _write_marker(tmp_path / ".otsinfra.yaml", web_ip="127.0.0.1")
+        cfg = load_env_config_from_file("eu-demo", marker)
+        assert cfg.web.ip == "127.0.0.1"
+
+
+# --- rejection: newline injection ---------------------------------------
+
+
+class TestWebIpNewlineInjection:
+    """CR/LF in ``web.ip`` is refused — the value flows into pg_hba.conf.
+
+    A newline here would let the caller append arbitrary pg_hba rules
+    (e.g. a blanket ``host all all 0.0.0.0/0 trust``). The validator
+    rejects before ``ipaddress.ip_address()`` even runs.
+    """
+
+    def test_lf_injection_rejected(self, tmp_path: Path):
+        marker = _write_marker(
+            tmp_path / ".otsinfra.yaml",
+            web_ip="10.0.0.5\nhost all all 0.0.0.0/0 trust",
+        )
+        with pytest.raises(InfraMarkerError) as excinfo:
+            load_env_config_from_file("eu-demo", marker)
+        assert "web.ip" in str(excinfo.value)
+
+    def test_cr_injection_rejected(self, tmp_path: Path):
+        # Bare CR in addition to LF — POSIX-style injectors sometimes
+        # use \r\n. Must also fail.
+        marker = _write_marker(
+            tmp_path / ".otsinfra.yaml",
+            web_ip="10.0.0.5\r\nhost all all 0.0.0.0/0 trust",
+        )
+        with pytest.raises(InfraMarkerError) as excinfo:
+            load_env_config_from_file("eu-demo", marker)
+        assert "web.ip" in str(excinfo.value)
+
+
+# --- rejection: not an IP address ---------------------------------------
+
+
+class TestWebIpNotAnIp:
+    """Free-form strings that are not valid addresses are refused."""
+
+    def test_garbage_text_rejected(self, tmp_path: Path):
+        marker = _write_marker(tmp_path / ".otsinfra.yaml", web_ip="not-an-ip")
+        with pytest.raises(InfraMarkerError) as excinfo:
+            load_env_config_from_file("eu-demo", marker)
+        assert "web.ip" in str(excinfo.value)
+
+    def test_hostname_rejected(self, tmp_path: Path):
+        # A DNS name is a common mistake and must fail — the value is
+        # consumed literally by pg_hba which does its own name resolution
+        # policy; the bootstrap command constrains to IPs only.
+        marker = _write_marker(tmp_path / ".otsinfra.yaml", web_ip="example.com")
+        with pytest.raises(InfraMarkerError) as excinfo:
+            load_env_config_from_file("eu-demo", marker)
+        assert "web.ip" in str(excinfo.value)
+
+    def test_cidr_block_rejected(self, tmp_path: Path):
+        # A CIDR expression contains ``/``; ``ipaddress.ip_address()``
+        # rejects it (use ip_network() for that). Good — pg_hba builds
+        # the /32 itself.
+        marker = _write_marker(tmp_path / ".otsinfra.yaml", web_ip="10.0.0.5/32")
+        with pytest.raises(InfraMarkerError) as excinfo:
+            load_env_config_from_file("eu-demo", marker)
+        assert "web.ip" in str(excinfo.value)
+
+    def test_malformed_ipv4_rejected(self, tmp_path: Path):
+        marker = _write_marker(tmp_path / ".otsinfra.yaml", web_ip="999.0.0.1")
+        with pytest.raises(InfraMarkerError) as excinfo:
+            load_env_config_from_file("eu-demo", marker)
+        assert "web.ip" in str(excinfo.value)
+
+
+# --- rejection: empty / missing -----------------------------------------
+
+
+class TestWebIpEmpty:
+    """Empty string fails the ``_require_str`` pre-check; error still mentions web.ip.
+
+    The exact message wording is owned by ``_require_str`` ("must be a
+    non-empty string"), but the dotted path it builds includes ``web.ip``,
+    so callers can still surface which field was bad.
+    """
+
+    def test_empty_string_rejected(self, tmp_path: Path):
+        # Empty-string YAML scalar: ``ip: ""``.
+        marker = _write_marker(tmp_path / ".otsinfra.yaml", web_ip="")
+        with pytest.raises(InfraMarkerError) as excinfo:
+            load_env_config_from_file("eu-demo", marker)
+        # Path must be identifiable regardless of exact message.
+        assert "web.ip" in str(excinfo.value)
+
+    def test_whitespace_only_rejected(self, tmp_path: Path):
+        # Pure whitespace fails the ``not value.strip()`` guard in
+        # ``_require_str`` — same ``web.ip`` dotted path in the error.
+        marker = _write_marker(tmp_path / ".otsinfra.yaml", web_ip="   ")
+        with pytest.raises(InfraMarkerError) as excinfo:
+            load_env_config_from_file("eu-demo", marker)
+        assert "web.ip" in str(excinfo.value)


### PR DESCRIPTION
Closes #55.

## Summary

Adds eight new sidecar RPC verbs for Postgres, Valkey, secrets delivery, and backup job management, plus a `rots env bootstrap` operator command that drives them. This is the rots-side slice of the two-phase provisioning model described in [onetime/tools-monorepo#37](https://github.com/onetime/tools-monorepo/issues/37) — cloud-init brings services up with peer-auth or a bootstrap ACL user; the sidecar takes over for application-level provisioning (roles, databases, ACL users, secret delivery, backup timers).

## What landed

### Eight new RPC verbs (role-gated)

| Verb | Role | Returns |
|---|---|---|
| `postgres.bootstrap_app` | `db` | `role, database, password_delivered_to, changed` |
| `postgres.add_hba` | `db` | `reloaded, changed` |
| `postgres.rotate_password` | `db` | `delivered_to, changed` |
| `valkey.create_acl_user` | `db` | `delivered_to, changed` |
| `valkey.reload_acl` | `db` | `ok, changed` |
| `secrets.deliver` | `db`+`web` | `written, path, changed` |
| `backup.install` | `db` | `unit, timer, changed` |
| `backup.uninstall` | `db` | `ok, changed` |

- **`changed: bool` invariant** on every payload so the operator command can produce accurate idempotency receipts.
- **Role gating**: `@register_handler(..., roles={"db"})` + `_import_handlers(role=...)`. Web sidecars register only `secrets.deliver` + container-lifecycle handlers; db sidecars register everything. A `--role` flag on `rots sidecar run` plumbs the choice through.
- **Hardened `secrets.deliver`**: allowlist on `env_file` (only `/etc/default/onetimesecret`) and `name` (only `PG_PASSWORD`, `VALKEY_PASSWORD`). Atomic write-if-different via tempfile + `os.rename`, `O_NOFOLLOW` on read, symlink rejection, mode `0640`, never logs values.
- **In-process RPC transport** (`InProcessRpcClient`) for tests — handlers that generate secrets call `secrets.deliver` at the web peer via `_get_rpc_client().publish(...)`, and tests swap the RabbitMQ transport for an in-memory bus so the sidecar-to-sidecar flow runs end-to-end against real Postgres and Valkey without a broker.

### Operator command

```
rots env bootstrap --env <env> [--rotate] [--dry-run] [--json]
```

Reads `.otsinfra.yaml` (new file; parsed by `src/rots/infra_marker.py`), orchestrates `postgres.bootstrap_app` → `valkey.create_acl_user` → `postgres.add_hba` → optional `backup.install` against the db sidecar. Fails fast on first step failure. `--rotate` swaps step 1 for `postgres.rotate_password`. `--dry-run` prints the plan without publishing.

### Docs

`docs/SIDECAR-SPEC.md` extended with the vocabulary table rows and a new "Two-phase provisioning" section. Diff is proportionate — 53 additive lines, no rewrites.

### Housekeeping

Drops `ENV/` from `.gitignore` — redundant (`venv/` already covers the common virtualenv case) and matched `src/rots/commands/env/` on macOS under `core.ignorecase=true`, silently hiding new files from `git add`.

## Deferred to follow-ups

1. **Web-side sidecar install verification** (original acceptance criterion: "Web-side sidecar install path verified"). Gated on [onetime/tools-monorepo#12](https://github.com/onetime/tools-monorepo/issues/12) (per-host queue routing). Mirror the existing runcmd block from `tools-monorepo:packages/lots/src/lots/cloudinit/generators/db.py:558-569` for web hosts and smoke-test end-to-end once #12 lands.
2. **Live RabbitMQ run of `rots env bootstrap`**. Also gated on #12. The command publishes via `RabbitMqRpcClient` today; routing to a specific sidecar by `host_id` is correct in code but unverified against a real broker until #12 lands.
3. **Pre-existing SIDECAR-SPEC.md drifts** flagged during the docs pass, scoped out of this PR: `host_id`/`peer_id` terminology inconsistency in `_types.py` docstrings; legacy command role registrations (`restart.*`, `config.*`) undocumented; file-layout tree pointing at the old `src/rots/sidecar/` handler path.

## Test plan

- [x] `pytest tests/` — **2488 passed, 6 skipped** (1 documented skip in the handler suite: coaxing `ACL SAVE` into failing needs a read-only mount the podman fixture does not expose).
- [x] `ruff check src/ tests/` clean.
- [x] `ruff format --check src/ tests/` clean.
- [x] `PYTHONPATH=src pyright src/` — 0 errors.
- [x] Pre-commit hooks pass (pyright, ruff, ruff-format, pytest-quick).
- [x] New test counts: 159 handler tests + 25 env bootstrap tests = 184 new tests.
- [x] State-mutating handler tests run against real Postgres (`postgres:16-alpine`) and Valkey (`valkey:8-alpine`) via session-scoped podman containers; skip gracefully when podman is absent.
- [ ] Manual smoke: `rots env bootstrap --help`, `rots env bootstrap --env <env> --dry-run`, `rots env bootstrap --env <env> --dry-run --json`.
- [ ] Idempotency: `rots env bootstrap --env <env>` twice in a row; second call reports `changed=False` everywhere.
- [ ] **Deferred**: live RabbitMQ end-to-end against Hetzner CPX21 in eu-demo (gated on tools-monorepo#12).

## Architectural notes for review

- **Scaffold-first, then parallel fan-out.** Phase 0 produced interface files, TypedDicts, the transport abstraction, `conftest.py` fixtures, and a fully-implemented `secrets.deliver` as the worked example. Phase 1 ran three impl+test pairs (postgres, valkey, backup) in parallel against the locked spec, with impl and test agents deriving independently from the stub docstrings — no cross-reading. One real drift surfaced this way: the valkey `aclfile` fixture (immutable at runtime in valkey 8.x), caught because both agents disagreed on how to handle it.
- **Test isolation.** Session-scoped podman containers per service; per-test unique Postgres database (`CREATE DATABASE rots_<hex>`) and Valkey ACL-user prefix. No mocks for state-mutating handlers. `conftest.py` fixtures (`postgres_service`, `postgres_db`, `valkey_service`, `valkey_acl_prefix`, `in_process_bus`, `fake_env_file`) are the downstream contract.
- **Security posture.** `secrets.deliver` never logs values. Postgres handlers use `sudo -u postgres psql` over UNIX socket (peer auth, no stored credential). Identifier validation is allowlist-based (`^[a-z][a-z0-9_]{0,62}$`) to eliminate SQL injection surface before any `psql` call. Backup handlers never log `target` (may contain URL-embedded credentials).