### PR TITLE
Fix release workflow: skip GitHub release creation if tag already has one

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,11 +32,16 @@ jobs:
       - name: Build package
         run: uv build
 
-      - name: Create GitHub Release
+      - name: Create or update GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.ref_name }}
-        run: gh release create "$TAG_NAME" dist/* --generate-notes
+        run: |
+          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
+            gh release upload "$TAG_NAME" dist/* --clobber
+          else
+            gh release create "$TAG_NAME" dist/* --generate-notes
+          fi
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,16 +32,13 @@ jobs:
       - name: Build package
         run: uv build
 
-      - name: Create or update GitHub Release
+      - name: Create GitHub Release if missing
         env:
           GH_TOKEN: ${{ github.token }}
           TAG_NAME: ${{ github.ref_name }}
         run: |
-          if gh release view "$TAG_NAME" >/dev/null 2>&1; then
-            gh release upload "$TAG_NAME" dist/* --clobber
-          else
+          gh release view "$TAG_NAME" >/dev/null 2>&1 || \
             gh release create "$TAG_NAME" dist/* --generate-notes
-          fi
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
The release workflow was failing with \"a release with the same tag name already exists\" whenever a GitHub release was created in the UI (which also creates the tag, which triggers the workflow). This blocked the PyPI publish step from running — v0.7.0, v0.7.1, and v0.7.2 were all affected.

The fix makes the release creation step idempotent: if the tag already has a release, skip that step and proceed to publishing on PyPI. If no release exists yet (tag pushed directly), it creates one as before.