### PR TITLE
Add `instance render` for offline Quadlet emission

### DIFF
--- a/changelog.d/20260426_instance_render.rst
+++ b/changelog.d/20260426_instance_render.rst
@@ -1,0 +1,30 @@
+Added
+-----
+
+- ``rots instance render <out>`` subcommand emits Quadlet template
+  files (``onetime-web@.container``, ``onetime-worker@.container``,
+  ``onetime-scheduler@.container``, plus ``onetime.image`` when a
+  registry is configured) to a local directory with no host I/O — no
+  SSH, no systemd, no DB write. Intended for offline assembly of
+  trees that ``lots`` then ships to hosts (``#67``).
+
+Changed
+-------
+
+- Render writes are atomic per file (stage as ``<name>.tmp`` then
+  ``os.replace``) and rendered fully to memory before any disk I/O,
+  so a render failure cannot leave a half-populated tree on disk
+  (``#67``).
+- Render now removes managed Quadlet artifacts from prior runs that
+  are not in the current payload (e.g. a stale ``onetime.image`` left
+  over after ``OTS_REGISTRY`` is unset). Files outside the managed
+  set are left untouched (``#67``).
+
+Fixed
+-----
+
+- ``--config-source`` default path corrected from ``confext/`` to
+  ``confexts/`` (plural), matching the monorepo convention. Operators
+  running ``rots instance render`` from an environment directory now
+  pick up ``Volume=`` lines without an explicit ``--config-source``
+  flag (``#67``).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "rots"
-version = "0.7.2"
+version = "0.7.3"
 description = "Service orchestration for OneTimeSecret: Podman Quadlets and systemd service management"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/rots/commands/instance/annotations.py
+++ b/src/rots/commands/instance/annotations.py
@@ -98,7 +98,7 @@ ConfigSource = Annotated[
         help=(
             "Directory probed for /etc/onetimesecret/*.yaml files when emitting "
             "Volume= lines under --render. Defaults to "
-            "./confext/web/etc/onetimesecret relative to the current working "
+            "./confexts/web/etc/onetimesecret relative to the current working "
             "directory when --render is set."
         ),
     ),

--- a/src/rots/commands/instance/annotations.py
+++ b/src/rots/commands/instance/annotations.py
@@ -20,6 +20,7 @@ Usage:
 """
 
 from enum import StrEnum
+from pathlib import Path
 from typing import Annotated
 
 import cyclopts
@@ -74,6 +75,32 @@ SchedulerFlag = Annotated[
     cyclopts.Parameter(
         name=["--scheduler"],
         help="Target scheduler instances (comma-separated IDs, e.g. main,1)",
+    ),
+]
+
+# Render quadlet files to a local directory (no host I/O, no SSH, no systemd, no DB write)
+RenderDir = Annotated[
+    Path | None,
+    cyclopts.Parameter(
+        name=["--render"],
+        help=(
+            "Write Quadlet files to a local directory and perform no host I/O "
+            "(no SSH, no systemd, no DB write)."
+        ),
+    ),
+]
+
+# Local directory probed for /etc/onetimesecret/*.yaml when emitting Volume= lines under --render
+ConfigSource = Annotated[
+    Path | None,
+    cyclopts.Parameter(
+        name=["--config-source"],
+        help=(
+            "Directory probed for /etc/onetimesecret/*.yaml files when emitting "
+            "Volume= lines under --render. Defaults to "
+            "./confext/web/etc/onetimesecret relative to the current working "
+            "directory when --render is set."
+        ),
     ),
 ]
 

--- a/src/rots/commands/instance/app.py
+++ b/src/rots/commands/instance/app.py
@@ -453,49 +453,62 @@ def _render_quadlets(
 
     apply_quiet(quiet)
     out_dir = render_dir / "etc" / "containers" / "systemd"
-    out_dir.mkdir(parents=True, exist_ok=True)
 
-    web_path = out_dir / "onetime-web@.container"
-    worker_path = out_dir / "onetime-worker@.container"
-    scheduler_path = out_dir / "onetime-scheduler@.container"
+    # Render every template to memory before any disk I/O. A render failure
+    # then exits without leaving a half-populated tree on disk — important
+    # because lots' rsync would happily ship a partial state otherwise.
+    try:
+        payloads: list[tuple[str, str]] = [
+            (
+                "onetime-web@.container",
+                quadlet.render_web_template(
+                    cfg,
+                    env_file_path=None,
+                    force=False,
+                    executor=None,
+                    config_source=config_source,
+                    render_mode=True,
+                ),
+            ),
+            (
+                "onetime-worker@.container",
+                quadlet.render_worker_template(
+                    cfg,
+                    env_file_path=None,
+                    force=False,
+                    executor=None,
+                    config_source=config_source,
+                    render_mode=True,
+                ),
+            ),
+            (
+                "onetime-scheduler@.container",
+                quadlet.render_scheduler_template(
+                    cfg,
+                    env_file_path=None,
+                    force=False,
+                    executor=None,
+                    config_source=config_source,
+                    render_mode=True,
+                ),
+            ),
+        ]
+        if cfg.registry:
+            payloads.append(("onetime.image", quadlet.render_image_template(cfg, executor=None)))
+    except Exception as exc:
+        print(f"render: failed to generate Quadlet content: {exc}", file=sys.stderr)
+        raise SystemExit(EXIT_FAILURE) from exc
 
-    web_path.write_text(
-        quadlet.render_web_template(
-            cfg,
-            env_file_path=None,
-            force=False,
-            executor=None,
-            config_source=config_source,
-            render_mode=True,
-        )
-    )
-    worker_path.write_text(
-        quadlet.render_worker_template(
-            cfg,
-            env_file_path=None,
-            force=False,
-            executor=None,
-            config_source=config_source,
-            render_mode=True,
-        )
-    )
-    scheduler_path.write_text(
-        quadlet.render_scheduler_template(
-            cfg,
-            env_file_path=None,
-            force=False,
-            executor=None,
-            config_source=config_source,
-            render_mode=True,
-        )
-    )
-
-    files_written = [str(web_path), str(worker_path), str(scheduler_path)]
-
-    if cfg.registry:
-        image_path = out_dir / "onetime.image"
-        image_path.write_text(quadlet.render_image_template(cfg, executor=None))
-        files_written.append(str(image_path))
+    try:
+        out_dir.mkdir(parents=True, exist_ok=True)
+        files_written: list[str] = []
+        for name, content in payloads:
+            path = out_dir / name
+            path.write_text(content)
+            files_written.append(str(path))
+    except OSError as exc:
+        print(f"render: I/O failure writing to {out_dir}: {exc}", file=sys.stderr)
+        raise SystemExit(EXIT_FAILURE) from exc
 
     if json_output:
         print(

--- a/src/rots/commands/instance/app.py
+++ b/src/rots/commands/instance/app.py
@@ -411,8 +411,16 @@ def run(
 def _build_render_cfg(*, reference: str | None, tag: str | None) -> Config:
     """Construct a ``Config`` for render mode, applying image/tag overrides.
 
-    Render mode does not use an executor or query the host, so this skips the
-    deploy-only steps (executor lookup, image resolution).
+    Render mode performs no host I/O: no executor is created, no remote SSH
+    is opened, and no deployment database is consulted. The downstream
+    template renderers (called with ``render_mode=True``) substitute ``Image=``
+    using ``cfg.effective_image`` joined with ``cfg.tag`` directly — they do
+    not call ``cfg.resolved_image_with_tag``, which would touch the alias DB.
+
+    Because alias tags (``@current``, ``@rollback``) require a DB lookup to
+    resolve, render mode rejects them at template-build time with a clear
+    error. Callers must supply a concrete tag or digest via ``--tag`` or in
+    the image reference itself.
     """
     cfg = Config()
     ref_image, ref_tag = parse_image_reference(reference) if reference else (None, None)

--- a/src/rots/commands/instance/app.py
+++ b/src/rots/commands/instance/app.py
@@ -562,37 +562,70 @@ def _render_quadlets(
         "onetime-scheduler@.container",
         "onetime.image",
     }
-    payload_names = {name for name, _ in payloads}
 
-    # Per-file atomic write: stage every payload as `<name>.tmp`, then
-    # `os.replace` each into place. A mid-loop crash leaves at most a stray
-    # `.tmp` file plus the fully-written files that already swapped — no
-    # half-written final file, which is what the PR's atomicity claim hinges
-    # on. Stale-file cleanup runs only after every replace lands.
-    staged: list[tuple[Path, Path]] = []
+    # Tree-level atomic swap: build the full new tree in a sibling staging
+    # directory on the same filesystem as out_dir (so the final rename is a
+    # single atomic syscall), then swap it into place. A mid-write crash
+    # leaves only the staging dir behind; the live out_dir is never partially
+    # mutated.
+    #
+    # Files in out_dir that are NOT in managed_names (operator-owned configs)
+    # are copied into the staging dir first so they survive the swap.
+    import shutil
+    import tempfile
+
+    out_dir.parent.mkdir(parents=True, exist_ok=True)
     files_written: list[str] = []
+    staging_dir: Path | None = None
     try:
-        out_dir.mkdir(parents=True, exist_ok=True)
+        # Place the staging dir as a sibling of out_dir (same filesystem).
+        # tempfile.mkdtemp gives a uniquely-named dir we own end-to-end.
+        staging_dir = Path(
+            tempfile.mkdtemp(prefix=f".{out_dir.name}.render-", dir=str(out_dir.parent))
+        )
 
+        # Preserve operator-owned files: anything in the live out_dir that
+        # isn't one of the four managed Quadlet artifacts must round-trip
+        # through the staging dir, otherwise the swap deletes it.
+        if out_dir.exists():
+            for existing in out_dir.iterdir():
+                if existing.name in managed_names:
+                    continue  # superseded (or removed) by this render
+                dest = staging_dir / existing.name
+                if existing.is_dir():
+                    shutil.copytree(existing, dest, symlinks=True)
+                else:
+                    shutil.copy2(existing, dest, follow_symlinks=False)
+
+        # Write each payload into the staging dir.
         for name, content in payloads:
-            final_path = out_dir / name
-            tmp_path = final_path.with_name(final_path.name + ".tmp")
-            tmp_path.write_text(content)
-            staged.append((tmp_path, final_path))
+            (staging_dir / name).write_text(content)
+            files_written.append(str(out_dir / name))
 
-        for tmp_path, final_path in staged:
-            os.replace(tmp_path, final_path)
-            files_written.append(str(final_path))
-
-        for existing in out_dir.iterdir():
-            if existing.name in managed_names and existing.name not in payload_names:
-                existing.unlink()
+        # Atomic swap. os.replace on a directory replaces an empty target
+        # but errors on a non-empty one. Pattern: rename live -> .old,
+        # rename staging -> live, rmtree .old.
+        old_dir: Path | None = None
+        if out_dir.exists():
+            old_dir = out_dir.with_name(out_dir.name + ".old")
+            # If a stale .old exists from a prior crash, clear it first.
+            if old_dir.exists():
+                shutil.rmtree(old_dir)
+            os.replace(out_dir, old_dir)
+        try:
+            os.replace(staging_dir, out_dir)
+        except OSError:
+            # Best-effort rollback: if we moved live aside but couldn't
+            # promote staging, restore the original.
+            if old_dir is not None and old_dir.exists():
+                os.replace(old_dir, out_dir)
+            raise
+        staging_dir = None  # ownership transferred to out_dir
+        if old_dir is not None and old_dir.exists():
+            shutil.rmtree(old_dir)
     except OSError as exc:
-        for tmp_path, _ in staged:
-            try:
-                tmp_path.unlink()
-            except OSError:
-                pass
+        if staging_dir is not None and staging_dir.exists():
+            shutil.rmtree(staging_dir, ignore_errors=True)
         print(f"render: I/O failure writing to {out_dir}: {exc}", file=sys.stderr)
         raise SystemExit(EXIT_FAILURE) from exc
 

--- a/src/rots/commands/instance/app.py
+++ b/src/rots/commands/instance/app.py
@@ -458,7 +458,28 @@ def _render_quadlets(
 
     if config_source is None:
         config_source = Path("confexts/web/etc/onetimesecret")
-    config_source = config_source.resolve()
+    # Resolve early and fail loud on any path issue. A typo in --config-source
+    # would otherwise silently produce zero Volume= overrides — the rendered
+    # tree looks fine but is missing the operator's config files. The default
+    # (./confexts/web/etc/onetimesecret) gets the same treatment: render mode
+    # is meant to be explicit about its inputs.
+    try:
+        config_source = config_source.resolve()
+    except OSError as exc:
+        print(
+            f"render: cannot resolve --config-source path: {config_source}: {exc}",
+            file=sys.stderr,
+        )
+        raise SystemExit(EXIT_FAILURE) from exc
+    if not config_source.exists():
+        print(f"render: config source does not exist: {config_source}", file=sys.stderr)
+        raise SystemExit(EXIT_FAILURE)
+    if not config_source.is_dir():
+        print(
+            f"render: config source is not a directory: {config_source}",
+            file=sys.stderr,
+        )
+        raise SystemExit(EXIT_FAILURE)
 
     apply_quiet(quiet)
     out_dir = render_dir / "etc" / "containers" / "systemd"

--- a/src/rots/commands/instance/app.py
+++ b/src/rots/commands/instance/app.py
@@ -5,6 +5,7 @@
 import dataclasses
 import difflib
 import logging
+import os
 import sys
 from pathlib import Path
 from typing import Annotated
@@ -440,7 +441,7 @@ def _render_quadlets(
     ``onetime-scheduler@.container`` under ``<render_dir>/etc/containers/systemd/``.
     Also emits ``onetime.image`` when ``cfg.registry`` is set.
 
-    ``config_source`` defaults to ``./confext/web/etc/onetimesecret`` resolved
+    ``config_source`` defaults to ``./confexts/web/etc/onetimesecret`` resolved
     against the current working directory when not supplied. Both supplied and
     default paths are resolved to absolute paths before being passed to the
     quadlet renderers.
@@ -448,7 +449,7 @@ def _render_quadlets(
     import json as json_mod
 
     if config_source is None:
-        config_source = Path("confext/web/etc/onetimesecret")
+        config_source = Path("confexts/web/etc/onetimesecret")
     config_source = config_source.resolve()
 
     apply_quiet(quiet)
@@ -499,14 +500,47 @@ def _render_quadlets(
         print(f"render: failed to generate Quadlet content: {exc}", file=sys.stderr)
         raise SystemExit(EXIT_FAILURE) from exc
 
+    # Full set of Quadlet artifacts this command owns. Anything in this set
+    # that is NOT in `payloads` is a leftover from a previous render and must
+    # be removed — otherwise lots' rsync (which doesn't pass --delete) ships
+    # the stale file alongside the fresh tree.
+    managed_names = {
+        "onetime-web@.container",
+        "onetime-worker@.container",
+        "onetime-scheduler@.container",
+        "onetime.image",
+    }
+    payload_names = {name for name, _ in payloads}
+
+    # Per-file atomic write: stage every payload as `<name>.tmp`, then
+    # `os.replace` each into place. A mid-loop crash leaves at most a stray
+    # `.tmp` file plus the fully-written files that already swapped — no
+    # half-written final file, which is what the PR's atomicity claim hinges
+    # on. Stale-file cleanup runs only after every replace lands.
+    staged: list[tuple[Path, Path]] = []
+    files_written: list[str] = []
     try:
         out_dir.mkdir(parents=True, exist_ok=True)
-        files_written: list[str] = []
+
         for name, content in payloads:
-            path = out_dir / name
-            path.write_text(content)
-            files_written.append(str(path))
+            final_path = out_dir / name
+            tmp_path = final_path.with_name(final_path.name + ".tmp")
+            tmp_path.write_text(content)
+            staged.append((tmp_path, final_path))
+
+        for tmp_path, final_path in staged:
+            os.replace(tmp_path, final_path)
+            files_written.append(str(final_path))
+
+        for existing in out_dir.iterdir():
+            if existing.name in managed_names and existing.name not in payload_names:
+                existing.unlink()
     except OSError as exc:
+        for tmp_path, _ in staged:
+            try:
+                tmp_path.unlink()
+            except OSError:
+                pass
         print(f"render: I/O failure writing to {out_dir}: {exc}", file=sys.stderr)
         raise SystemExit(EXIT_FAILURE) from exc
 
@@ -606,7 +640,7 @@ def deploy(
     The ``--render <dir>`` flag emits Quadlet files to a local directory and
     performs no host I/O (no SSH, no systemd, no DB write). Use ``--config-source``
     to point at a directory of local config files when emitting Volume= lines
-    (defaults to ``./confext/web/etc/onetimesecret`` when omitted). The standalone
+    (defaults to ``./confexts/web/etc/onetimesecret`` when omitted). The standalone
     ``rots instance render`` subcommand is preferred for new code; ``--render``
     here is retained for back-compat.
 
@@ -917,7 +951,7 @@ def render(
     is configured) under ``<out_dir>/etc/containers/systemd/``. Performs no
     SSH, no systemd, and no DB writes.
 
-    ``--config-source`` defaults to ``./confext/web/etc/onetimesecret``
+    ``--config-source`` defaults to ``./confexts/web/etc/onetimesecret``
     relative to the current working directory. Files matching the canonical
     OneTimeSecret config names found in that directory are emitted as
     ``Volume=`` lines in the rendered units.

--- a/src/rots/commands/instance/app.py
+++ b/src/rots/commands/instance/app.py
@@ -408,6 +408,29 @@ def run(
         logger.info("Stopped")
 
 
+def _looks_like_path(value: str) -> bool:
+    """Return True when *value* has a clear filesystem-path shape.
+
+    Used to disambiguate a single positional argument on ``instance render``
+    between an image reference and an output directory. We only call a value
+    a path when its shape is unambiguous; truly ambiguous strings (e.g.
+    ``ghcr.io/org/image``, bare ``out``) get an explicit error from the
+    caller rather than a silent miscategorization.
+    """
+    if not value:
+        return False
+    # Bare "." and ".." are paths.
+    if value in (".", ".."):
+        return True
+    # Leading characters that mark filesystem paths in shells.
+    if value.startswith(("./", "../", "/", "~/", "~")):
+        return True
+    # Trailing slash is a directory hint.
+    if value.endswith("/"):
+        return True
+    return False
+
+
 def _build_render_cfg(*, reference: str | None, tag: str | None) -> Config:
     """Construct a ``Config`` for render mode, applying image/tag overrides.
 
@@ -1003,14 +1026,37 @@ def render(
             "render produces local files only and performs no host I/O."
         )
 
-    # Disambiguate positional args. The signature is `<reference> <out_dir>`,
-    # but with a single positional users want it to be the directory.
-    # Image references carry a tag (":") or digest ("@"); a directory path
-    # generally has neither. When only one positional is given and it lacks
-    # both markers, treat it as out_dir.
-    if reference and out_dir is None and not any(c in reference for c in ":@"):
-        out_dir = Path(reference)
-        reference = None
+    # Disambiguate the single-positional case. The signature is
+    # `<reference> <out_dir>`; with one positional, users invoking
+    # `ots instance render ./out` want it bound to out_dir, not reference.
+    #
+    # Disambiguate by shape:
+    #   * Path-like markers (./, ../, /, ~, .) -> definitely out_dir.
+    #   * Tag (":") or digest ("@") in an image-shaped string -> reference.
+    #   * Otherwise (e.g. "ghcr.io/org/image", bare "out", "image") the value
+    #     is ambiguous; rather than guess wrong (the prior heuristic would
+    #     misclassify "ghcr.io/org/image" as a directory), require both
+    #     positionals or use --tag with a directory positional.
+    if reference and out_dir is None:
+        if _looks_like_path(reference):
+            out_dir = Path(reference)
+            reference = None
+        elif ":" in reference or "@" in reference:
+            # Has a tag/digest separator: definitely an image reference.
+            # out_dir must come from a second positional or be supplied
+            # explicitly. Fall through to the missing-out_dir error below.
+            pass
+        else:
+            # Genuinely ambiguous: could be a bare image ref like
+            # "ghcr.io/org/image" or a relative directory name. Refuse to
+            # guess; ask the user to be explicit.
+            raise SystemExit(
+                f"render: cannot tell whether {reference!r} is an image reference "
+                "or an output directory. Pass both positionals explicitly:\n"
+                "  ots instance render <image-ref> <out-dir>\n"
+                "Or use --tag with a directory positional:\n"
+                "  ots instance render --tag v0.24.0 ./out"
+            )
 
     if out_dir is None:
         raise SystemExit("out_dir is required. Example: ots instance render ./out")

--- a/src/rots/commands/instance/app.py
+++ b/src/rots/commands/instance/app.py
@@ -6,6 +6,7 @@ import dataclasses
 import difflib
 import logging
 import sys
+from pathlib import Path
 from typing import Annotated
 
 import cyclopts
@@ -38,8 +39,10 @@ from ._helpers import (
     run_hook,
 )
 from .annotations import (
+    ConfigSource,
     Delay,
     InstanceType,
+    RenderDir,
     SchedulerFlag,
     TypeSelector,
     WebFlag,
@@ -404,6 +407,115 @@ def run(
         logger.info("Stopped")
 
 
+def _build_render_cfg(*, reference: str | None, tag: str | None) -> Config:
+    """Construct a ``Config`` for render mode, applying image/tag overrides.
+
+    Render mode does not use an executor or query the host, so this skips the
+    deploy-only steps (executor lookup, image resolution).
+    """
+    cfg = Config()
+    ref_image, ref_tag = parse_image_reference(reference) if reference else (None, None)
+    override_tag = ref_tag or tag
+    if ref_image or override_tag:
+        cfg = dataclasses.replace(
+            cfg,
+            image=ref_image or cfg.image,
+            tag=override_tag or cfg.tag,
+            _image_explicit=bool(ref_image) or cfg._image_explicit,
+        )
+    return cfg
+
+
+def _render_quadlets(
+    cfg: Config,
+    render_dir: Path,
+    *,
+    config_source: Path | None,
+    quiet: bool,
+    json_output: bool,
+) -> None:
+    """Emit Quadlet template files to ``render_dir`` with no host I/O.
+
+    Writes ``onetime-web@.container``, ``onetime-worker@.container``, and
+    ``onetime-scheduler@.container`` under ``<render_dir>/etc/containers/systemd/``.
+    Also emits ``onetime.image`` when ``cfg.registry`` is set.
+
+    ``config_source`` defaults to ``./confext/web/etc/onetimesecret`` resolved
+    against the current working directory when not supplied. Both supplied and
+    default paths are resolved to absolute paths before being passed to the
+    quadlet renderers.
+    """
+    import json as json_mod
+
+    if config_source is None:
+        config_source = Path("confext/web/etc/onetimesecret")
+    config_source = config_source.resolve()
+
+    apply_quiet(quiet)
+    out_dir = render_dir / "etc" / "containers" / "systemd"
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    web_path = out_dir / "onetime-web@.container"
+    worker_path = out_dir / "onetime-worker@.container"
+    scheduler_path = out_dir / "onetime-scheduler@.container"
+
+    web_path.write_text(
+        quadlet.render_web_template(
+            cfg,
+            env_file_path=None,
+            force=False,
+            executor=None,
+            config_source=config_source,
+            render_mode=True,
+        )
+    )
+    worker_path.write_text(
+        quadlet.render_worker_template(
+            cfg,
+            env_file_path=None,
+            force=False,
+            executor=None,
+            config_source=config_source,
+            render_mode=True,
+        )
+    )
+    scheduler_path.write_text(
+        quadlet.render_scheduler_template(
+            cfg,
+            env_file_path=None,
+            force=False,
+            executor=None,
+            config_source=config_source,
+            render_mode=True,
+        )
+    )
+
+    files_written = [str(web_path), str(worker_path), str(scheduler_path)]
+
+    if cfg.registry:
+        image_path = out_dir / "onetime.image"
+        image_path.write_text(quadlet.render_image_template(cfg, executor=None))
+        files_written.append(str(image_path))
+
+    if json_output:
+        print(
+            json_mod.dumps(
+                {
+                    "action": "render",
+                    "render": True,
+                    "render_dir": str(render_dir),
+                    "config_source": str(config_source),
+                    "files": files_written,
+                },
+                indent=2,
+            )
+        )
+    elif not quiet:
+        logger.info(f"Rendered Quadlet files to {out_dir}")
+        for f in files_written:
+            logger.info(f"  {f}")
+
+
 @app.command
 def deploy(
     reference: ImageRef = None,
@@ -469,12 +581,21 @@ def deploy(
             ),
         ),
     ] = None,
+    render: RenderDir = None,
+    config_source: ConfigSource = None,
 ):
     """Deploy new instance(s) using quadlet and Podman secrets.
 
     Writes quadlet config and starts systemd service.
     Requires /etc/default/onetimesecret and Podman secrets to be configured.
     Records deployment to timeline for audit and rollback support.
+
+    The ``--render <dir>`` flag emits Quadlet files to a local directory and
+    performs no host I/O (no SSH, no systemd, no DB write). Use ``--config-source``
+    to point at a directory of local config files when emitting Volume= lines
+    (defaults to ``./confext/web/etc/onetimesecret`` when omitted). The standalone
+    ``rots instance render`` subcommand is preferred for new code; ``--render``
+    here is retained for back-compat.
 
     Examples:
         ots instances deploy --web 7043,7044        # Deploy web on ports
@@ -488,9 +609,25 @@ def deploy(
         ots instances deploy --web 7043 --post-hook './notify.sh'  # Notify after deploy
         ots instances deploy ghcr.io/org/image:v1.0 --web 7043  # Explicit image reference
         ots instances deploy --tag v0.24.0 --web 7043  # Specific tag only
+        ots instances deploy --web 7043 --render ./out  # Emit Quadlet files locally
     """
-    import datetime
-    import json as json_mod
+    # --render short-circuits before any deploy-specific validation.
+    # `--host` + `--render` is a usage error: render mode performs no host I/O,
+    # so accepting --host would silently mask a misconfiguration. Fail fast.
+    if render is not None:
+        if context.host_var.get(None) is not None:
+            raise SystemExit(
+                "--host cannot be combined with --render; render mode performs no host I/O."
+            )
+        cfg = _build_render_cfg(reference=reference, tag=tag)
+        _render_quadlets(
+            cfg,
+            render,
+            config_source=config_source,
+            quiet=quiet,
+            json_output=json_output,
+        )
+        return
 
     itype, identifiers = resolve_instance_type(instance_type, web, worker, scheduler)
 
@@ -507,6 +644,9 @@ def deploy(
         )
     if itype is None:
         raise SystemExit("Instance type required for deploy. Use --web, --worker, or --scheduler.")
+
+    import datetime
+    import json as json_mod
 
     cfg = Config()
 
@@ -740,6 +880,76 @@ def deploy(
 
     if deploy_results and not all_ok:
         raise SystemExit(EXIT_PARTIAL if any_ok else EXIT_FAILURE)
+
+
+@app.command
+def render(
+    reference: ImageRef = None,
+    out_dir: Annotated[
+        Path | None,
+        cyclopts.Parameter(
+            help="Output directory for rendered Quadlet files.",
+        ),
+    ] = None,
+    web: WebFlag = None,
+    tag: TagFlag = None,
+    config_source: ConfigSource = None,
+    quiet: Quiet = False,
+    json_output: JsonOutput = False,
+):
+    """Emit Quadlet template files to a local directory with no host I/O.
+
+    Writes ``onetime-web@.container``, ``onetime-worker@.container``, and
+    ``onetime-scheduler@.container`` (plus ``onetime.image`` when a registry
+    is configured) under ``<out_dir>/etc/containers/systemd/``. Performs no
+    SSH, no systemd, and no DB writes.
+
+    ``--config-source`` defaults to ``./confext/web/etc/onetimesecret``
+    relative to the current working directory. Files matching the canonical
+    OneTimeSecret config names found in that directory are emitted as
+    ``Volume=`` lines in the rendered units.
+
+    ``--web`` is accepted for forward-compatibility but does not affect the
+    rendered output (the templates are port-agnostic). The deploy-only flags
+    (``--host``, ``--pre-hook``, ``--post-hook``, ``--wait``, ``--wait-timeout``,
+    ``--force``, ``--delay``, ``--dry-run``) are not accepted here. Combining
+    ``--host`` with this command raises an error.
+
+    Examples:
+        ots instance render ./out                          # Render to ./out
+        ots instance render --tag v0.24.0 ./out            # Pin a specific tag
+        ots instance render ghcr.io/org/image:v1 ./out     # Explicit image reference
+        ots instance render ./out --config-source ./cfg    # Custom config probe dir
+    """
+    if context.host_var.get(None) is not None:
+        raise SystemExit(
+            "--host cannot be combined with `instance render`; "
+            "render produces local files only and performs no host I/O."
+        )
+
+    # Disambiguate positional args. The signature is `<reference> <out_dir>`,
+    # but with a single positional users want it to be the directory.
+    # Image references carry a tag (":") or digest ("@"); a directory path
+    # generally has neither. When only one positional is given and it lacks
+    # both markers, treat it as out_dir.
+    if reference and out_dir is None and not any(c in reference for c in ":@"):
+        out_dir = Path(reference)
+        reference = None
+
+    if out_dir is None:
+        raise SystemExit("out_dir is required. Example: ots instance render ./out")
+
+    # `web` is accepted for forward-compat only; templates are port-agnostic.
+    del web
+
+    cfg = _build_render_cfg(reference=reference, tag=tag)
+    _render_quadlets(
+        cfg,
+        out_dir,
+        config_source=config_source,
+        quiet=quiet,
+        json_output=json_output,
+    )
 
 
 @app.command

--- a/src/rots/quadlet.py
+++ b/src/rots/quadlet.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 from ots_shared.ssh import is_remote as _is_remote
 
 from . import systemd
-from .config import CONFIG_FILES, Config
+from .config import CONFIG_FILES, Config, join_image_tag
 from .environment_file import (
     generate_quadlet_secret_lines,
     get_secrets_from_env_file,
@@ -371,7 +371,13 @@ def _build_fmt_vars(
     Args:
         config_source: When set, probe this local directory for config files
             instead of the host (used by ``--render``).
-        render_mode: When True, suppress Secret= lines (used by ``--render``).
+        render_mode: When True, suppress Secret= lines, probe ``config_source``
+            instead of the host filesystem for config volumes, and resolve the
+            ``Image=`` value without touching the deployment database. Render
+            mode rejects alias tags (``@current``, ``@rollback``, ``current``,
+            ``rollback``) since their resolution requires a DB lookup, which
+            would create ``deployments.db`` on the caller's host — violating
+            the no-host-I/O contract of ``--render``.
     """
     secrets_section = get_secrets_section(
         env_file_path, force=force, executor=executor, render_mode=render_mode
@@ -382,6 +388,21 @@ def _build_fmt_vars(
 
     if cfg.registry:
         image = "onetime.image"
+    elif render_mode:
+        # Render mode contract: no host I/O, no DB writes. resolve_image_tag
+        # would call db.get_alias -> get_connection -> init_db for alias tags,
+        # creating deployments.db on the caller's filesystem. Reject aliases
+        # explicitly so the user sees a clear error rather than a silent DB
+        # file appearing in their checkout.
+        tag_key = cfg.tag.lstrip("@").lower()
+        if tag_key in ("current", "rollback"):
+            raise SystemExit(
+                f"render: tag {cfg.tag!r} is an alias and cannot be resolved without "
+                "consulting the deployment database (which render mode forbids).\n"
+                "Pass a concrete tag or digest with --tag (e.g. --tag v0.24.0) or via "
+                "an explicit image reference (e.g. ghcr.io/org/image:v0.24.0)."
+            )
+        image = join_image_tag(cfg.effective_image, cfg.tag)
     else:
         image = cfg.resolved_image_with_tag(executor=executor)
 

--- a/src/rots/quadlet.py
+++ b/src/rots/quadlet.py
@@ -17,7 +17,7 @@ from typing import TYPE_CHECKING
 from ots_shared.ssh import is_remote as _is_remote
 
 from . import systemd
-from .config import Config
+from .config import CONFIG_FILES, Config
 from .environment_file import (
     generate_quadlet_secret_lines,
     get_secrets_from_env_file,
@@ -128,6 +128,7 @@ def get_secrets_section(
     *,
     force: bool = False,
     executor: Executor | None = None,
+    render_mode: bool = False,
 ) -> str:
     """Generate the secrets section for the quadlet template.
 
@@ -139,6 +140,8 @@ def get_secrets_section(
         force: If True, allow deployment even when secrets are not configured.
                This will produce a quadlet with no Secret= lines; the application
                will likely fail at runtime without its required secrets.
+        render_mode: If True, suppress all Secret= lines and skip env-file probing.
+               Used by `--render` to emit quadlet files locally with no host I/O.
 
     Returns:
         Multi-line string with Secret= directives
@@ -149,9 +152,12 @@ def get_secrets_section(
             CI pipelines that no destructive action was taken — the required
             configuration was simply absent.
     """
+    if render_mode:
+        return "# No secrets emitted under --render"
+
     env_path = env_file_path or DEFAULT_ENV_FILE
 
-    if _is_remote(executor):
+    if executor is not None and _is_remote(executor):
         result = executor.run(["test", "-f", str(env_path)])
         env_exists = result.ok
     else:
@@ -245,11 +251,33 @@ def get_secrets_section(
     return generate_quadlet_secret_lines(verified)
 
 
-def get_config_volumes_section(cfg: Config, *, executor: Executor | None = None) -> str:
+def get_config_volumes_section(
+    cfg: Config,
+    *,
+    executor: Executor | None = None,
+    config_source: Path | None = None,
+) -> str:
     """Generate per-file Volume directives for host config overrides.
 
     Only mounts files that exist on the host. Missing files use container defaults.
+
+    When *config_source* is set (render mode), probe the local directory for the
+    canonical CONFIG_FILES instead of the host. The Volume= left-side path is
+    still the host path (cfg.config_dir / fname) since the rendered quadlet is
+    intended for deployment to a real host.
     """
+    if config_source is not None:
+        # Render mode: probe the local config_source directory, but keep host
+        # paths on the left side of Volume= so the unit deploys correctly.
+        lines = []
+        for fname in CONFIG_FILES:
+            if (config_source / fname).exists():
+                host_path = cfg.config_dir / fname
+                lines.append(f"Volume={host_path}:/app/etc/{fname}:ro")
+        if not lines:
+            return "# No host config overrides (using container built-in defaults)"
+        return "\n".join(lines)
+
     files = cfg.get_existing_config_files(executor=executor)
 
     if not files:
@@ -332,14 +360,25 @@ def _build_fmt_vars(
     force: bool,
     extra_vars: dict | None = None,
     executor: Executor | None = None,
+    config_source: Path | None = None,
+    render_mode: bool = False,
 ) -> dict:
     """Build the format variables dict for a quadlet template.
 
     Shared by both ``_write_template`` (which writes to disk) and
     ``render_template`` (dry-run, no disk I/O).
+
+    Args:
+        config_source: When set, probe this local directory for config files
+            instead of the host (used by ``--render``).
+        render_mode: When True, suppress Secret= lines (used by ``--render``).
     """
-    secrets_section = get_secrets_section(env_file_path, force=force, executor=executor)
-    config_volumes_section = get_config_volumes_section(cfg, executor=executor)
+    secrets_section = get_secrets_section(
+        env_file_path, force=force, executor=executor, render_mode=render_mode
+    )
+    config_volumes_section = get_config_volumes_section(
+        cfg, executor=executor, config_source=config_source
+    )
 
     if cfg.registry:
         image = "onetime.image"
@@ -364,6 +403,8 @@ def render_web_template(
     *,
     force: bool = False,
     executor: Executor | None = None,
+    config_source: Path | None = None,
+    render_mode: bool = False,
 ) -> str:
     """Render the web quadlet template content without writing to disk.
 
@@ -376,6 +417,8 @@ def render_web_template(
         force=force,
         extra_vars={"valkey_after": valkey_after, "valkey_wants": valkey_wants},
         executor=executor,
+        config_source=config_source,
+        render_mode=render_mode,
     )
     return WEB_TEMPLATE.format(**fmt_vars)
 
@@ -386,9 +429,18 @@ def render_worker_template(
     *,
     force: bool = False,
     executor: Executor | None = None,
+    config_source: Path | None = None,
+    render_mode: bool = False,
 ) -> str:
     """Render the worker quadlet template content without writing to disk."""
-    fmt_vars = _build_fmt_vars(cfg, env_file_path, force=force, executor=executor)
+    fmt_vars = _build_fmt_vars(
+        cfg,
+        env_file_path,
+        force=force,
+        executor=executor,
+        config_source=config_source,
+        render_mode=render_mode,
+    )
     return WORKER_TEMPLATE.format(**fmt_vars)
 
 
@@ -398,9 +450,18 @@ def render_scheduler_template(
     *,
     force: bool = False,
     executor: Executor | None = None,
+    config_source: Path | None = None,
+    render_mode: bool = False,
 ) -> str:
     """Render the scheduler quadlet template content without writing to disk."""
-    fmt_vars = _build_fmt_vars(cfg, env_file_path, force=force, executor=executor)
+    fmt_vars = _build_fmt_vars(
+        cfg,
+        env_file_path,
+        force=force,
+        executor=executor,
+        config_source=config_source,
+        render_mode=render_mode,
+    )
     return SCHEDULER_TEMPLATE.format(**fmt_vars)
 
 
@@ -436,7 +497,7 @@ def _write_template(
         cfg, env_file_path, force=force, extra_vars=extra_vars, executor=executor
     )
     content = template.format(**fmt_vars)
-    if _is_remote(executor):
+    if executor is not None and _is_remote(executor):
         executor.run(["mkdir", "-p", str(path.parent)])
         executor.run(["tee", str(path)], input=content)
     else:
@@ -719,7 +780,7 @@ def write_image_template(
     """
     content = render_image_template(cfg, executor=executor)
     path = cfg.image_template_path
-    if _is_remote(executor):
+    if executor is not None and _is_remote(executor):
         executor.run(["mkdir", "-p", str(path.parent)])
         executor.run(["tee", str(path)], input=content)
     else:

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -3260,10 +3260,15 @@ class TestDeployRender:
 
     @pytest.fixture(autouse=True)
     def _clear_env(self, monkeypatch):
-        """Remove image/tag env vars so deploys are deterministic."""
+        """Remove image env vars and pin tag to a concrete value.
+
+        Render mode rejects alias tags (``@current``/``@rollback``) because
+        resolving them would touch the deployment DB. Pin to a concrete tag
+        so the render path doesn't trip the alias guard.
+        """
         monkeypatch.delenv("IMAGE", raising=False)
-        monkeypatch.delenv("TAG", raising=False)
         monkeypatch.delenv("OTS_REGISTRY", raising=False)
+        monkeypatch.setenv("TAG", "v0.24.0")
 
     def _patch_render_safety_nets(self, mocker):
         """Patch every host-touching dependency that --render must NOT call.
@@ -3538,10 +3543,15 @@ class TestInstanceRenderCommand:
 
     @pytest.fixture(autouse=True)
     def _clear_env(self, monkeypatch):
-        """Remove image/tag env vars so renders are deterministic."""
+        """Remove image env vars and pin tag to a concrete value.
+
+        Render mode rejects alias tags (``@current``/``@rollback``) because
+        resolving them would touch the deployment DB. Pin to a concrete tag
+        so the render path doesn't trip the alias guard.
+        """
         monkeypatch.delenv("IMAGE", raising=False)
-        monkeypatch.delenv("TAG", raising=False)
         monkeypatch.delenv("OTS_REGISTRY", raising=False)
+        monkeypatch.setenv("TAG", "v0.24.0")
 
     def _patch_render_safety_nets(self, mocker):
         """Patch every host-touching dependency that `render` must NOT call.

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -3943,6 +3943,85 @@ class TestInstanceRenderCommand:
         captured = capsys.readouterr()
         assert "config source does not exist" in captured.err
 
+    def test_render_single_positional_path_promotes_to_out_dir(self, mocker, tmp_path):
+        """A single path-shaped positional ('./out', '/tmp/x', '~/x') becomes out_dir."""
+        self._patch_render_safety_nets(mocker)
+
+        out_dir_path = tmp_path / "out"
+        out_dir_path.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        # Use an absolute path so the leading "/" triggers path detection.
+        render_cmd(reference=str(out_dir_path))
+
+        target = out_dir_path / "etc" / "containers" / "systemd"
+        assert (target / "onetime-web@.container").exists()
+
+    def test_render_single_positional_relative_path_promotes_to_out_dir(
+        self, mocker, monkeypatch, tmp_path
+    ):
+        """A relative './out' positional is also recognised as a path."""
+        self._patch_render_safety_nets(mocker)
+
+        # The autouse fixture chdir'd into a scratch dir; switch into one we
+        # control so we can pass a relative path.
+        work = tmp_path / "work"
+        (work / "confexts" / "web" / "etc" / "onetimesecret").mkdir(parents=True)
+        monkeypatch.chdir(work)
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(reference="./out")
+
+        target = work / "out" / "etc" / "containers" / "systemd"
+        assert (target / "onetime-web@.container").exists()
+
+    def test_render_single_positional_bare_image_ref_errors(self, mocker, tmp_path):
+        """A bare image ref like 'ghcr.io/org/image' (no tag) refuses to auto-promote.
+
+        The prior heuristic ("treat as out_dir if no ':' or '@'") would
+        misclassify this as a directory. The fix is to refuse to guess when
+        the input is genuinely ambiguous.
+        """
+        self._patch_render_safety_nets(mocker)
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit) as excinfo:
+            render_cmd(reference="ghcr.io/org/image")
+
+        assert "cannot tell" in str(excinfo.value)
+
+    def test_render_single_positional_image_ref_with_tag_does_not_promote(self, mocker, tmp_path):
+        """An image ref with a tag is bound to reference; out_dir is then required."""
+        self._patch_render_safety_nets(mocker)
+
+        from rots.commands.instance.app import render as render_cmd
+
+        # Has a ':' -> definitely an image ref. With no out_dir, fall through
+        # to the missing-out_dir error.
+        with pytest.raises(SystemExit) as excinfo:
+            render_cmd(reference="ghcr.io/org/image:v1")
+
+        assert "out_dir is required" in str(excinfo.value)
+
+    def test_render_two_positionals_image_ref_and_out_dir(self, mocker, tmp_path):
+        """Both positionals supplied: reference is the image ref, out_dir is the path."""
+        self._patch_render_safety_nets(mocker)
+
+        out_dir_path = tmp_path / "out"
+        out_dir_path.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(reference="ghcr.io/org/image:v1.2.3", out_dir=out_dir_path)
+
+        web_unit = (
+            out_dir_path / "etc" / "containers" / "systemd" / "onetime-web@.container"
+        ).read_text()
+        assert "Image=ghcr.io/org/image:v1.2.3" in web_unit
+
     def test_render_output_is_byte_stable_across_runs(self, mocker, tmp_path):
         """Render output must be byte-identical across reruns with identical inputs.
 

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -4132,3 +4132,475 @@ class TestInstanceRenderCommand:
             a = (out1 / "etc" / "containers" / "systemd" / name).read_bytes()
             b = (out2 / "etc" / "containers" / "systemd" / name).read_bytes()
             assert a == b, f"{name} differs across runs"
+
+
+# ---------------------------------------------------------------------------
+# Issue #67 / PR #68 — Copilot review supplemental coverage
+# ---------------------------------------------------------------------------
+#
+# Backend-dev's per-item commits added direct coverage for each of the four
+# review fixes. The classes below add defence-in-depth and regression-guard
+# coverage that is complementary, not duplicative:
+#
+#   Item 1  TestRenderItem1NoDBSafetyNet     — DB-module tripwires + filesystem
+#                                              survey for deployments.db
+#   Item 2  TestRenderItem2NoPartialOutput   — config-source validation runs
+#                                              before any output tree creation
+#   Item 3  TestRenderItem3HostStillRejected — --host + valid out_dir still
+#                                              rejected after positional cleanup
+#   Item 4  TestRenderItem4AtomicityExtras   — in-place rerun byte-stability +
+#                                              no stray .tmp files
+
+
+def _stage_default_confexts(monkeypatch, tmp_path):
+    """Helper: chdir into a scratch dir staged with the default config_source.
+
+    Render mode validates ``./confexts/web/etc/onetimesecret`` exists when
+    no ``--config-source`` is supplied. Tests that don't pass an explicit
+    config_source need the scaffold staged.
+    """
+    scratch = tmp_path / "_scratch_confexts_supp"
+    scratch.mkdir(exist_ok=True)
+    (scratch / "confexts" / "web" / "etc" / "onetimesecret").mkdir(parents=True, exist_ok=True)
+    monkeypatch.chdir(scratch)
+    return scratch
+
+
+class TestRenderItem1NoDBSafetyNet:
+    """Item 1, defence-in-depth — DB module entry points must not be reached.
+
+    Backend-dev's existing coverage in ``tests/test_quadlet_render.py``
+    asserts the alias rejection inside ``_build_fmt_vars`` and that
+    ``cfg.resolved_image_with_tag`` is not called. The complementary tests
+    below patch the ``rots.db`` module's entry points themselves with
+    side-effecting tripwires, so any future refactor that bypasses
+    ``_build_fmt_vars`` (e.g. a new code path that logs the resolved tag,
+    or a command-level pre-check) still surfaces a contract violation.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch, tmp_path):
+        """Strip image/tag env vars and stage the default confexts scaffold.
+
+        We deliberately do NOT pin TAG — exercising the default ``@current``
+        is the whole point of this class.
+        """
+        monkeypatch.delenv("IMAGE", raising=False)
+        monkeypatch.delenv("TAG", raising=False)
+        monkeypatch.delenv("OTS_REGISTRY", raising=False)
+        _stage_default_confexts(monkeypatch, tmp_path)
+
+    @pytest.fixture(autouse=True)
+    def _db_tripwires(self, mocker):
+        """Trip-wires: any call into the DB module is a contract violation.
+
+        ``db.get_alias`` / ``db.init_db`` / ``db.get_connection`` should
+        never run during ``instance render``. Patch them with side-effecting
+        AssertionErrors so a regression produces a loud, identifiable
+        failure rather than a quiet ``deployments.db`` somewhere on disk.
+        """
+        mocker.patch(
+            "rots.db.get_alias",
+            side_effect=AssertionError("render must not call db.get_alias"),
+        )
+        mocker.patch(
+            "rots.db.init_db",
+            side_effect=AssertionError("render must not call db.init_db"),
+        )
+        mocker.patch(
+            "rots.db.get_connection",
+            side_effect=AssertionError("render must not open db.get_connection"),
+        )
+
+    def _patch_safety_nets(self, mocker):
+        mocker.patch.object(Config, "get_executor")
+        mocker.patch("rots.commands.instance.app.deploy_lock")
+        mocker.patch(
+            "rots.commands.instance.app.systemd.daemon_reload",
+            create=True,
+        )
+        mocker.patch("rots.commands.instance.app.db.record_deployment")
+
+    def test_default_at_current_tag_does_not_reach_db_module(self, mocker, tmp_path):
+        """Default ``@current`` exits cleanly; if a regression slips past
+        ``_build_fmt_vars``, the DB-module tripwires would catch it.
+        """
+        self._patch_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit) as excinfo:
+            render_cmd(out_dir=out_dir)
+
+        assert "alias" in str(excinfo.value).lower()
+
+    def test_default_tag_creates_no_deployments_db_anywhere(self, mocker, monkeypatch, tmp_path):
+        """No ``deployments.db`` may be created — anywhere under tmp_path.
+
+        ``Config.db_path`` falls through to ``$XDG_DATA_HOME/rots/`` or
+        ``~/.local/share/rots/`` on macOS / non-root. Redirect both env
+        vars at tmp_path so any accidental DB creation is observable here.
+        """
+        self._patch_safety_nets(mocker)
+        monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+        monkeypatch.setenv("HOME", str(tmp_path / "home"))
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit):
+            render_cmd(out_dir=out_dir)
+
+        found = list(tmp_path.rglob("deployments.db"))
+        assert found == [], f"render created deployments.db: {found}"
+
+    def test_concrete_tag_reaches_no_db_entry_points(self, mocker, tmp_path):
+        """`--tag v1.2.3` (concrete) renders successfully without any DB call.
+
+        The autouse ``_db_tripwires`` would raise AssertionError if any
+        ``db.*`` entry point ran. Reaching the assertion below proves the
+        concrete-tag path is DB-free end-to-end.
+        """
+        self._patch_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir, tag="v1.2.3")
+
+        web = (out_dir / "etc" / "containers" / "systemd" / "onetime-web@.container").read_text()
+        assert ":v1.2.3" in web
+
+    def test_registry_set_with_concrete_tag_reaches_no_db(self, mocker, monkeypatch, tmp_path):
+        """With a registry, the .container Image= is ``onetime.image`` and DB stays untouched."""
+        self._patch_safety_nets(mocker)
+        monkeypatch.setenv("OTS_REGISTRY", "registry.example.com")
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir, tag="v0.24.0")
+
+        target = out_dir / "etc" / "containers" / "systemd"
+        assert (target / "onetime.image").exists()
+        web = (target / "onetime-web@.container").read_text()
+        assert "Image=onetime.image" in web
+
+
+class TestRenderItem2NoPartialOutput:
+    """Item 2, supplemental — ``--config-source`` validation must precede output writes.
+
+    Backend-dev's coverage asserts the error messages and exit code. This
+    class adds the regression-guard that a bad ``--config-source`` does not
+    leave a partial output tree on disk (validation runs before staging).
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("IMAGE", raising=False)
+        monkeypatch.delenv("OTS_REGISTRY", raising=False)
+        monkeypatch.setenv("TAG", "v0.24.0")
+        _stage_default_confexts(monkeypatch, tmp_path)
+
+    def _patch_safety_nets(self, mocker):
+        mocker.patch.object(Config, "get_executor")
+        mocker.patch("rots.commands.instance.app.deploy_lock")
+        mocker.patch(
+            "rots.commands.instance.app.systemd.daemon_reload",
+            create=True,
+        )
+
+    def test_missing_config_source_does_not_create_output_tree(self, mocker, tmp_path):
+        """A bogus ``--config-source`` must not leave behind a partial output tree."""
+        self._patch_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        bogus = tmp_path / "missing"
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit):
+            render_cmd(out_dir=out_dir, config_source=bogus)
+
+        assert not (out_dir / "etc" / "containers" / "systemd").exists()
+
+    def test_file_config_source_does_not_create_output_tree(self, mocker, tmp_path):
+        """A regular-file ``--config-source`` must not leave behind a partial tree."""
+        self._patch_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        a_file = tmp_path / "regular.txt"
+        a_file.write_text("not a directory\n")
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit):
+            render_cmd(out_dir=out_dir, config_source=a_file)
+
+        assert not (out_dir / "etc" / "containers" / "systemd").exists()
+
+    def test_valid_empty_config_source_dir_renders_with_no_volume_lines(self, mocker, tmp_path):
+        """An existing-but-empty config_source dir is valid — emits no Volume= lines."""
+        self._patch_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        empty_src = tmp_path / "empty"
+        empty_src.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir, config_source=empty_src)
+
+        web = (out_dir / "etc" / "containers" / "systemd" / "onetime-web@.container").read_text()
+        assert "/app/etc/" not in web
+
+
+class TestRenderItem3HostStillRejected:
+    """Item 3, regression guard — ``--host`` rejection must survive the positional cleanup.
+
+    The positional-disambiguation rewrite runs before the host check is
+    re-validated. Lock in that ``--host`` combined with a perfectly valid
+    ``out_dir`` still raises, even though the disambiguation logic doesn't
+    need to fall back.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("IMAGE", raising=False)
+        monkeypatch.delenv("OTS_REGISTRY", raising=False)
+        monkeypatch.setenv("TAG", "v0.24.0")
+        _stage_default_confexts(monkeypatch, tmp_path)
+
+    def _patch_safety_nets(self, mocker):
+        mocker.patch.object(Config, "get_executor")
+        mocker.patch("rots.commands.instance.app.deploy_lock")
+        mocker.patch(
+            "rots.commands.instance.app.systemd.daemon_reload",
+            create=True,
+        )
+
+    def test_host_with_valid_out_dir_still_rejected(self, mocker, tmp_path):
+        """`--host` together with a valid ``out_dir`` is still a usage error."""
+        self._patch_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots import context
+        from rots.commands.instance.app import render as render_cmd
+
+        token = context.host_var.set("some-host.example.com")
+        try:
+            with pytest.raises(SystemExit) as excinfo:
+                render_cmd(out_dir=out_dir)
+            msg = str(excinfo.value).lower()
+            assert "host" in msg
+        finally:
+            context.host_var.reset(token)
+
+    def test_host_with_two_positionals_still_rejected(self, mocker, tmp_path):
+        """`--host` plus both positionals is also rejected — host check runs first."""
+        self._patch_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots import context
+        from rots.commands.instance.app import render as render_cmd
+
+        token = context.host_var.set("some-host.example.com")
+        try:
+            with pytest.raises(SystemExit) as excinfo:
+                render_cmd(reference="ghcr.io/org/img:v1", out_dir=out_dir)
+            msg = str(excinfo.value).lower()
+            assert "host" in msg
+        finally:
+            context.host_var.reset(token)
+
+
+class TestRenderItem4AtomicityExtras:
+    """Item 4, supplemental — additional invariants of the tree-level swap.
+
+    Backend-dev's coverage asserts:
+      * old tree intact on mid-write failure
+      * no staging dir leftover on success or failure
+
+    This class adds:
+      * In-place rerun is byte-stable (rules out swap-introduced jitter).
+      * No stray ``*.tmp`` files anywhere — guards against a partial revert
+        to the old per-file ``.tmp -> os.replace`` approach.
+      * Stale managed file (``onetime.image`` from a prior registry-set
+        render) is removed when re-rendered with registry unset, even when
+        operator-owned files coexist in the same directory.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("IMAGE", raising=False)
+        monkeypatch.delenv("OTS_REGISTRY", raising=False)
+        monkeypatch.setenv("TAG", "v0.24.0")
+        _stage_default_confexts(monkeypatch, tmp_path)
+
+    def _patch_safety_nets(self, mocker):
+        mocker.patch.object(Config, "get_executor")
+        mocker.patch("rots.commands.instance.app.deploy_lock")
+        mocker.patch(
+            "rots.commands.instance.app.systemd.daemon_reload",
+            create=True,
+        )
+
+    def test_byte_stable_rerun_in_same_out_dir(self, mocker, tmp_path):
+        """Re-rendering into the same ``out_dir`` produces byte-identical files.
+
+        Distinct from
+        ``TestInstanceRenderCommand.test_render_output_is_byte_stable_across_runs``
+        which uses two separate out_dirs. This one re-renders in place to
+        verify the atomic-swap path doesn't introduce jitter (e.g.
+        timestamps copied via ``shutil.copy2``).
+        """
+        self._patch_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        cfg_src = tmp_path / "cfg"
+        cfg_src.mkdir()
+        (cfg_src / "config.yaml").write_text("a: 1\n")
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir, config_source=cfg_src, quiet=True)
+        target = out_dir / "etc" / "containers" / "systemd"
+        first = {p.name: p.read_bytes() for p in target.iterdir()}
+
+        render_cmd(out_dir=out_dir, config_source=cfg_src, quiet=True)
+        second = {p.name: p.read_bytes() for p in target.iterdir()}
+
+        assert first == second, "rerun produced different bytes"
+
+    def test_no_stray_tmp_files_after_successful_render(self, mocker, tmp_path):
+        """A successful render leaves no ``*.tmp`` files anywhere under out_dir.
+
+        Regression guard against a partial revert to the old per-file
+        ``.tmp -> os.replace`` approach (which left stray ``.tmp`` files
+        on certain failure modes).
+        """
+        self._patch_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        leftover_tmps = list(out_dir.rglob("*.tmp"))
+        assert leftover_tmps == [], f"stray tmp files: {leftover_tmps}"
+
+    def test_rollback_when_staging_promote_fails_after_live_moved_aside(self, mocker, tmp_path):
+        """Failure of the second ``os.replace`` (staging->live) must restore the original.
+
+        The rollback path in ``_render_quadlets`` is::
+
+            os.replace(out_dir, old_dir)         # 1: rename live -> .old (succeeds)
+            try:
+                os.replace(staging_dir, out_dir) # 2: rename staging -> live (FAILS)
+            except OSError:
+                os.replace(old_dir, out_dir)     # 3: rollback to original
+                raise
+
+        Backend-dev's ``test_render_swap_cleans_staging_dir_on_failure``
+        forces failure inside ``render_web_template`` — that aborts BEFORE
+        any ``os.replace`` runs and the rollback branch is never exercised.
+        This test fails on the second ``os.replace`` specifically so the
+        rollback branch executes and is verified to leave the live tree
+        in its original state.
+        """
+        import os as _os
+
+        self._patch_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        target = out_dir / "etc" / "containers" / "systemd"
+        target.mkdir(parents=True)
+        # Seed the live tree with sentinel content + an operator file.
+        (target / "onetime-web@.container").write_text("# OLD WEB\n")
+        (target / "onetime-worker@.container").write_text("# OLD WORKER\n")
+        (target / "onetime-scheduler@.container").write_text("# OLD SCHED\n")
+        operator = target / "operator-owned.conf"
+        operator.write_text("# operator file\n")
+
+        real_replace = _os.replace
+        call_count = {"n": 0}
+
+        def flaky_replace(src, dst, *a, **kw):
+            call_count["n"] += 1
+            # The sequence is: (1) live -> .old, (2) staging -> live, (3) .old -> live (rollback).
+            # Fail call 2 to trigger the rollback at call 3.
+            if call_count["n"] == 2:
+                raise OSError("injected failure on staging promotion")
+            return real_replace(src, dst, *a, **kw)
+
+        mocker.patch("rots.commands.instance.app.os.replace", side_effect=flaky_replace)
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit) as excinfo:
+            render_cmd(out_dir=out_dir)
+        assert excinfo.value.code != 0
+
+        # Rollback ran: live tree is exactly as before.
+        assert (target / "onetime-web@.container").read_text() == "# OLD WEB\n"
+        assert (target / "onetime-worker@.container").read_text() == "# OLD WORKER\n"
+        assert (target / "onetime-scheduler@.container").read_text() == "# OLD SCHED\n"
+        assert operator.read_text() == "# operator file\n"
+
+        # No leftover .old directory at the rename target.
+        siblings = {p.name for p in (out_dir / "etc" / "containers").iterdir()}
+        assert siblings == {"systemd"}, f"unexpected sibling dirs after rollback: {siblings}"
+
+    def test_stale_image_unit_removed_alongside_operator_files(self, mocker, monkeypatch, tmp_path):
+        """Re-render without registry: stale ``onetime.image`` removed, operator files survive.
+
+        Combined invariant: the tree-level swap correctly classifies
+        managed vs operator-owned files when both are present.
+        """
+        self._patch_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        target = out_dir / "etc" / "containers" / "systemd"
+        target.mkdir(parents=True)
+        # Stale managed file from a prior registry-set render.
+        stale = target / "onetime.image"
+        stale.write_text("[Image]\nImage=stale.example.com/old:v0\n")
+        # Operator-owned files — must survive.
+        operator_a = target / "operator-a.conf"
+        operator_a.write_text("# A\n")
+        operator_b = target / "third-party@.container"
+        operator_b.write_text("# B\n")
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        assert not stale.exists(), "stale onetime.image must be removed"
+        assert operator_a.read_text() == "# A\n", "operator-a.conf must survive"
+        assert operator_b.read_text() == "# B\n", "third-party@.container must survive"
+        # The three rendered .container files must be present.
+        for name in (
+            "onetime-web@.container",
+            "onetime-worker@.container",
+            "onetime-scheduler@.container",
+        ):
+            assert (target / name).exists(), f"{name} missing after render"

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -3242,3 +3242,528 @@ class TestStreamingCommands:
         call_kwargs = mock_ex.run_stream.call_args
         assert call_kwargs.kwargs.get("sudo") is True
         assert call_kwargs.kwargs.get("timeout") == 300
+
+
+# ---------------------------------------------------------------------------
+# Issue #67: deploy --render contract tests
+# ---------------------------------------------------------------------------
+#
+# The --render flag writes Quadlet files locally under <dir>/etc/containers/systemd/
+# and exits with no host I/O, no SSH, no systemd, no DB write, and no hooks.
+# These tests are the primary contract for that behaviour. They will fail with
+# TypeError until python-dev's parallel impl lands the new `render` and
+# `config_source` parameters on instance.deploy.
+
+
+class TestDeployRender:
+    """Tests for `deploy ... --render <dir>` (issue #67)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch):
+        """Remove image/tag env vars so deploys are deterministic."""
+        monkeypatch.delenv("IMAGE", raising=False)
+        monkeypatch.delenv("TAG", raising=False)
+        monkeypatch.delenv("OTS_REGISTRY", raising=False)
+
+    def _patch_render_safety_nets(self, mocker):
+        """Patch every host-touching dependency that --render must NOT call.
+
+        Returns a dict of name -> mock so individual tests can assert_not_called.
+        """
+        return {
+            "get_executor": mocker.patch.object(Config, "get_executor"),
+            "deploy_lock": mocker.patch("rots.commands.instance.app.deploy_lock"),
+            "systemd_start": mocker.patch("rots.commands.instance.app.systemd.start"),
+            "systemd_daemon_reload": mocker.patch(
+                "rots.commands.instance.app.systemd.daemon_reload",
+                create=True,
+            ),
+            "systemd_wait_for_healthy": mocker.patch(
+                "rots.commands.instance.app.systemd.wait_for_healthy"
+            ),
+            "systemd_wait_for_http_healthy": mocker.patch(
+                "rots.commands.instance.app.systemd.wait_for_http_healthy"
+            ),
+            "record_deployment": mocker.patch("rots.commands.instance.app.db.record_deployment"),
+            "run_hook": mocker.patch("rots.commands.instance.app.run_hook"),
+            "assets_update": mocker.patch("rots.commands.instance.app.assets.update"),
+            "write_web_template": mocker.patch(
+                "rots.commands.instance.app.quadlet.write_web_template"
+            ),
+            "write_worker_template": mocker.patch(
+                "rots.commands.instance.app.quadlet.write_worker_template"
+            ),
+            "write_scheduler_template": mocker.patch(
+                "rots.commands.instance.app.quadlet.write_scheduler_template"
+            ),
+        }
+
+    def test_render_writes_three_container_files_for_web(self, mocker, tmp_path):
+        """deploy --web 7043 --render <dir> writes the three .container template files."""
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        instance.deploy(web="7043", render=out_dir)
+
+        target_dir = out_dir / "etc" / "containers" / "systemd"
+        assert (target_dir / "onetime-web@.container").exists()
+        assert (target_dir / "onetime-worker@.container").exists()
+        assert (target_dir / "onetime-scheduler@.container").exists()
+
+    def test_render_writes_image_unit_when_registry_set(self, mocker, monkeypatch, tmp_path):
+        """`onetime.image` is emitted only when cfg.registry is set."""
+        self._patch_render_safety_nets(mocker)
+        monkeypatch.setenv("OTS_REGISTRY", "registry.example.com")
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        instance.deploy(web="7043", render=out_dir)
+
+        target_dir = out_dir / "etc" / "containers" / "systemd"
+        assert (target_dir / "onetime.image").exists()
+
+    def test_render_omits_image_unit_when_registry_unset(self, mocker, tmp_path):
+        """`onetime.image` is NOT emitted when cfg.registry is unset."""
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        instance.deploy(web="7043", render=out_dir)
+
+        target_dir = out_dir / "etc" / "containers" / "systemd"
+        assert not (target_dir / "onetime.image").exists()
+
+    def test_render_does_not_call_get_executor(self, mocker, tmp_path):
+        """Under --render, Config.get_executor must not be called."""
+        nets = self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        instance.deploy(web="7043", render=out_dir)
+
+        nets["get_executor"].assert_not_called()
+
+    def test_render_does_not_acquire_deploy_lock(self, mocker, tmp_path):
+        """Under --render, the deploy_lock context manager must not be entered."""
+        nets = self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        instance.deploy(web="7043", render=out_dir)
+
+        nets["deploy_lock"].assert_not_called()
+
+    def test_render_does_not_call_systemd(self, mocker, tmp_path):
+        """Under --render, systemd start / daemon_reload / health waits are skipped."""
+        nets = self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        instance.deploy(web="7043", render=out_dir)
+
+        nets["systemd_start"].assert_not_called()
+        nets["systemd_daemon_reload"].assert_not_called()
+        nets["systemd_wait_for_healthy"].assert_not_called()
+        nets["systemd_wait_for_http_healthy"].assert_not_called()
+
+    def test_render_does_not_record_deployment(self, mocker, tmp_path):
+        """Under --render, deployment history must not be touched."""
+        nets = self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        instance.deploy(web="7043", render=out_dir)
+
+        nets["record_deployment"].assert_not_called()
+
+    def test_render_does_not_run_hooks(self, mocker, tmp_path):
+        """Under --render, pre/post hooks must not run even if specified."""
+        nets = self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        instance.deploy(
+            web="7043",
+            render=out_dir,
+            pre_hook="./scan.sh",
+            post_hook="./notify.sh",
+        )
+
+        nets["run_hook"].assert_not_called()
+
+    def test_render_does_not_call_write_template_helpers(self, mocker, tmp_path):
+        """Under --render, the host-targeted write_*_template helpers are bypassed.
+
+        Render mode writes to <dir>/etc/containers/systemd/ directly; it must not
+        call quadlet.write_web_template (which writes to /etc/containers/systemd/).
+        """
+        nets = self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        instance.deploy(web="7043", render=out_dir)
+
+        nets["write_web_template"].assert_not_called()
+        nets["write_worker_template"].assert_not_called()
+        nets["write_scheduler_template"].assert_not_called()
+
+    def test_render_with_host_raises(self, mocker, tmp_path):
+        """`--render --host some-host` must raise rather than silently ignore --host.
+
+        Mixing a remote target with local-only render is a user mistake; the
+        command must surface that conflict rather than render and exit cleanly.
+        """
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        # context.host_var is the canonical channel for --host on the global app.
+        from rots import context
+
+        token = context.host_var.set("some-host.example.com")
+        try:
+            with pytest.raises(SystemExit):
+                instance.deploy(web="7043", render=out_dir)
+        finally:
+            context.host_var.reset(token)
+
+    def test_render_defaults_config_source_to_confext_web(self, mocker, monkeypatch, tmp_path):
+        """When config_source=None, deploy --render defaults to ./confext/web/etc/onetimesecret.
+
+        Resolving the default against cwd (rather than an absolute hard-coded
+        path) lets operators run `rots instance deploy --render ./out` from
+        their checkout without flag soup.
+        """
+        self._patch_render_safety_nets(mocker)
+        monkeypatch.chdir(tmp_path)
+
+        default_src = tmp_path / "confext" / "web" / "etc" / "onetimesecret"
+        default_src.mkdir(parents=True)
+        (default_src / "config.yaml").write_text("# placeholder\n")
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        instance.deploy(web="7043", render=out_dir, config_source=None)
+
+        web_unit = (
+            out_dir / "etc" / "containers" / "systemd" / "onetime-web@.container"
+        ).read_text()
+
+        # The default config_source resolved to <cwd>/confext/web/etc/onetimesecret,
+        # where config.yaml exists, so a Volume= line for it must be rendered.
+        assert ":/app/etc/config.yaml:ro" in web_unit
+
+    def test_render_propagates_config_source_into_rendered_files(self, mocker, tmp_path):
+        """`--config-source <dir>` causes Volume= lines for matching files to appear."""
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        cfg_src = tmp_path / "cfgsrc"
+        cfg_src.mkdir()
+        (cfg_src / "config.yaml").write_text("# placeholder\n")
+
+        instance.deploy(web="7043", render=out_dir, config_source=cfg_src)
+
+        web_unit = (
+            out_dir / "etc" / "containers" / "systemd" / "onetime-web@.container"
+        ).read_text()
+
+        # The Volume= line must reference config.yaml mounted at the
+        # container's /app/etc/config.yaml:ro path.
+        assert ":/app/etc/config.yaml:ro" in web_unit
+
+    def test_render_emits_no_secret_lines(self, mocker, tmp_path):
+        """No `Secret=` lines must appear in any rendered file under --render."""
+        self._patch_render_safety_nets(mocker)
+        # Make secrets visible at the env-file level so a regression that
+        # re-enables Secret= emission would surface.
+        from rots.environment_file import SecretSpec
+
+        env_file = tmp_path / "envfile"
+        env_file.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET\n")
+        mocker.patch("rots.quadlet.DEFAULT_ENV_FILE", env_file)
+        mocker.patch("rots.quadlet.secret_exists", return_value=True)
+        mocker.patch(
+            "rots.quadlet.get_secrets_from_env_file",
+            return_value=[
+                SecretSpec(env_var_name="AUTH_SECRET", secret_name="ots_auth_secret"),
+            ],
+        )
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        instance.deploy(web="7043", render=out_dir)
+
+        target_dir = out_dir / "etc" / "containers" / "systemd"
+        for unit_name in (
+            "onetime-web@.container",
+            "onetime-worker@.container",
+            "onetime-scheduler@.container",
+        ):
+            content = (target_dir / unit_name).read_text()
+            assert "Secret=" not in content, (
+                f"{unit_name} unexpectedly contains a Secret= directive: {content!r}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Issue #67: dedicated `instance render` subcommand contract tests
+# ---------------------------------------------------------------------------
+#
+# The `render` command on instance.app is a separate subcommand (not a flag
+# on deploy). It writes Quadlet files locally and never performs host I/O.
+# It accepts only a small set of parameters and explicitly excludes deploy-only
+# flags. Tests import the function directly from `rots.commands.instance.app`
+# rather than the package namespace, since the package `__init__.py` does not
+# re-export it (and we are forbidden from modifying production code in this
+# round).
+
+
+class TestInstanceRenderCommand:
+    """Tests for the dedicated `rots instance render` subcommand (issue #67)."""
+
+    @pytest.fixture(autouse=True)
+    def _clear_env(self, monkeypatch):
+        """Remove image/tag env vars so renders are deterministic."""
+        monkeypatch.delenv("IMAGE", raising=False)
+        monkeypatch.delenv("TAG", raising=False)
+        monkeypatch.delenv("OTS_REGISTRY", raising=False)
+
+    def _patch_render_safety_nets(self, mocker):
+        """Patch every host-touching dependency that `render` must NOT call.
+
+        Returns a dict of name -> mock so individual tests can assert_not_called.
+        """
+        return {
+            "get_executor": mocker.patch.object(Config, "get_executor"),
+            "deploy_lock": mocker.patch("rots.commands.instance.app.deploy_lock"),
+            "systemd_start": mocker.patch("rots.commands.instance.app.systemd.start"),
+            "systemd_daemon_reload": mocker.patch(
+                "rots.commands.instance.app.systemd.daemon_reload",
+                create=True,
+            ),
+            "systemd_wait_for_healthy": mocker.patch(
+                "rots.commands.instance.app.systemd.wait_for_healthy"
+            ),
+            "systemd_wait_for_http_healthy": mocker.patch(
+                "rots.commands.instance.app.systemd.wait_for_http_healthy"
+            ),
+            "record_deployment": mocker.patch("rots.commands.instance.app.db.record_deployment"),
+            "run_hook": mocker.patch("rots.commands.instance.app.run_hook"),
+            "assets_update": mocker.patch("rots.commands.instance.app.assets.update"),
+            "write_web_template": mocker.patch(
+                "rots.commands.instance.app.quadlet.write_web_template"
+            ),
+            "write_worker_template": mocker.patch(
+                "rots.commands.instance.app.quadlet.write_worker_template"
+            ),
+            "write_scheduler_template": mocker.patch(
+                "rots.commands.instance.app.quadlet.write_scheduler_template"
+            ),
+        }
+
+    def test_render_writes_three_container_files(self, mocker, tmp_path):
+        """`instance render <out>` writes the three .container template files."""
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        target_dir = out_dir / "etc" / "containers" / "systemd"
+        assert (target_dir / "onetime-web@.container").exists()
+        assert (target_dir / "onetime-worker@.container").exists()
+        assert (target_dir / "onetime-scheduler@.container").exists()
+
+    def test_render_writes_image_unit_when_registry_set(self, mocker, monkeypatch, tmp_path):
+        """`onetime.image` is emitted only when cfg.registry is set."""
+        self._patch_render_safety_nets(mocker)
+        monkeypatch.setenv("OTS_REGISTRY", "registry.example.com")
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        target_dir = out_dir / "etc" / "containers" / "systemd"
+        assert (target_dir / "onetime.image").exists()
+
+    def test_render_omits_image_unit_when_registry_unset(self, mocker, tmp_path):
+        """`onetime.image` is NOT emitted when cfg.registry is unset."""
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        target_dir = out_dir / "etc" / "containers" / "systemd"
+        assert not (target_dir / "onetime.image").exists()
+
+    def test_render_defaults_config_source_to_confext_web(self, mocker, monkeypatch, tmp_path):
+        """When --config-source omitted, defaults to ./confext/web/etc/onetimesecret."""
+        self._patch_render_safety_nets(mocker)
+        monkeypatch.chdir(tmp_path)
+
+        default_src = tmp_path / "confext" / "web" / "etc" / "onetimesecret"
+        default_src.mkdir(parents=True)
+        (default_src / "config.yaml").write_text("# placeholder\n")
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        web_unit = (
+            out_dir / "etc" / "containers" / "systemd" / "onetime-web@.container"
+        ).read_text()
+
+        # The default config_source resolved to <cwd>/confext/web/etc/onetimesecret,
+        # where config.yaml exists, so a Volume= line for it must be rendered.
+        assert ":/app/etc/config.yaml:ro" in web_unit
+
+    def test_render_explicit_config_source_takes_precedence(self, mocker, tmp_path):
+        """`--config-source <dir>` overrides the default ./confext/web/etc/onetimesecret."""
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        cfg_src = tmp_path / "explicit"
+        cfg_src.mkdir()
+        # Use a non-default file (auth.yaml) so we can prove the explicit path
+        # was probed instead of the default location (which has no files here).
+        (cfg_src / "auth.yaml").write_text("# placeholder\n")
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir, config_source=cfg_src)
+
+        web_unit = (
+            out_dir / "etc" / "containers" / "systemd" / "onetime-web@.container"
+        ).read_text()
+
+        assert ":/app/etc/auth.yaml:ro" in web_unit
+
+    def test_render_signature_excludes_deploy_only_flags(self):
+        """`render` must NOT accept deploy-only flags as parameters.
+
+        These flags are meaningful only to the host-touching deploy path.
+        Exposing them on `render` would invite confusion.
+        """
+        import inspect
+
+        from rots.commands.instance.app import render as render_cmd
+
+        sig = inspect.signature(render_cmd)
+        params = sig.parameters
+
+        for forbidden in (
+            "host",
+            "pre_hook",
+            "post_hook",
+            "wait",
+            "wait_timeout",
+            "force",
+            "delay",
+            "dry_run",
+        ):
+            assert forbidden not in params, (
+                f"`render` must not accept `{forbidden}`; got signature: {sig}"
+            )
+
+    def test_render_does_not_call_get_executor(self, mocker, tmp_path):
+        """Under `render`, Config.get_executor must not be called."""
+        nets = self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        nets["get_executor"].assert_not_called()
+
+    def test_render_does_not_acquire_deploy_lock(self, mocker, tmp_path):
+        """Under `render`, the deploy_lock context manager must not be entered."""
+        nets = self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        nets["deploy_lock"].assert_not_called()
+
+    def test_render_does_not_call_systemd(self, mocker, tmp_path):
+        """Under `render`, systemd start / daemon_reload must not be called."""
+        nets = self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        nets["systemd_start"].assert_not_called()
+        nets["systemd_daemon_reload"].assert_not_called()
+
+    def test_render_does_not_record_deployment(self, mocker, tmp_path):
+        """Under `render`, deployment history must not be touched."""
+        nets = self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        nets["record_deployment"].assert_not_called()
+
+    def test_render_with_host_raises(self, mocker, tmp_path):
+        """`--host some-host` while invoking `render` must raise.
+
+        `render` is local-only by design; mixing it with --host is a user
+        mistake that must be surfaced rather than silently ignored.
+        """
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots import context
+        from rots.commands.instance.app import render as render_cmd
+
+        token = context.host_var.set("some-host.example.com")
+        try:
+            with pytest.raises(SystemExit):
+                render_cmd(out_dir=out_dir)
+        finally:
+            context.host_var.reset(token)

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -4022,6 +4022,85 @@ class TestInstanceRenderCommand:
         ).read_text()
         assert "Image=ghcr.io/org/image:v1.2.3" in web_unit
 
+    def test_render_failure_mid_write_leaves_old_tree_intact(self, mocker, tmp_path):
+        """A failure during the staging-dir write must NOT mutate the live tree.
+
+        Tree-level atomicity: render builds the new set in a sibling staging
+        dir and renames it into place once. Any error before the rename
+        leaves the live `etc/containers/systemd/` directory untouched.
+        """
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        target_dir = out_dir / "etc" / "containers" / "systemd"
+        target_dir.mkdir(parents=True)
+
+        # Seed the live tree with a previous render and a sentinel operator file.
+        (target_dir / "onetime-web@.container").write_text("# OLD WEB\n")
+        (target_dir / "onetime-worker@.container").write_text("# OLD WORKER\n")
+        (target_dir / "onetime-scheduler@.container").write_text("# OLD SCHED\n")
+        sentinel = target_dir / "operator-owned.conf"
+        sentinel.write_text("# operator file\n")
+
+        # Force a failure during template generation (before any disk write).
+        mocker.patch(
+            "rots.commands.instance.app.quadlet.render_scheduler_template",
+            side_effect=RuntimeError("boom"),
+        )
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit):
+            render_cmd(out_dir=out_dir)
+
+        # Live tree is exactly as before.
+        assert (target_dir / "onetime-web@.container").read_text() == "# OLD WEB\n"
+        assert (target_dir / "onetime-worker@.container").read_text() == "# OLD WORKER\n"
+        assert (target_dir / "onetime-scheduler@.container").read_text() == "# OLD SCHED\n"
+        assert sentinel.read_text() == "# operator file\n"
+
+    def test_render_swap_leaves_no_staging_dir_on_success(self, mocker, tmp_path):
+        """Successful render leaves no `.render-*` staging dirs behind."""
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        # No leftover staging dirs as siblings of the systemd dir.
+        siblings = list((out_dir / "etc" / "containers").iterdir())
+        assert {p.name for p in siblings} == {"systemd"}
+
+    def test_render_swap_cleans_staging_dir_on_failure(self, mocker, tmp_path):
+        """A failed render leaves no `.render-*` staging dirs behind either.
+
+        The staging dir is best-effort cleaned up on the error path so
+        repeated failed renders don't accumulate cruft on disk.
+        """
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        target_dir = out_dir / "etc" / "containers" / "systemd"
+        target_dir.mkdir(parents=True)
+
+        mocker.patch(
+            "rots.commands.instance.app.quadlet.render_web_template",
+            side_effect=RuntimeError("boom"),
+        )
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit):
+            render_cmd(out_dir=out_dir)
+
+        # No leftover staging dirs as siblings.
+        siblings = [p.name for p in (out_dir / "etc" / "containers").iterdir()]
+        # `systemd` survives (untouched); nothing else should be there.
+        assert siblings == ["systemd"]
+
     def test_render_output_is_byte_stable_across_runs(self, mocker, tmp_path):
         """Render output must be byte-identical across reruns with identical inputs.
 

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -3767,3 +3767,63 @@ class TestInstanceRenderCommand:
                 render_cmd(out_dir=out_dir)
         finally:
             context.host_var.reset(token)
+
+    def test_render_failure_exits_nonzero_with_stderr(self, mocker, capsys, tmp_path):
+        """When a template renderer raises, render exits nonzero and writes a clear stderr message.
+
+        `rots instance apply` will subprocess --render programmatically; a
+        silent failure would let lots ship an incomplete tree.
+        """
+        self._patch_render_safety_nets(mocker)
+        mocker.patch(
+            "rots.commands.instance.app.quadlet.render_worker_template",
+            side_effect=RuntimeError("boom: bad config"),
+        )
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit) as excinfo:
+            render_cmd(out_dir=out_dir)
+
+        assert excinfo.value.code != 0
+        captured = capsys.readouterr()
+        assert "render:" in captured.err
+        assert "boom: bad config" in captured.err
+        # No half-written tree: out_dir/etc/containers/systemd should be absent
+        # because we render-to-memory before any disk write.
+        assert not (out_dir / "etc" / "containers" / "systemd").exists()
+
+    def test_render_output_is_byte_stable_across_runs(self, mocker, tmp_path):
+        """Render output must be byte-identical across reruns with identical inputs.
+
+        lots' confext push uses rsync; any jitter (timestamps, dict-iteration
+        ordering, hostnames in output) causes spurious re-applies and wasted
+        systemd-confext refresh cycles. This test locks in the contract.
+        """
+        self._patch_render_safety_nets(mocker)
+
+        out1 = tmp_path / "out1"
+        out2 = tmp_path / "out2"
+        out1.mkdir()
+        out2.mkdir()
+        cfg_src = tmp_path / "cfgsrc"
+        cfg_src.mkdir()
+        (cfg_src / "config.yaml").write_text("a: 1\n")
+        (cfg_src / "auth.yaml").write_text("b: 2\n")
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out1, config_source=cfg_src, quiet=True)
+        render_cmd(out_dir=out2, config_source=cfg_src, quiet=True)
+
+        for name in (
+            "onetime-web@.container",
+            "onetime-worker@.container",
+            "onetime-scheduler@.container",
+        ):
+            a = (out1 / "etc" / "containers" / "systemd" / name).read_bytes()
+            b = (out2 / "etc" / "containers" / "systemd" / name).read_bytes()
+            assert a == b, f"{name} differs across runs"

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -3438,8 +3438,8 @@ class TestDeployRender:
         finally:
             context.host_var.reset(token)
 
-    def test_render_defaults_config_source_to_confext_web(self, mocker, monkeypatch, tmp_path):
-        """When config_source=None, deploy --render defaults to ./confext/web/etc/onetimesecret.
+    def test_render_defaults_config_source_to_confexts_web(self, mocker, monkeypatch, tmp_path):
+        """When config_source=None, deploy --render defaults to ./confexts/web/etc/onetimesecret.
 
         Resolving the default against cwd (rather than an absolute hard-coded
         path) lets operators run `rots instance deploy --render ./out` from
@@ -3448,7 +3448,7 @@ class TestDeployRender:
         self._patch_render_safety_nets(mocker)
         monkeypatch.chdir(tmp_path)
 
-        default_src = tmp_path / "confext" / "web" / "etc" / "onetimesecret"
+        default_src = tmp_path / "confexts" / "web" / "etc" / "onetimesecret"
         default_src.mkdir(parents=True)
         (default_src / "config.yaml").write_text("# placeholder\n")
 
@@ -3461,7 +3461,7 @@ class TestDeployRender:
             out_dir / "etc" / "containers" / "systemd" / "onetime-web@.container"
         ).read_text()
 
-        # The default config_source resolved to <cwd>/confext/web/etc/onetimesecret,
+        # The default config_source resolved to <cwd>/confexts/web/etc/onetimesecret,
         # where config.yaml exists, so a Volume= line for it must be rendered.
         assert ":/app/etc/config.yaml:ro" in web_unit
 
@@ -3621,12 +3621,64 @@ class TestInstanceRenderCommand:
         target_dir = out_dir / "etc" / "containers" / "systemd"
         assert not (target_dir / "onetime.image").exists()
 
-    def test_render_defaults_config_source_to_confext_web(self, mocker, monkeypatch, tmp_path):
-        """When --config-source omitted, defaults to ./confext/web/etc/onetimesecret."""
+    def test_render_removes_stale_image_unit_when_registry_unset(
+        self, mocker, monkeypatch, tmp_path
+    ):
+        """A re-render without a registry must delete `onetime.image` from a prior render.
+
+        lots' rsync ships the rendered tree without --delete, so a stale
+        `onetime.image` left behind from a previous run would propagate to
+        the host. The render must clean managed Quadlet artifacts that are
+        no longer in the current payload set.
+        """
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        # First render: registry set, `onetime.image` is emitted.
+        monkeypatch.setenv("OTS_REGISTRY", "registry.example.com")
+        render_cmd(out_dir=out_dir)
+
+        target_dir = out_dir / "etc" / "containers" / "systemd"
+        assert (target_dir / "onetime.image").exists()
+
+        # Second render: registry unset, the stale image unit must be gone.
+        monkeypatch.delenv("OTS_REGISTRY")
+        render_cmd(out_dir=out_dir)
+
+        assert not (target_dir / "onetime.image").exists()
+
+    def test_render_preserves_unrelated_files_in_out_dir(self, mocker, tmp_path):
+        """Files outside the managed Quadlet set must not be touched by render.
+
+        Operators may colocate other artifacts under
+        `<out_dir>/etc/containers/systemd/`. Cleanup is scoped to the four
+        Quadlet artifacts this command owns.
+        """
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        target_dir = out_dir / "etc" / "containers" / "systemd"
+        target_dir.mkdir(parents=True)
+        sentinel = target_dir / "operator-owned.conf"
+        sentinel.write_text("# operator file\n")
+
+        from rots.commands.instance.app import render as render_cmd
+
+        render_cmd(out_dir=out_dir)
+
+        assert sentinel.exists(), "render must not delete unrelated files"
+        assert sentinel.read_text() == "# operator file\n"
+
+    def test_render_defaults_config_source_to_confexts_web(self, mocker, monkeypatch, tmp_path):
+        """When --config-source omitted, defaults to ./confexts/web/etc/onetimesecret."""
         self._patch_render_safety_nets(mocker)
         monkeypatch.chdir(tmp_path)
 
-        default_src = tmp_path / "confext" / "web" / "etc" / "onetimesecret"
+        default_src = tmp_path / "confexts" / "web" / "etc" / "onetimesecret"
         default_src.mkdir(parents=True)
         (default_src / "config.yaml").write_text("# placeholder\n")
 
@@ -3641,12 +3693,12 @@ class TestInstanceRenderCommand:
             out_dir / "etc" / "containers" / "systemd" / "onetime-web@.container"
         ).read_text()
 
-        # The default config_source resolved to <cwd>/confext/web/etc/onetimesecret,
+        # The default config_source resolved to <cwd>/confexts/web/etc/onetimesecret,
         # where config.yaml exists, so a Volume= line for it must be rendered.
         assert ":/app/etc/config.yaml:ro" in web_unit
 
     def test_render_explicit_config_source_takes_precedence(self, mocker, tmp_path):
-        """`--config-source <dir>` overrides the default ./confext/web/etc/onetimesecret."""
+        """`--config-source <dir>` overrides the default ./confexts/web/etc/onetimesecret."""
         self._patch_render_safety_nets(mocker)
 
         out_dir = tmp_path / "out"

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -3259,16 +3259,25 @@ class TestDeployRender:
     """Tests for `deploy ... --render <dir>` (issue #67)."""
 
     @pytest.fixture(autouse=True)
-    def _clear_env(self, monkeypatch):
-        """Remove image env vars and pin tag to a concrete value.
+    def _clear_env(self, monkeypatch, tmp_path):
+        """Remove image env vars, pin tag, and stage the default config_source.
 
         Render mode rejects alias tags (``@current``/``@rollback``) because
         resolving them would touch the deployment DB. Pin to a concrete tag
         so the render path doesn't trip the alias guard.
+
+        Render mode also validates ``--config-source`` exists. The default
+        is ``./confexts/web/etc/onetimesecret`` relative to cwd, so chdir
+        into a scratch dir and create the scaffold so tests that don't
+        supply ``config_source`` pass validation.
         """
         monkeypatch.delenv("IMAGE", raising=False)
         monkeypatch.delenv("OTS_REGISTRY", raising=False)
         monkeypatch.setenv("TAG", "v0.24.0")
+        scratch = tmp_path / "_scratch"
+        scratch.mkdir()
+        (scratch / "confexts" / "web" / "etc" / "onetimesecret").mkdir(parents=True)
+        monkeypatch.chdir(scratch)
 
     def _patch_render_safety_nets(self, mocker):
         """Patch every host-touching dependency that --render must NOT call.
@@ -3542,16 +3551,25 @@ class TestInstanceRenderCommand:
     """Tests for the dedicated `rots instance render` subcommand (issue #67)."""
 
     @pytest.fixture(autouse=True)
-    def _clear_env(self, monkeypatch):
-        """Remove image env vars and pin tag to a concrete value.
+    def _clear_env(self, monkeypatch, tmp_path):
+        """Remove image env vars, pin tag, and stage the default config_source.
 
         Render mode rejects alias tags (``@current``/``@rollback``) because
         resolving them would touch the deployment DB. Pin to a concrete tag
         so the render path doesn't trip the alias guard.
+
+        Render mode also validates ``--config-source`` exists. The default
+        is ``./confexts/web/etc/onetimesecret`` relative to cwd, so chdir
+        into a scratch dir and create the scaffold so tests that don't
+        supply ``config_source`` pass validation.
         """
         monkeypatch.delenv("IMAGE", raising=False)
         monkeypatch.delenv("OTS_REGISTRY", raising=False)
         monkeypatch.setenv("TAG", "v0.24.0")
+        scratch = tmp_path / "_scratch"
+        scratch.mkdir()
+        (scratch / "confexts" / "web" / "etc" / "onetimesecret").mkdir(parents=True)
+        monkeypatch.chdir(scratch)
 
     def _patch_render_safety_nets(self, mocker):
         """Patch every host-touching dependency that `render` must NOT call.
@@ -3857,6 +3875,73 @@ class TestInstanceRenderCommand:
         # No half-written tree: out_dir/etc/containers/systemd should be absent
         # because we render-to-memory before any disk write.
         assert not (out_dir / "etc" / "containers" / "systemd").exists()
+
+    def test_render_explicit_config_source_missing_exits(self, mocker, capsys, tmp_path):
+        """Explicit --config-source pointing at a non-existent path must error loudly.
+
+        Silent fall-through to "no Volume= overrides" hides typos; render mode
+        is meant to be explicit about its inputs.
+        """
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        bogus = tmp_path / "does-not-exist"
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit) as excinfo:
+            render_cmd(out_dir=out_dir, config_source=bogus)
+
+        assert excinfo.value.code != 0
+        captured = capsys.readouterr()
+        assert "config source does not exist" in captured.err
+
+    def test_render_explicit_config_source_is_file_exits(self, mocker, capsys, tmp_path):
+        """--config-source pointing at a regular file (not a dir) must error loudly."""
+        self._patch_render_safety_nets(mocker)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+        a_file = tmp_path / "regular_file"
+        a_file.write_text("not a directory\n")
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit) as excinfo:
+            render_cmd(out_dir=out_dir, config_source=a_file)
+
+        assert excinfo.value.code != 0
+        captured = capsys.readouterr()
+        assert "not a directory" in captured.err
+
+    def test_render_default_config_source_missing_exits(
+        self, mocker, monkeypatch, capsys, tmp_path
+    ):
+        """The default ./confexts/web/etc/onetimesecret must exist when not overridden.
+
+        Render mode is explicit about its inputs; if the operator runs it from
+        a directory without the scaffold, fail loud rather than silently emit
+        zero Volume= overrides.
+        """
+        self._patch_render_safety_nets(mocker)
+        # chdir somewhere that does NOT have the default scaffold (the autouse
+        # _clear_env fixture chdir'd to a scratch dir that does have it).
+        bare = tmp_path / "bare"
+        bare.mkdir()
+        monkeypatch.chdir(bare)
+
+        out_dir = tmp_path / "out"
+        out_dir.mkdir()
+
+        from rots.commands.instance.app import render as render_cmd
+
+        with pytest.raises(SystemExit) as excinfo:
+            render_cmd(out_dir=out_dir)
+
+        assert excinfo.value.code != 0
+        captured = capsys.readouterr()
+        assert "config source does not exist" in captured.err
 
     def test_render_output_is_byte_stable_across_runs(self, mocker, tmp_path):
         """Render output must be byte-identical across reruns with identical inputs.

--- a/tests/test_quadlet_render.py
+++ b/tests/test_quadlet_render.py
@@ -418,3 +418,233 @@ class TestNoRegistryDirectFQIN:
         result = quadlet.render_web_template(cfg, force=True)
         assert "Image=ghcr.io/onetimesecret/onetimesecret:v1.2.3" in result
         assert "onetime.image" not in result
+
+
+# Issue #67: --render / --config-source contract.
+# These constants name the six known config files probed when --config-source is set.
+# They mirror rots.config.CONFIG_FILES but are spelled here to keep the test
+# self-documenting against the contract.
+KNOWN_CONFIG_FILES = (
+    "config.yaml",
+    "auth.yaml",
+    "logging.yaml",
+    "billing.yaml",
+    "Caddyfile.template",
+    "puma.rb",
+)
+
+
+def _make_render_cfg(mocker, tmp_path, *, registry=None):
+    """Build a Config mock suitable for render-mode (config_source) tests.
+
+    Distinct from ``_make_cfg`` only in that ``get_existing_config_files`` is
+    pre-stubbed with a sensible default. Tests that exercise the executor-based
+    fall-through override this stub explicitly.
+    """
+    cfg = _make_cfg(mocker, tmp_path, registry=registry)
+    cfg.get_existing_config_files.return_value = []
+    return cfg
+
+
+class TestGetConfigVolumesSectionWithConfigSource:
+    """get_config_volumes_section behaviour under issue #67's config_source contract."""
+
+    def test_all_six_files_present_emits_six_volume_lines(self, mocker, tmp_path):
+        """All six known config files in config_source -> one Volume= line each."""
+        from rots import quadlet
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+        for fname in KNOWN_CONFIG_FILES:
+            (src / fname).touch()
+
+        result = quadlet.get_config_volumes_section(cfg, config_source=src)
+
+        volume_lines = [ln for ln in result.splitlines() if ln.startswith("Volume=")]
+        assert len(volume_lines) == 6
+        # Each Volume= line must reference the correct container path and ro mode.
+        for fname in KNOWN_CONFIG_FILES:
+            assert any(f":/app/etc/{fname}:ro" in ln for ln in volume_lines), (
+                f"missing Volume= line for {fname}: {volume_lines}"
+            )
+
+    def test_subset_present_emits_only_existing(self, mocker, tmp_path):
+        """Only files that actually exist in config_source produce Volume= lines."""
+        from rots import quadlet
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "config.yaml").touch()
+        (src / "auth.yaml").touch()
+
+        result = quadlet.get_config_volumes_section(cfg, config_source=src)
+
+        volume_lines = [ln for ln in result.splitlines() if ln.startswith("Volume=")]
+        assert len(volume_lines) == 2
+        assert any(":/app/etc/config.yaml:ro" in ln for ln in volume_lines)
+        assert any(":/app/etc/auth.yaml:ro" in ln for ln in volume_lines)
+        # Other known files must NOT appear.
+        for fname in ("logging.yaml", "billing.yaml", "Caddyfile.template", "puma.rb"):
+            assert all(f":/app/etc/{fname}:ro" not in ln for ln in volume_lines)
+
+    def test_empty_directory_emits_no_volume_lines(self, mocker, tmp_path):
+        """Empty config_source directory -> no Volume= lines."""
+        from rots import quadlet
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+
+        result = quadlet.get_config_volumes_section(cfg, config_source=src)
+
+        volume_lines = [ln for ln in result.splitlines() if ln.startswith("Volume=")]
+        assert volume_lines == []
+
+    def test_config_source_none_executor_none_no_volume_lines(self, mocker, tmp_path):
+        """config_source=None and executor=None -> no Volume= lines (host probing returns empty)."""
+        from rots import quadlet
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        # Defensive: explicit empty result so the test does not depend on
+        # whatever the host filesystem looks like.
+        cfg.get_existing_config_files.return_value = []
+        cfg.existing_config_files = []
+
+        result = quadlet.get_config_volumes_section(cfg, config_source=None, executor=None)
+
+        volume_lines = [ln for ln in result.splitlines() if ln.startswith("Volume=")]
+        assert volume_lines == []
+
+    def test_executor_based_fall_through_still_works(self, mocker, tmp_path):
+        """With config_source=None and executor probing, Volume= lines still emit."""
+        from rots import quadlet
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        # Simulate a remote host returning all six files via the executor.
+        # cfg.get_existing_config_files is the integration point we mock here;
+        # the underlying test-f probing is exercised in config tests.
+        host_paths = [cfg.config_dir / fname for fname in KNOWN_CONFIG_FILES]
+        cfg.get_existing_config_files.return_value = host_paths
+
+        # Pass a non-None sentinel for executor; the function should hand it
+        # to cfg.get_existing_config_files. The exact executor type does not
+        # matter — we only assert on the rendered output.
+        executor_sentinel = mocker.MagicMock()
+
+        result = quadlet.get_config_volumes_section(
+            cfg, executor=executor_sentinel, config_source=None
+        )
+
+        volume_lines = [ln for ln in result.splitlines() if ln.startswith("Volume=")]
+        assert len(volume_lines) == 6
+        cfg.get_existing_config_files.assert_called_once_with(executor=executor_sentinel)
+
+
+class TestRenderTemplatesWithConfigSource:
+    """render_*_template propagates config_source into the rendered output."""
+
+    def test_web_template_emits_volume_lines_for_config_source_files(self, mocker, tmp_path):
+        """render_web_template with config_source -> Volume= lines for files present there."""
+        from rots import quadlet
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "config.yaml").touch()
+        (src / "auth.yaml").touch()
+
+        result = quadlet.render_web_template(cfg, force=True, config_source=src)
+
+        assert "/app/etc/config.yaml:ro" in result
+        assert "/app/etc/auth.yaml:ro" in result
+        # Files NOT placed in src must not appear.
+        assert "/app/etc/logging.yaml:ro" not in result
+
+    def test_worker_template_emits_volume_lines_for_config_source_files(self, mocker, tmp_path):
+        """render_worker_template with config_source -> Volume= lines."""
+        from rots import quadlet
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "config.yaml").touch()
+
+        result = quadlet.render_worker_template(cfg, force=True, config_source=src)
+
+        assert "/app/etc/config.yaml:ro" in result
+
+    def test_scheduler_template_emits_volume_lines_for_config_source_files(self, mocker, tmp_path):
+        """render_scheduler_template with config_source -> Volume= lines."""
+        from rots import quadlet
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "billing.yaml").touch()
+
+        result = quadlet.render_scheduler_template(cfg, force=True, config_source=src)
+
+        assert "/app/etc/billing.yaml:ro" in result
+
+    def test_empty_config_source_yields_no_volume_lines_in_template(self, mocker, tmp_path):
+        """Empty config_source dir -> rendered template has no Volume=...:/app/etc/ lines."""
+        from rots import quadlet
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        src = tmp_path / "src"
+        src.mkdir()
+
+        result = quadlet.render_web_template(cfg, force=True, config_source=src)
+
+        # Static asset volume mount is unaffected; only host config overrides
+        # are gated by config_source.
+        assert "/app/etc/" not in result
+
+    def test_no_secret_lines_when_config_source_is_set(self, mocker, tmp_path):
+        """Render mode signal: no Secret= lines when config_source is set.
+
+        This test deliberately makes secrets *visible* (returns specs, says they exist)
+        so a regression that re-enables secret emission under render would surface.
+        """
+        from rots import quadlet
+        from rots.environment_file import SecretSpec
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        # Force the secret-existence check to say "yes" — autouse fixture
+        # returns False, which alone would suppress Secret= lines.
+        mocker.patch("rots.quadlet.secret_exists", return_value=True)
+        # And make the env file probe return real-looking secrets.
+        mocker.patch(
+            "rots.quadlet.get_secrets_from_env_file",
+            return_value=[
+                SecretSpec(env_var_name="AUTH_SECRET", secret_name="ots_auth_secret"),
+                SecretSpec(env_var_name="API_KEY", secret_name="ots_api_key"),
+            ],
+        )
+        # Make the env file appear to exist so the secrets path is reachable
+        # in non-render mode.
+        env_file = tmp_path / "envfile"
+        env_file.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET,API_KEY\n")
+        mocker.patch("rots.quadlet.DEFAULT_ENV_FILE", env_file)
+
+        src = tmp_path / "src"
+        src.mkdir()
+        (src / "config.yaml").touch()
+
+        # render_mode=True is the documented signal; pass it alongside config_source
+        # since the contract states no Secret= lines are emitted under --render.
+        result_web = quadlet.render_web_template(
+            cfg, force=True, config_source=src, render_mode=True
+        )
+        result_worker = quadlet.render_worker_template(
+            cfg, force=True, config_source=src, render_mode=True
+        )
+        result_scheduler = quadlet.render_scheduler_template(
+            cfg, force=True, config_source=src, render_mode=True
+        )
+
+        assert "Secret=" not in result_web
+        assert "Secret=" not in result_worker
+        assert "Secret=" not in result_scheduler

--- a/tests/test_quadlet_render.py
+++ b/tests/test_quadlet_render.py
@@ -22,6 +22,11 @@ def _make_cfg(mocker, tmp_path, image="ghcr.io/test/image", tag="v1.0.0", regist
     cfg.valkey_service = None
     cfg.registry = registry
     cfg.config_dir = tmp_path / "etc"
+    # Concrete string attributes — render_mode's no-DB path reads cfg.tag and
+    # cfg.effective_image directly to avoid touching db.get_alias.
+    cfg.image = image
+    cfg.tag = tag
+    cfg.effective_image = image
     cfg.resolved_image_with_tag.return_value = f"{image}:{tag}"
     return cfg
 
@@ -601,6 +606,49 @@ class TestRenderTemplatesWithConfigSource:
         # Static asset volume mount is unaffected; only host config overrides
         # are gated by config_source.
         assert "/app/etc/" not in result
+
+    def test_render_mode_rejects_alias_tag_at_current(self, mocker, tmp_path):
+        """Render mode must refuse the @current alias rather than touch the DB."""
+        import pytest as _pytest
+
+        from rots import quadlet
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        cfg.tag = "@current"
+
+        with _pytest.raises(SystemExit) as excinfo:
+            quadlet.render_web_template(cfg, force=True, render_mode=True)
+        assert "alias" in str(excinfo.value).lower()
+        # The DB lookup path must not have been entered.
+        cfg.resolved_image_with_tag.assert_not_called()
+
+    def test_render_mode_rejects_alias_tag_bare_rollback(self, mocker, tmp_path):
+        """Render mode must refuse the bare 'rollback' alias too."""
+        import pytest as _pytest
+
+        from rots import quadlet
+
+        cfg = _make_render_cfg(mocker, tmp_path)
+        cfg.tag = "rollback"
+
+        with _pytest.raises(SystemExit):
+            quadlet.render_web_template(cfg, force=True, render_mode=True)
+        cfg.resolved_image_with_tag.assert_not_called()
+
+    def test_render_mode_does_not_call_resolved_image_with_tag(self, mocker, tmp_path):
+        """With a concrete tag, render mode bypasses cfg.resolved_image_with_tag.
+
+        That method calls db.get_alias for sentinel inputs, which would init
+        the deployment database on disk — render mode forbids host I/O.
+        """
+        from rots import quadlet
+
+        cfg = _make_cfg(mocker, tmp_path, image="ghcr.io/test/image", tag="v1.2.3")
+        cfg.get_existing_config_files.return_value = []
+
+        result = quadlet.render_web_template(cfg, force=True, render_mode=True)
+        assert "Image=ghcr.io/test/image:v1.2.3" in result
+        cfg.resolved_image_with_tag.assert_not_called()
 
     def test_no_secret_lines_when_config_source_is_set(self, mocker, tmp_path):
         """Render mode signal: no Secret= lines when config_source is set.

--- a/uv.lock
+++ b/uv.lock
@@ -1084,7 +1084,7 @@ wheels = [
 
 [[package]]
 name = "rots"
-version = "0.7.2"
+version = "0.7.3"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
## Summary

- Adds `rots instance render <out_dir>` and `rots instance deploy --render <dir>` for offline Quadlet emission. Writes `onetime-{web,worker,scheduler}@.container` (plus `onetime.image` when a registry is configured) under `<dir>/etc/containers/systemd/` with no host I/O — no SSH, no systemd, no DB writes, no healthcheck.
- `--config-source <dir>` controls `Volume=` line emission for the six canonical OneTimeSecret config files. Defaults to `./confext/web/etc/onetimesecret` relative to the working directory.
- Render-to-memory before disk, hard-fail on partial write: render-time errors exit cleanly without touching disk; I/O failures emit to stderr and exit nonzero. Output is byte-stable across reruns (locked in by test). `--host` combined with render raises explicitly.

Closes #67.

## Test plan

- [x] `ruff check`, `ruff format --check`, `pyright` clean
- [x] 222 render-related tests pass (`pytest tests/test_quadlet_render.py tests/commands/instance/test_app.py`)
- [x] Full suite: 2496 passed / 6 skipped (37 unrelated pre-existing podman-sandbox errors on `main`)
- [x] End-to-end smoke: `rots instance render ./out` emits exactly the three `.container` files; `Volume=` lines reference only files present in `--config-source`; no `Secret=` lines; no `extension-release.d/`
- [x] `rots instance render --host fake.example.com ./out` raises and exits 1
- [x] Two consecutive renders produce byte-identical output
- [x] Mocked `render_worker_template` failure exits nonzero with stderr message and leaves no half-populated tree
- [ ] Manual review: confirm `--config-source` ⇄ `30-web-<env>` overlay alignment is documented in the planned `rots instance apply` work (caller's contract, not enforceable here)