### PR TITLE
Use drop-in directory for environment variables

### DIFF
--- a/src/rots/commands/instance/annotations.py
+++ b/src/rots/commands/instance/annotations.py
@@ -98,7 +98,7 @@ ConfigSource = Annotated[
         help=(
             "Directory probed for /etc/onetimesecret/*.yaml files when emitting "
             "Volume= lines under --render. Defaults to "
-            "./confexts/web/etc/onetimesecret relative to the current working "
+            "./confexts/web/__base__/etc/onetimesecret relative to the current working "
             "directory when --render is set."
         ),
     ),

--- a/src/rots/commands/instance/app.py
+++ b/src/rots/commands/instance/app.py
@@ -472,7 +472,7 @@ def _render_quadlets(
     ``onetime-scheduler@.container`` under ``<render_dir>/etc/containers/systemd/``.
     Also emits ``onetime.image`` when ``cfg.registry`` is set.
 
-    ``config_source`` defaults to ``./confexts/web/etc/onetimesecret`` resolved
+    ``config_source`` defaults to ``./confexts/web/__base__/etc/onetimesecret`` resolved
     against the current working directory when not supplied. Both supplied and
     default paths are resolved to absolute paths before being passed to the
     quadlet renderers.
@@ -480,11 +480,11 @@ def _render_quadlets(
     import json as json_mod
 
     if config_source is None:
-        config_source = Path("confexts/web/etc/onetimesecret")
+        config_source = Path("confexts/web/__base__/etc/onetimesecret")
     # Resolve early and fail loud on any path issue. A typo in --config-source
     # would otherwise silently produce zero Volume= overrides — the rendered
     # tree looks fine but is missing the operator's config files. The default
-    # (./confexts/web/etc/onetimesecret) gets the same treatment: render mode
+    # (./confexts/web/__base__/etc/onetimesecret) gets the same treatment: render mode
     # is meant to be explicit about its inputs.
     try:
         config_source = config_source.resolve()
@@ -725,7 +725,7 @@ def deploy(
     The ``--render <dir>`` flag emits Quadlet files to a local directory and
     performs no host I/O (no SSH, no systemd, no DB write). Use ``--config-source``
     to point at a directory of local config files when emitting Volume= lines
-    (defaults to ``./confexts/web/etc/onetimesecret`` when omitted). The standalone
+    (defaults to ``./confexts/web/__base__/etc/onetimesecret`` when omitted). The standalone
     ``rots instance render`` subcommand is preferred for new code; ``--render``
     here is retained for back-compat.
 
@@ -1036,7 +1036,7 @@ def render(
     is configured) under ``<out_dir>/etc/containers/systemd/``. Performs no
     SSH, no systemd, and no DB writes.
 
-    ``--config-source`` defaults to ``./confexts/web/etc/onetimesecret``
+    ``--config-source`` defaults to ``./confexts/web/__base__/etc/onetimesecret``
     relative to the current working directory. Files matching the canonical
     OneTimeSecret config names found in that directory are emitted as
     ``Volume=`` lines in the rendered units.

--- a/src/rots/quadlet.py
+++ b/src/rots/quadlet.py
@@ -4,8 +4,9 @@
 Quadlet template generation for OneTimeSecret containers.
 
 The quadlet template is a systemd unit file that defines how to run
-the container. Secret= lines are generated dynamically based on the
-SECRET_VARIABLE_NAMES defined in the environment file.
+the container. Environment variables are loaded from a drop-in directory
+(/etc/default/onetimesecret.d/*.conf) where lexical order determines
+precedence (00-baseline.conf, 50-host.conf, etc.).
 """
 
 from __future__ import annotations
@@ -18,25 +19,20 @@ from ots_shared.ssh import is_remote as _is_remote
 
 from . import systemd
 from .config import CONFIG_FILES, Config, join_image_tag
-from .environment_file import (
-    generate_quadlet_secret_lines,
-    get_secrets_from_env_file,
-    secret_exists,
-)
 
 if TYPE_CHECKING:
     from ots_shared.ssh import Executor
 
 logger = logging.getLogger(__name__)
 
-# EXIT_PRECOND (3) is intentionally not imported from commands.common to avoid
-# a circular import: quadlet -> commands -> env -> quadlet.
-# The value matches commands.common.EXIT_PRECOND.
-_EXIT_PRECOND = 3
 
-
-# Default environment file path
-DEFAULT_ENV_FILE = Path("/etc/default/onetimesecret")
+# The quadlet templates use a drop-in directory pattern for runtime:
+#   EnvironmentFile=/etc/default/onetimesecret.d/*.conf
+# To simplify back to a single file, change the glob to:
+#   EnvironmentFile=/etc/default/onetimesecret
+DEFAULT_ENV_FILE = Path("/etc/default/onetimesecret.d/00-baseline.conf")
+# Legacy single-file path for reference:
+# DEFAULT_ENV_FILE = Path("/etc/default/onetimesecret")
 
 # Quadlet template with {secrets_section} placeholder for dynamic generation
 WEB_TEMPLATE = """\
@@ -49,10 +45,10 @@ WEB_TEMPLATE = """\
 #    rots image pull --tag <tag>
 #    # Uses credentials from /etc/containers/auth.json
 #
-# 1. Process environment file to create podman secrets:
-#    ots env process /etc/default/onetimesecret
-#    # This reads SECRET_VARIABLE_NAMES from the env file,
-#    # creates podman secrets, and updates the file
+# 1. Environment drop-in directory:
+#    /etc/default/onetimesecret.d/*.conf
+#    Lexical order determines precedence (00-baseline.conf, 50-host.conf).
+#    Baseline ships in confext; per-host overrides layer via OverlayFS.
 #
 # 2. (Optional) Place config overrides in {config_dir}/:
 #    config.yaml, auth.yaml, logging.yaml
@@ -64,14 +60,7 @@ WEB_TEMPLATE = """\
 #   Logs:     journalctl -u onetime-web@7043 -f
 #   Status:   systemctl status onetime-web@7043
 #
-# SECRET ROTATION:
-#   podman secret rm ots_hmac_secret
-#   openssl rand -hex 32 | podman secret create ots_hmac_secret -
-#   systemctl restart onetime-web@7043
-#
 # TROUBLESHOOTING:
-#   List secrets:  podman secret ls
-#   Inspect:       podman secret inspect ots_hmac_secret
 #   Container:     podman exec -it onetime-web-7043 /bin/sh
 
 [Unit]
@@ -100,9 +89,9 @@ PodmanArgs=--log-opt tag=onetime-web-%i
 # Port is derived from instance name: onetime-web@7043 -> PORT=7043
 Environment=PORT=%i
 
-# Infrastructure config (connection strings, log level)
-# Edit this file and restart to apply changes
-EnvironmentFile=/etc/default/onetimesecret
+# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
+# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
+EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 
 {secrets_section}
 
@@ -124,131 +113,21 @@ WantedBy=multi-user.target
 
 
 def get_secrets_section(
-    env_file_path: Path | None = None,
+    env_file_path: Path | None = None,  # noqa: ARG001
     *,
-    force: bool = False,
-    executor: Executor | None = None,
-    render_mode: bool = False,
+    force: bool = False,  # noqa: ARG001
+    executor: Executor | None = None,  # noqa: ARG001
+    render_mode: bool = False,  # noqa: ARG001
 ) -> str:
     """Generate the secrets section for the quadlet template.
 
-    Reads SECRET_VARIABLE_NAMES from the environment file and generates
-    corresponding Secret= directives.
+    Secrets are now managed via the drop-in environment directory
+    (/etc/default/onetimesecret.d/*.conf) rather than probed from
+    SECRET_VARIABLE_NAMES. This function returns a placeholder comment.
 
-    Args:
-        env_file_path: Path to environment file (defaults to /etc/default/onetimesecret)
-        force: If True, allow deployment even when secrets are not configured.
-               This will produce a quadlet with no Secret= lines; the application
-               will likely fail at runtime without its required secrets.
-        render_mode: If True, suppress all Secret= lines and skip env-file probing.
-               Used by `--render` to emit quadlet files locally with no host I/O.
-
-    Returns:
-        Multi-line string with Secret= directives
-
-    Raises:
-        SystemExit(3): When env file is missing or no secrets are configured,
-            unless force=True.  Exit code 3 (precondition not met) signals to
-            CI pipelines that no destructive action was taken — the required
-            configuration was simply absent.
+    The signature is preserved for API compatibility with existing callers.
     """
-    if render_mode:
-        return "# No secrets emitted under --render"
-
-    env_path = env_file_path or DEFAULT_ENV_FILE
-
-    if executor is not None and _is_remote(executor):
-        result = executor.run(["test", "-f", str(env_path)])
-        env_exists = result.ok
-    else:
-        env_exists = env_path.exists()
-
-    if not env_exists:
-        msg = (
-            f"Environment file not found: {env_path}\n"
-            "\n"
-            "The environment file must exist before deploying. It defines which\n"
-            "variables are secrets and provides infrastructure configuration.\n"
-            "\n"
-            "To create it:\n"
-            f"  sudo cp /usr/share/doc/rots/onetimesecret.env.example {env_path}\n"
-            "  # or: ots init  (scaffolds the file from template)\n"
-            "\n"
-            "Then configure secrets:\n"
-            f"  sudo vi {env_path}  # set SECRET_VARIABLE_NAMES and secret values\n"
-            "  sudo ots env process  # moves secret values into podman secret store\n"
-            "\n"
-            "Use --force to skip this check and write a quadlet with no secrets\n"
-            "(the application will fail at runtime without required secrets)."
-        )
-        if force:
-            logger.warning(msg)
-            return "# No secrets configured (env file not found - deployed with --force)"
-        logger.error(msg)
-        raise SystemExit(_EXIT_PRECOND)
-
-    secrets = get_secrets_from_env_file(env_path, executor=executor)
-    if not secrets:
-        msg = (
-            f"No secrets configured in {env_path}\n"
-            "\n"
-            "SECRET_VARIABLE_NAMES is not set or is empty. The application requires\n"
-            "secrets (AUTH_SECRET, SECRET, SESSION_SECRET, etc.) to function.\n"
-            "\n"
-            "To configure secrets:\n"
-            f"  sudo vi {env_path}  # set SECRET_VARIABLE_NAMES and secret values\n"
-            "  sudo ots env process  # moves secret values into podman secret store\n"
-            "\n"
-            "Use --force to skip this check and write a quadlet with no secrets\n"
-            "(the application will fail at runtime without required secrets)."
-        )
-        if force:
-            logger.warning(msg)
-            return "# No secrets configured (SECRET_VARIABLE_NAMES not set - deployed with --force)"
-        logger.error(msg)
-        raise SystemExit(_EXIT_PRECOND)
-
-    # Defense-in-depth: only include secrets that actually exist as podman secrets.
-    # A secret may have been processed in the env file but later deleted from the
-    # podman secret store. Warn rather than letting podman fail at container start.
-    verified = []
-    missing = []
-    for spec in secrets:
-        if secret_exists(spec.secret_name, executor=executor):
-            verified.append(spec)
-        else:
-            missing.append(spec)
-
-    if missing:
-        names = ", ".join(s.secret_name for s in missing)
-        logger.warning(
-            f"Podman secrets not found: {names}\n"
-            "These secrets are listed in SECRET_VARIABLE_NAMES but don't exist in\n"
-            "the podman secret store. Run 'ots env process' to create them.\n"
-            "Skipping their Secret= lines in the quadlet."
-        )
-
-    if not verified:
-        msg = (
-            "No podman secrets found for any configured secret variable.\n"
-            "\n"
-            f"Secrets listed in {env_path} (SECRET_VARIABLE_NAMES) have not been\n"
-            "created in the podman secret store. The application will fail at\n"
-            "runtime without them.\n"
-            "\n"
-            "To create podman secrets:\n"
-            "  sudo ots env process  # reads env file and creates podman secrets\n"
-            "\n"
-            "Use --force to skip this check and write a quadlet with no secrets\n"
-            "(the application will fail at runtime without required secrets)."
-        )
-        if force:
-            logger.warning(msg)
-            return "# No secrets configured (no podman secrets found - deployed with --force)"
-        logger.error(msg)
-        raise SystemExit(_EXIT_PRECOND)
-
-    return generate_quadlet_secret_lines(verified)
+    return "# Secrets loaded via environment drop-in directory"
 
 
 def get_config_volumes_section(
@@ -567,10 +446,10 @@ WORKER_TEMPLATE = """\
 #    rots image pull --tag <tag>
 #    # Uses credentials from /etc/containers/auth.json
 #
-# 1. Process environment file to create podman secrets:
-#    ots env process /etc/default/onetimesecret
-#    # This reads SECRET_VARIABLE_NAMES from the env file,
-#    # creates podman secrets, and updates the file
+# 1. Environment drop-in directory:
+#    /etc/default/onetimesecret.d/*.conf
+#    Lexical order determines precedence (00-baseline.conf, 50-host.conf).
+#    Baseline ships in confext; per-host overrides layer via OverlayFS.
 #
 # 2. (Optional) Place config overrides in {config_dir}/:
 #    config.yaml, auth.yaml, logging.yaml
@@ -586,14 +465,7 @@ WORKER_TEMPLATE = """\
 #   Numeric: onetime-worker@1, onetime-worker@2
 #   Named:   onetime-worker@billing, onetime-worker@emails
 #
-# SECRET ROTATION:
-#   podman secret rm ots_hmac_secret
-#   openssl rand -hex 32 | podman secret create ots_hmac_secret -
-#   systemctl restart onetime-worker@1
-#
 # TROUBLESHOOTING:
-#   List secrets:  podman secret ls
-#   Inspect:       podman secret inspect ots_hmac_secret
 #   Container:     podman exec -it onetime-worker-1 /bin/sh
 
 [Unit]
@@ -618,9 +490,9 @@ PodmanArgs=--log-opt tag=onetime-worker-%i
 # Worker ID is derived from instance name: onetime-worker@1 -> WORKER_ID=1
 Environment=WORKER_ID=%i
 
-# Infrastructure config (connection strings, log level)
-# Edit this file and restart to apply changes
-EnvironmentFile=/etc/default/onetimesecret
+# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
+# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
+EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 
 {secrets_section}
 
@@ -679,10 +551,10 @@ SCHEDULER_TEMPLATE = """\
 #    rots image pull --tag <tag>
 #    # Uses credentials from /etc/containers/auth.json
 #
-# 1. Process environment file to create podman secrets:
-#    ots env process /etc/default/onetimesecret
-#    # This reads SECRET_VARIABLE_NAMES from the env file,
-#    # creates podman secrets, and updates the file
+# 1. Environment drop-in directory:
+#    /etc/default/onetimesecret.d/*.conf
+#    Lexical order determines precedence (00-baseline.conf, 50-host.conf).
+#    Baseline ships in confext; per-host overrides layer via OverlayFS.
 #
 # 2. (Optional) Place config overrides in {config_dir}/:
 #    config.yaml, auth.yaml, logging.yaml
@@ -698,14 +570,7 @@ SCHEDULER_TEMPLATE = """\
 #   Named:   onetime-scheduler@main, onetime-scheduler@cron
 #   Numeric: onetime-scheduler@1
 #
-# SECRET ROTATION:
-#   podman secret rm ots_hmac_secret
-#   openssl rand -hex 32 | podman secret create ots_hmac_secret -
-#   systemctl restart onetime-scheduler@main
-#
 # TROUBLESHOOTING:
-#   List secrets:  podman secret ls
-#   Inspect:       podman secret inspect ots_hmac_secret
 #   Container:     podman exec -it onetime-scheduler-main /bin/sh
 
 [Unit]
@@ -730,9 +595,9 @@ PodmanArgs=--log-opt tag=onetime-scheduler-%i
 # Scheduler ID is derived from instance name: onetime-scheduler@main -> SCHEDULER_ID=main
 Environment=SCHEDULER_ID=%i
 
-# Infrastructure config (connection strings, log level)
-# Edit this file and restart to apply changes
-EnvironmentFile=/etc/default/onetimesecret
+# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
+# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
+EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 
 {secrets_section}
 

--- a/src/rots/quadlet.py
+++ b/src/rots/quadlet.py
@@ -77,6 +77,11 @@ RestartSec=5
 # Caddy upstream health checks (HealthInterval=30s) will detect the
 # removed backend and stop routing new requests within one check cycle.
 TimeoutStopSec=30
+# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
+# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
+# NOTE: EnvironmentFile must be in [Service] for systemd glob expansion (250+).
+# Quadlet's [Container] section passes --env-file to podman, which doesn't glob.
+EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 {resource_limits_section}
 [Container]
 ContainerName=onetime-web-%i
@@ -88,10 +93,6 @@ PodmanArgs=--log-opt tag=onetime-web-%i
 
 # Port is derived from instance name: onetime-web@7043 -> PORT=7043
 Environment=PORT=%i
-
-# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
-# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
-EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 
 {secrets_section}
 
@@ -125,7 +126,14 @@ def get_secrets_section(
     (/etc/default/onetimesecret.d/*.conf) rather than probed from
     SECRET_VARIABLE_NAMES. This function returns a placeholder comment.
 
-    The signature is preserved for API compatibility with existing callers.
+    Args:
+        env_file_path: Ignored. Preserved for API compatibility.
+        force: Ignored. Preserved for API compatibility.
+        executor: Ignored. Preserved for API compatibility.
+        render_mode: Ignored. Preserved for API compatibility.
+
+    Returns:
+        A comment string indicating secrets are loaded via drop-in directory.
     """
     return "# Secrets loaded via environment drop-in directory"
 
@@ -478,6 +486,10 @@ Restart=on-failure
 RestartSec=5
 # Allow time for graceful job completion on stop
 TimeoutStopSec=90
+# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
+# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
+# NOTE: EnvironmentFile must be in [Service] for systemd glob expansion (250+).
+EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 {resource_limits_section}
 [Container]
 ContainerName=onetime-worker-%i
@@ -489,10 +501,6 @@ PodmanArgs=--log-opt tag=onetime-worker-%i
 
 # Worker ID is derived from instance name: onetime-worker@1 -> WORKER_ID=1
 Environment=WORKER_ID=%i
-
-# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
-# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
-EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 
 {secrets_section}
 
@@ -583,6 +591,10 @@ Restart=on-failure
 RestartSec=5
 # Allow time for graceful job completion on stop
 TimeoutStopSec=60
+# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
+# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
+# NOTE: EnvironmentFile must be in [Service] for systemd glob expansion (250+).
+EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 {resource_limits_section}
 [Container]
 ContainerName=onetime-scheduler-%i
@@ -594,10 +606,6 @@ PodmanArgs=--log-opt tag=onetime-scheduler-%i
 
 # Scheduler ID is derived from instance name: onetime-scheduler@main -> SCHEDULER_ID=main
 Environment=SCHEDULER_ID=%i
-
-# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
-# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
-EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 
 {secrets_section}
 

--- a/src/rots/quadlet.py
+++ b/src/rots/quadlet.py
@@ -4,9 +4,9 @@
 Quadlet template generation for OneTimeSecret containers.
 
 The quadlet template is a systemd unit file that defines how to run
-the container. Environment variables are loaded from a drop-in directory
-(/etc/default/onetimesecret.d/*.conf) where lexical order determines
-precedence (00-baseline.conf, 50-host.conf, etc.).
+the container. Environment variables are loaded via a two-file layered
+pattern: /etc/default/onetimesecret (baseline, required) plus
+/etc/default/onetimesecret.local (host overrides, optional).
 """
 
 from __future__ import annotations
@@ -118,9 +118,9 @@ def get_secrets_section(
 ) -> str:
     """Generate the secrets section for the quadlet template.
 
-    Secrets are now managed via the drop-in environment directory
-    (/etc/default/onetimesecret.d/*.conf) rather than probed from
-    SECRET_VARIABLE_NAMES. This function returns a placeholder comment.
+    Secrets are now managed via the two-file layered EnvironmentFile
+    pattern rather than probed from SECRET_VARIABLE_NAMES. This function
+    returns a placeholder comment.
 
     Args:
         env_file_path: Ignored. Preserved for API compatibility.
@@ -129,9 +129,9 @@ def get_secrets_section(
         render_mode: Ignored. Preserved for API compatibility.
 
     Returns:
-        A comment string indicating secrets are loaded via drop-in directory.
+        A comment string indicating secrets are loaded via EnvironmentFile.
     """
-    return "# Secrets loaded via environment drop-in directory"
+    return "# Secrets loaded via EnvironmentFile layered pattern"
 
 
 def get_config_volumes_section(

--- a/src/rots/quadlet.py
+++ b/src/rots/quadlet.py
@@ -26,13 +26,11 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-# The quadlet templates use a drop-in directory pattern for runtime:
-#   EnvironmentFile=/etc/default/onetimesecret.d/*.conf
-# To simplify back to a single file, change the glob to:
-#   EnvironmentFile=/etc/default/onetimesecret
-DEFAULT_ENV_FILE = Path("/etc/default/onetimesecret.d/00-baseline.conf")
-# Legacy single-file path for reference:
-# DEFAULT_ENV_FILE = Path("/etc/default/onetimesecret")
+# Environment files use a two-file layered pattern:
+#   EnvironmentFile=/etc/default/onetimesecret        (baseline, confext)
+#   EnvironmentFile=-/etc/default/onetimesecret.local (optional host overrides)
+# The "-" prefix makes .local optional — missing file is not an error.
+DEFAULT_ENV_FILE = Path("/etc/default/onetimesecret")
 
 # Quadlet template with {secrets_section} placeholder for dynamic generation
 WEB_TEMPLATE = """\
@@ -45,10 +43,9 @@ WEB_TEMPLATE = """\
 #    rots image pull --tag <tag>
 #    # Uses credentials from /etc/containers/auth.json
 #
-# 1. Environment drop-in directory:
-#    /etc/default/onetimesecret.d/*.conf
-#    Lexical order determines precedence (00-baseline.conf, 50-host.conf).
-#    Baseline ships in confext; per-host overrides layer via OverlayFS.
+# 1. Environment files (layered):
+#    /etc/default/onetimesecret       - baseline config (required, via confext)
+#    /etc/default/onetimesecret.local - host overrides (optional)
 #
 # 2. (Optional) Place config overrides in {config_dir}/:
 #    config.yaml, auth.yaml, logging.yaml
@@ -77,11 +74,6 @@ RestartSec=5
 # Caddy upstream health checks (HealthInterval=30s) will detect the
 # removed backend and stop routing new requests within one check cycle.
 TimeoutStopSec=30
-# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
-# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
-# NOTE: EnvironmentFile must be in [Service] for systemd glob expansion (250+).
-# Quadlet's [Container] section passes --env-file to podman, which doesn't glob.
-EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 {resource_limits_section}
 [Container]
 ContainerName=onetime-web-%i
@@ -93,6 +85,10 @@ PodmanArgs=--log-opt tag=onetime-web-%i
 
 # Port is derived from instance name: onetime-web@7043 -> PORT=7043
 Environment=PORT=%i
+
+# Infrastructure config: baseline (confext) + optional host overrides
+EnvironmentFile=/etc/default/onetimesecret
+EnvironmentFile=-/etc/default/onetimesecret.local
 
 {secrets_section}
 
@@ -454,10 +450,9 @@ WORKER_TEMPLATE = """\
 #    rots image pull --tag <tag>
 #    # Uses credentials from /etc/containers/auth.json
 #
-# 1. Environment drop-in directory:
-#    /etc/default/onetimesecret.d/*.conf
-#    Lexical order determines precedence (00-baseline.conf, 50-host.conf).
-#    Baseline ships in confext; per-host overrides layer via OverlayFS.
+# 1. Environment files (layered):
+#    /etc/default/onetimesecret       - baseline config (required, via confext)
+#    /etc/default/onetimesecret.local - host overrides (optional)
 #
 # 2. (Optional) Place config overrides in {config_dir}/:
 #    config.yaml, auth.yaml, logging.yaml
@@ -486,10 +481,6 @@ Restart=on-failure
 RestartSec=5
 # Allow time for graceful job completion on stop
 TimeoutStopSec=90
-# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
-# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
-# NOTE: EnvironmentFile must be in [Service] for systemd glob expansion (250+).
-EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 {resource_limits_section}
 [Container]
 ContainerName=onetime-worker-%i
@@ -501,6 +492,10 @@ PodmanArgs=--log-opt tag=onetime-worker-%i
 
 # Worker ID is derived from instance name: onetime-worker@1 -> WORKER_ID=1
 Environment=WORKER_ID=%i
+
+# Infrastructure config: baseline (confext) + optional host overrides
+EnvironmentFile=/etc/default/onetimesecret
+EnvironmentFile=-/etc/default/onetimesecret.local
 
 {secrets_section}
 
@@ -559,10 +554,9 @@ SCHEDULER_TEMPLATE = """\
 #    rots image pull --tag <tag>
 #    # Uses credentials from /etc/containers/auth.json
 #
-# 1. Environment drop-in directory:
-#    /etc/default/onetimesecret.d/*.conf
-#    Lexical order determines precedence (00-baseline.conf, 50-host.conf).
-#    Baseline ships in confext; per-host overrides layer via OverlayFS.
+# 1. Environment files (layered):
+#    /etc/default/onetimesecret       - baseline config (required, via confext)
+#    /etc/default/onetimesecret.local - host overrides (optional)
 #
 # 2. (Optional) Place config overrides in {config_dir}/:
 #    config.yaml, auth.yaml, logging.yaml
@@ -591,10 +585,6 @@ Restart=on-failure
 RestartSec=5
 # Allow time for graceful job completion on stop
 TimeoutStopSec=60
-# Infrastructure config via drop-in directory (lexical order: 00-baseline, 50-host, etc.)
-# Baseline ships in confext; per-host overrides layer on top via OverlayFS merge
-# NOTE: EnvironmentFile must be in [Service] for systemd glob expansion (250+).
-EnvironmentFile=/etc/default/onetimesecret.d/*.conf
 {resource_limits_section}
 [Container]
 ContainerName=onetime-scheduler-%i
@@ -606,6 +596,10 @@ PodmanArgs=--log-opt tag=onetime-scheduler-%i
 
 # Scheduler ID is derived from instance name: onetime-scheduler@main -> SCHEDULER_ID=main
 Environment=SCHEDULER_ID=%i
+
+# Infrastructure config: baseline (confext) + optional host overrides
+EnvironmentFile=/etc/default/onetimesecret
+EnvironmentFile=-/etc/default/onetimesecret.local
 
 {secrets_section}
 

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -3267,7 +3267,7 @@ class TestDeployRender:
         so the render path doesn't trip the alias guard.
 
         Render mode also validates ``--config-source`` exists. The default
-        is ``./confexts/web/etc/onetimesecret`` relative to cwd, so chdir
+        is ``./confexts/web/__base__/etc/onetimesecret`` relative to cwd, so chdir
         into a scratch dir and create the scaffold so tests that don't
         supply ``config_source`` pass validation.
         """
@@ -3276,7 +3276,7 @@ class TestDeployRender:
         monkeypatch.setenv("TAG", "v0.24.0")
         scratch = tmp_path / "_scratch"
         scratch.mkdir()
-        (scratch / "confexts" / "web" / "etc" / "onetimesecret").mkdir(parents=True)
+        (scratch / "confexts" / "web" / "__base__" / "etc" / "onetimesecret").mkdir(parents=True)
         monkeypatch.chdir(scratch)
 
     def _patch_render_safety_nets(self, mocker):
@@ -3453,16 +3453,17 @@ class TestDeployRender:
             context.host_var.reset(token)
 
     def test_render_defaults_config_source_to_confexts_web(self, mocker, monkeypatch, tmp_path):
-        """When config_source=None, deploy --render defaults to ./confexts/web/etc/onetimesecret.
+        """When config_source=None, deploy --render uses __base__/etc default.
 
-        Resolving the default against cwd (rather than an absolute hard-coded
-        path) lets operators run `rots instance deploy --render ./out` from
-        their checkout without flag soup.
+        Default is ./confexts/web/__base__/etc/onetimesecret. Resolving the
+        default against cwd (rather than an absolute hard-coded path) lets
+        operators run `rots instance deploy --render ./out` from their checkout
+        without flag soup.
         """
         self._patch_render_safety_nets(mocker)
         monkeypatch.chdir(tmp_path)
 
-        default_src = tmp_path / "confexts" / "web" / "etc" / "onetimesecret"
+        default_src = tmp_path / "confexts" / "web" / "__base__" / "etc" / "onetimesecret"
         default_src.mkdir(parents=True)
         (default_src / "config.yaml").write_text("# placeholder\n")
 
@@ -3475,7 +3476,7 @@ class TestDeployRender:
             out_dir / "etc" / "containers" / "systemd" / "onetime-web@.container"
         ).read_text()
 
-        # The default config_source resolved to <cwd>/confexts/web/etc/onetimesecret,
+        # The default config_source resolved to <cwd>/confexts/web/__base__/etc/onetimesecret,
         # where config.yaml exists, so a Volume= line for it must be rendered.
         assert ":/app/etc/config.yaml:ro" in web_unit
 
@@ -3551,7 +3552,7 @@ class TestInstanceRenderCommand:
         so the render path doesn't trip the alias guard.
 
         Render mode also validates ``--config-source`` exists. The default
-        is ``./confexts/web/etc/onetimesecret`` relative to cwd, so chdir
+        is ``./confexts/web/__base__/etc/onetimesecret`` relative to cwd, so chdir
         into a scratch dir and create the scaffold so tests that don't
         supply ``config_source`` pass validation.
         """
@@ -3560,7 +3561,7 @@ class TestInstanceRenderCommand:
         monkeypatch.setenv("TAG", "v0.24.0")
         scratch = tmp_path / "_scratch"
         scratch.mkdir()
-        (scratch / "confexts" / "web" / "etc" / "onetimesecret").mkdir(parents=True)
+        (scratch / "confexts" / "web" / "__base__" / "etc" / "onetimesecret").mkdir(parents=True)
         monkeypatch.chdir(scratch)
 
     def _patch_render_safety_nets(self, mocker):
@@ -3694,11 +3695,11 @@ class TestInstanceRenderCommand:
         assert sentinel.read_text() == "# operator file\n"
 
     def test_render_defaults_config_source_to_confexts_web(self, mocker, monkeypatch, tmp_path):
-        """When --config-source omitted, defaults to ./confexts/web/etc/onetimesecret."""
+        """When --config-source omitted, defaults to ./confexts/web/__base__/etc/onetimesecret."""
         self._patch_render_safety_nets(mocker)
         monkeypatch.chdir(tmp_path)
 
-        default_src = tmp_path / "confexts" / "web" / "etc" / "onetimesecret"
+        default_src = tmp_path / "confexts" / "web" / "__base__" / "etc" / "onetimesecret"
         default_src.mkdir(parents=True)
         (default_src / "config.yaml").write_text("# placeholder\n")
 
@@ -3713,12 +3714,12 @@ class TestInstanceRenderCommand:
             out_dir / "etc" / "containers" / "systemd" / "onetime-web@.container"
         ).read_text()
 
-        # The default config_source resolved to <cwd>/confexts/web/etc/onetimesecret,
+        # The default config_source resolved to <cwd>/confexts/web/__base__/etc/onetimesecret,
         # where config.yaml exists, so a Volume= line for it must be rendered.
         assert ":/app/etc/config.yaml:ro" in web_unit
 
     def test_render_explicit_config_source_takes_precedence(self, mocker, tmp_path):
-        """`--config-source <dir>` overrides the default ./confexts/web/etc/onetimesecret."""
+        """`--config-source <dir>` overrides the __base__/etc/onetimesecret default."""
         self._patch_render_safety_nets(mocker)
 
         out_dir = tmp_path / "out"
@@ -3910,7 +3911,7 @@ class TestInstanceRenderCommand:
     def test_render_default_config_source_missing_exits(
         self, mocker, monkeypatch, capsys, tmp_path
     ):
-        """The default ./confexts/web/etc/onetimesecret must exist when not overridden.
+        """The default ./confexts/web/__base__/etc/onetimesecret must exist when not overridden.
 
         Render mode is explicit about its inputs; if the operator runs it from
         a directory without the scaffold, fail loud rather than silently emit
@@ -3959,7 +3960,7 @@ class TestInstanceRenderCommand:
         # The autouse fixture chdir'd into a scratch dir; switch into one we
         # control so we can pass a relative path.
         work = tmp_path / "work"
-        (work / "confexts" / "web" / "etc" / "onetimesecret").mkdir(parents=True)
+        (work / "confexts" / "web" / "__base__" / "etc" / "onetimesecret").mkdir(parents=True)
         monkeypatch.chdir(work)
 
         from rots.commands.instance.app import render as render_cmd
@@ -4147,13 +4148,15 @@ class TestInstanceRenderCommand:
 def _stage_default_confexts(monkeypatch, tmp_path):
     """Helper: chdir into a scratch dir staged with the default config_source.
 
-    Render mode validates ``./confexts/web/etc/onetimesecret`` exists when
+    Render mode validates ``./confexts/web/__base__/etc/onetimesecret`` exists when
     no ``--config-source`` is supplied. Tests that don't pass an explicit
     config_source need the scaffold staged.
     """
     scratch = tmp_path / "_scratch_confexts_supp"
     scratch.mkdir(exist_ok=True)
-    (scratch / "confexts" / "web" / "etc" / "onetimesecret").mkdir(parents=True, exist_ok=True)
+    (scratch / "confexts" / "web" / "__base__" / "etc" / "onetimesecret").mkdir(
+        parents=True, exist_ok=True
+    )
     monkeypatch.chdir(scratch)
     return scratch
 

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -3500,22 +3500,12 @@ class TestDeployRender:
         assert ":/app/etc/config.yaml:ro" in web_unit
 
     def test_render_emits_no_secret_lines(self, mocker, tmp_path):
-        """No `Secret=` lines must appear in any rendered file under --render."""
-        self._patch_render_safety_nets(mocker)
-        # Make secrets visible at the env-file level so a regression that
-        # re-enables Secret= emission would surface.
-        from rots.environment_file import SecretSpec
+        """No `Secret=` lines must appear in any rendered file under --render.
 
-        env_file = tmp_path / "envfile"
-        env_file.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET\n")
-        mocker.patch("rots.quadlet.DEFAULT_ENV_FILE", env_file)
-        mocker.patch("rots.quadlet.secret_exists", return_value=True)
-        mocker.patch(
-            "rots.quadlet.get_secrets_from_env_file",
-            return_value=[
-                SecretSpec(env_var_name="AUTH_SECRET", secret_name="ots_auth_secret"),
-            ],
-        )
+        Secrets are now loaded via environment drop-in directory instead of
+        being enumerated as Secret= directives in the quadlet file.
+        """
+        self._patch_render_safety_nets(mocker)
 
         out_dir = tmp_path / "out"
         out_dir.mkdir()
@@ -3532,6 +3522,8 @@ class TestDeployRender:
             assert "Secret=" not in content, (
                 f"{unit_name} unexpectedly contains a Secret= directive: {content!r}"
             )
+            # Verify drop-in comment is present
+            assert "Secrets loaded via environment drop-in directory" in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -3503,7 +3503,7 @@ class TestDeployRender:
     def test_render_emits_no_secret_lines(self, mocker, tmp_path):
         """No `Secret=` lines must appear in any rendered file under --render.
 
-        Secrets are now loaded via environment drop-in directory instead of
+        Secrets are now loaded via EnvironmentFile layered pattern instead of
         being enumerated as Secret= directives in the quadlet file.
         """
         self._patch_render_safety_nets(mocker)
@@ -3523,8 +3523,8 @@ class TestDeployRender:
             assert "Secret=" not in content, (
                 f"{unit_name} unexpectedly contains a Secret= directive: {content!r}"
             )
-            # Verify drop-in comment is present
-            assert "Secrets loaded via environment drop-in directory" in content
+            # Verify EnvironmentFile pattern comment is present
+            assert "Secrets loaded via EnvironmentFile layered pattern" in content
 
 
 # ---------------------------------------------------------------------------

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,8 +7,6 @@ that may not exist on dev machines. Tests that need specific secret
 behavior should override with their own mocker.patch().
 """
 
-import pytest
-
 # Re-export handler fixtures (postgres_service, valkey_service,
 # in_process_bus, fake_env_file, postgres_db, valkey_acl_prefix) so sibling
 # test directories (notably ``tests/commands/env``) can consume them without
@@ -19,19 +17,6 @@ import pytest
 pytest_plugins = ["tests.commands.sidecar.handlers._fixtures"]
 
 
-@pytest.fixture(autouse=True)
-def _mock_secret_exists(mocker):
-    """Prevent podman subprocess calls during template generation.
-
-    quadlet.get_secrets_section() calls secret_exists() which runs
-    `podman secret exists <name>` via subprocess. This fails on machines
-    without podman installed (e.g., macOS dev environments).
-
-    Returns False by default (no secrets exist). Tests that exercise
-    secret behavior already provide their own mock with return_value=True
-    or a side_effect — those override this autouse fixture.
-    """
-    return mocker.patch(
-        "rots.quadlet.secret_exists",
-        return_value=False,
-    )
+# The _mock_secret_exists fixture was removed when SECRET_VARIABLE_NAMES
+# probing was replaced by drop-in environment directories. The quadlet module
+# no longer calls secret_exists() during template generation.

--- a/tests/test_quadlet.py
+++ b/tests/test_quadlet.py
@@ -93,7 +93,8 @@ class TestContainerTemplate:
 
         content = cfg.web_template_path.read_text()
         # Uses fixed path for infrastructure config (not per-instance)
-        assert "EnvironmentFile=/etc/default/onetimesecret.d/*.conf" in content
+        assert "EnvironmentFile=/etc/default/onetimesecret" in content
+        assert "EnvironmentFile=-/etc/default/onetimesecret.local" in content
 
     def test_write_web_template_includes_syslog_tag(self, mocker, tmp_path):
         """Container quadlet should include syslog tag for unified log filtering."""
@@ -480,7 +481,8 @@ class TestWorkerTemplate:
         quadlet.write_worker_template(cfg, force=True)
 
         content = cfg.worker_template_path.read_text()
-        assert "EnvironmentFile=/etc/default/onetimesecret.d/*.conf" in content
+        assert "EnvironmentFile=/etc/default/onetimesecret" in content
+        assert "EnvironmentFile=-/etc/default/onetimesecret.local" in content
 
     def test_write_worker_template_includes_config_volume(self, mocker, tmp_path):
         """Worker quadlet should mount per-file config volumes."""
@@ -739,7 +741,8 @@ class TestSchedulerTemplate:
         quadlet.write_scheduler_template(cfg, force=True)
 
         content = cfg.scheduler_template_path.read_text()
-        assert "EnvironmentFile=/etc/default/onetimesecret.d/*.conf" in content
+        assert "EnvironmentFile=/etc/default/onetimesecret" in content
+        assert "EnvironmentFile=-/etc/default/onetimesecret.local" in content
 
     def test_write_scheduler_template_includes_config_volume(self, mocker, tmp_path):
         """Scheduler quadlet should mount per-file config volumes."""

--- a/tests/test_quadlet.py
+++ b/tests/test_quadlet.py
@@ -93,7 +93,7 @@ class TestContainerTemplate:
 
         content = cfg.web_template_path.read_text()
         # Uses fixed path for infrastructure config (not per-instance)
-        assert "EnvironmentFile=/etc/default/onetimesecret" in content
+        assert "EnvironmentFile=/etc/default/onetimesecret.d/*.conf" in content
 
     def test_write_web_template_includes_syslog_tag(self, mocker, tmp_path):
         """Container quadlet should include syslog tag for unified log filtering."""
@@ -139,35 +139,8 @@ class TestContainerTemplate:
         assert f"Volume={config_dir}/logging.yaml:/app/etc/logging.yaml:ro" in content
         assert "Volume=static_assets:/app/public:ro" in content
 
-    def test_write_web_template_includes_podman_secrets_from_env_file(self, mocker, tmp_path):
-        """Container quadlet should include Secret= directives from env file."""
-        mocker.patch("rots.quadlet.systemd.daemon_reload")
-        mocker.patch("rots.quadlet.secret_exists", return_value=True)
-        from rots import quadlet
-        from rots.config import Config
-
-        # Create an env file with SECRET_VARIABLE_NAMES
-        env_file = tmp_path / "onetimesecret.env"
-        env_file.write_text(
-            "SECRET_VARIABLE_NAMES=API_KEY,DB_PASSWORD\n"
-            "_API_KEY=ots_api_key\n"
-            "_DB_PASSWORD=ots_db_password\n"
-        )
-
-        cfg = Config(
-            web_template_path=tmp_path / "onetime-web@.container",
-            var_dir=tmp_path / "var",
-        )
-
-        quadlet.write_web_template(cfg, env_file_path=env_file, force=True)
-
-        content = cfg.web_template_path.read_text()
-        # Secrets generated from env file's SECRET_VARIABLE_NAMES
-        assert "Secret=ots_api_key,type=env,target=API_KEY" in content
-        assert "Secret=ots_db_password,type=env,target=DB_PASSWORD" in content
-
-    def test_write_web_template_no_env_file_shows_comment(self, mocker, tmp_path):
-        """Container quadlet should show comment when no env file exists."""
+    def test_write_web_template_secrets_section_comment(self, mocker, tmp_path):
+        """Container quadlet should include drop-in directory comment for secrets."""
         mocker.patch("rots.quadlet.systemd.daemon_reload")
         from rots import quadlet
         from rots.config import Config
@@ -177,31 +150,11 @@ class TestContainerTemplate:
             var_dir=tmp_path / "var",
         )
 
-        # Pass a non-existent env file path
-        quadlet.write_web_template(cfg, env_file_path=tmp_path / "nonexistent.env", force=True)
+        quadlet.write_web_template(cfg, force=True)
 
         content = cfg.web_template_path.read_text()
-        assert "No secrets configured" in content
-
-    def test_write_web_template_no_secret_names_shows_comment(self, mocker, tmp_path):
-        """Container quadlet should show comment when no SECRET_VARIABLE_NAMES."""
-        mocker.patch("rots.quadlet.systemd.daemon_reload")
-        from rots import quadlet
-        from rots.config import Config
-
-        # Create an env file without SECRET_VARIABLE_NAMES
-        env_file = tmp_path / "onetimesecret.env"
-        env_file.write_text("REDIS_URL=redis://localhost\n")
-
-        cfg = Config(
-            web_template_path=tmp_path / "onetime-web@.container",
-            var_dir=tmp_path / "var",
-        )
-
-        quadlet.write_web_template(cfg, env_file_path=env_file, force=True)
-
-        content = cfg.web_template_path.read_text()
-        assert "No secrets configured" in content
+        # Secrets are now loaded via environment drop-in directory
+        assert "Secrets loaded via environment drop-in directory" in content
 
     def test_write_web_template_includes_systemd_dependencies(self, mocker, tmp_path):
         """Container quadlet should have proper systemd dependencies."""
@@ -527,7 +480,7 @@ class TestWorkerTemplate:
         quadlet.write_worker_template(cfg, force=True)
 
         content = cfg.worker_template_path.read_text()
-        assert "EnvironmentFile=/etc/default/onetimesecret" in content
+        assert "EnvironmentFile=/etc/default/onetimesecret.d/*.conf" in content
 
     def test_write_worker_template_includes_config_volume(self, mocker, tmp_path):
         """Worker quadlet should mount per-file config volumes."""
@@ -554,31 +507,21 @@ class TestWorkerTemplate:
         assert f"Volume={config_dir}/auth.yaml:/app/etc/auth.yaml:ro" in content
         assert f"Volume={config_dir}/logging.yaml:/app/etc/logging.yaml:ro" in content
 
-    def test_write_worker_template_includes_secrets(self, mocker, tmp_path):
-        """Worker quadlet should include Secret= directives from env file."""
+    def test_write_worker_template_secrets_section_comment(self, mocker, tmp_path):
+        """Worker quadlet should include drop-in directory comment for secrets."""
         mocker.patch("rots.quadlet.systemd.daemon_reload")
-        mocker.patch("rots.quadlet.secret_exists", return_value=True)
         from rots import quadlet
         from rots.config import Config
-
-        # Create an env file with SECRET_VARIABLE_NAMES
-        env_file = tmp_path / "onetimesecret.env"
-        env_file.write_text(
-            "SECRET_VARIABLE_NAMES=API_KEY,DB_PASSWORD\n"
-            "_API_KEY=ots_api_key\n"
-            "_DB_PASSWORD=ots_db_password\n"
-        )
 
         cfg = Config(
             worker_template_path=tmp_path / "onetime-worker@.container",
             var_dir=tmp_path / "var",
         )
 
-        quadlet.write_worker_template(cfg, env_file_path=env_file, force=True)
+        quadlet.write_worker_template(cfg, force=True)
 
         content = cfg.worker_template_path.read_text()
-        assert "Secret=ots_api_key,type=env,target=API_KEY" in content
-        assert "Secret=ots_db_password,type=env,target=DB_PASSWORD" in content
+        assert "Secrets loaded via environment drop-in directory" in content
 
     def test_write_worker_template_reloads_daemon(self, mocker, tmp_path):
         """write_worker_template should reload systemd daemon after writing."""
@@ -796,7 +739,7 @@ class TestSchedulerTemplate:
         quadlet.write_scheduler_template(cfg, force=True)
 
         content = cfg.scheduler_template_path.read_text()
-        assert "EnvironmentFile=/etc/default/onetimesecret" in content
+        assert "EnvironmentFile=/etc/default/onetimesecret.d/*.conf" in content
 
     def test_write_scheduler_template_includes_config_volume(self, mocker, tmp_path):
         """Scheduler quadlet should mount per-file config volumes."""
@@ -823,30 +766,21 @@ class TestSchedulerTemplate:
         assert f"Volume={config_dir}/auth.yaml:/app/etc/auth.yaml:ro" in content
         assert f"Volume={config_dir}/logging.yaml:/app/etc/logging.yaml:ro" in content
 
-    def test_write_scheduler_template_includes_podman_secrets(self, mocker, tmp_path):
-        """Scheduler quadlet should include Secret directives from env file."""
+    def test_write_scheduler_template_secrets_section_comment(self, mocker, tmp_path):
+        """Scheduler quadlet should include drop-in directory comment for secrets."""
         mocker.patch("rots.quadlet.systemd.daemon_reload")
-        mocker.patch("rots.quadlet.secret_exists", return_value=True)
         from rots import quadlet
         from rots.config import Config
-
-        env_file = tmp_path / "onetimesecret.env"
-        env_file.write_text(
-            "SECRET_VARIABLE_NAMES=API_KEY,DB_PASSWORD\n"
-            "_API_KEY=ots_api_key\n"
-            "_DB_PASSWORD=ots_db_password\n"
-        )
 
         cfg = Config(
             scheduler_template_path=tmp_path / "onetime-scheduler@.container",
             var_dir=tmp_path / "var",
         )
 
-        quadlet.write_scheduler_template(cfg, env_file_path=env_file, force=True)
+        quadlet.write_scheduler_template(cfg, force=True)
 
         content = cfg.scheduler_template_path.read_text()
-        assert "Secret=ots_api_key,type=env,target=API_KEY" in content
-        assert "Secret=ots_db_password,type=env,target=DB_PASSWORD" in content
+        assert "Secrets loaded via environment drop-in directory" in content
 
     def test_write_scheduler_template_creates_parent_dirs(self, mocker, tmp_path):
         """write_scheduler_template should create parent directories if needed."""
@@ -961,272 +895,14 @@ class TestGetConfigVolumesSection:
 
 
 class TestGetSecretsSection:
-    """Test get_secrets_section filtering of non-existent podman secrets."""
+    """Test get_secrets_section returns drop-in directory comment."""
 
-    def test_filters_out_nonexistent_podman_secrets(self, mocker, tmp_path):
-        """Should only include Secret= lines for secrets that actually exist in podman.
-
-        When SECRET_VARIABLE_NAMES lists variables that have been processed
-        (_VARNAME=ots_varname) but the corresponding podman secret doesn't
-        actually exist, the Secret= line should be omitted to prevent
-        container start failures.
-        """
-        # Mock secret_exists to simulate: ots_api_key exists, ots_db_password does not
-        mock_secret_exists = mocker.patch(
-            "rots.quadlet.secret_exists",
-            side_effect=lambda name, **kw: name == "ots_api_key",
-        )
-
+    def test_returns_drop_in_comment(self):
+        """get_secrets_section should return drop-in directory comment."""
         from rots.quadlet import get_secrets_section
 
-        env_file = tmp_path / "onetimesecret.env"
-        env_file.write_text(
-            "SECRET_VARIABLE_NAMES=API_KEY,DB_PASSWORD\n"
-            "_API_KEY=ots_api_key\n"
-            "_DB_PASSWORD=ots_db_password\n"
-        )
-
-        result = get_secrets_section(env_file_path=env_file)
-
-        # Only the existing secret should appear in output
-        assert "Secret=ots_api_key,type=env,target=API_KEY" in result
-        assert "Secret=ots_db_password" not in result
-
-        # secret_exists should have been called for each secret
-        assert mock_secret_exists.call_count == 2
-
-    def test_all_secrets_exist(self, mocker, tmp_path):
-        """Should include all Secret= lines when all podman secrets exist."""
-        mocker.patch(
-            "rots.quadlet.secret_exists",
-            return_value=True,
-        )
-
-        from rots.quadlet import get_secrets_section
-
-        env_file = tmp_path / "onetimesecret.env"
-        env_file.write_text(
-            "SECRET_VARIABLE_NAMES=API_KEY,DB_PASSWORD\n"
-            "_API_KEY=ots_api_key\n"
-            "_DB_PASSWORD=ots_db_password\n"
-        )
-
-        result = get_secrets_section(env_file_path=env_file)
-
-        assert "Secret=ots_api_key,type=env,target=API_KEY" in result
-        assert "Secret=ots_db_password,type=env,target=DB_PASSWORD" in result
-
-    def test_no_secrets_exist_returns_fallback(self, mocker, tmp_path):
-        """Should return a comment when no podman secrets exist at all."""
-        mocker.patch(
-            "rots.quadlet.secret_exists",
-            return_value=False,
-        )
-
-        from rots.quadlet import get_secrets_section
-
-        env_file = tmp_path / "onetimesecret.env"
-        env_file.write_text("SECRET_VARIABLE_NAMES=API_KEY\n_API_KEY=ots_api_key\n")
-
-        result = get_secrets_section(env_file_path=env_file, force=True)
-
-        # When all secrets are filtered out, should not contain Secret= lines
-        assert "Secret=" not in result
-
-    def test_missing_env_file_exits_with_precondition_code(self, tmp_path):
-        """Missing env file without --force should exit with code 3 (precondition not met)."""
-        from rots.quadlet import get_secrets_section
-
-        with pytest.raises(SystemExit) as exc_info:
-            get_secrets_section(env_file_path=tmp_path / "nonexistent.env")
-
-        assert exc_info.value.code == 3  # EXIT_PRECOND
-
-    def test_empty_secret_names_exits_with_precondition_code(self, tmp_path):
-        """Env file with no SECRET_VARIABLE_NAMES without --force exits with code 3."""
-        from rots.quadlet import get_secrets_section
-
-        env_file = tmp_path / "onetimesecret.env"
-        env_file.write_text("REDIS_URL=redis://localhost\n")  # No SECRET_VARIABLE_NAMES
-
-        with pytest.raises(SystemExit) as exc_info:
-            get_secrets_section(env_file_path=env_file)
-
-        assert exc_info.value.code == 3  # EXIT_PRECOND
-
-    def test_no_podman_secrets_exits_with_precondition_code(self, mocker, tmp_path):
-        """No existing podman secrets without --force exits with code 3."""
-        mocker.patch("rots.quadlet.secret_exists", return_value=False)
-
-        from rots.quadlet import get_secrets_section
-
-        env_file = tmp_path / "onetimesecret.env"
-        env_file.write_text("SECRET_VARIABLE_NAMES=API_KEY\n_API_KEY=ots_api_key\n")
-
-        with pytest.raises(SystemExit) as exc_info:
-            get_secrets_section(env_file_path=env_file)
-
-        assert exc_info.value.code == 3  # EXIT_PRECOND
-
-    def test_missing_env_file_force_returns_comment(self, tmp_path, caplog):
-        """get_secrets_section(force=True) with missing env file returns comment, logs WARNING."""
-        import logging
-
-        from rots.quadlet import get_secrets_section
-
-        with caplog.at_level(logging.WARNING):
-            result = get_secrets_section(
-                env_file_path=tmp_path / "nonexistent.env",
-                force=True,
-            )
-
-        assert "No secrets configured" in result
-        assert any(rec.levelno == logging.WARNING for rec in caplog.records)
-
-    def test_no_secret_names_force_returns_comment(self, tmp_path, caplog):
-        """get_secrets_section(force=True) with no SECRET_VARIABLE_NAMES returns comment."""
-        import logging
-
-        from rots.quadlet import get_secrets_section
-
-        env_file = tmp_path / "onetimesecret.env"
-        env_file.write_text("REDIS_URL=redis://localhost\n")  # No SECRET_VARIABLE_NAMES
-
-        with caplog.at_level(logging.WARNING):
-            result = get_secrets_section(env_file_path=env_file, force=True)
-
-        assert "No secrets configured" in result
-        assert any(rec.levelno == logging.WARNING for rec in caplog.records)
-
-    def test_write_web_template_missing_env_propagates_system_exit(self, mocker, tmp_path):
-        """write_web_template() without force propagates SystemExit(3) when env file missing."""
-        mocker.patch("rots.quadlet.systemd.daemon_reload")
-        from rots import quadlet
-        from rots.config import Config
-
-        cfg = Config(
-            web_template_path=tmp_path / "onetime-web@.container",
-            var_dir=tmp_path / "var",
-        )
-
-        with pytest.raises(SystemExit) as exc_info:
-            quadlet.write_web_template(cfg, env_file_path=tmp_path / "nonexistent.env")
-
-        assert exc_info.value.code == 3  # EXIT_PRECOND
-
-
-class TestWriteTemplatesForce:
-    """Tests for force= parameter across write_*_template functions."""
-
-    def test_write_web_template_force_skips_system_exit(self, mocker, tmp_path, caplog):
-        """write_web_template(force=True) should complete when env file is missing."""
-        import logging
-
-        mocker.patch("rots.quadlet.systemd.daemon_reload")
-        from rots import quadlet
-        from rots.config import Config
-
-        cfg = Config(
-            web_template_path=tmp_path / "onetime-web@.container",
-            var_dir=tmp_path / "var",
-        )
-
-        # Should not raise SystemExit
-        with caplog.at_level(logging.WARNING):
-            quadlet.write_web_template(cfg, env_file_path=tmp_path / "nonexistent.env", force=True)
-
-        assert cfg.web_template_path.exists()
-        assert any(rec.levelno == logging.WARNING for rec in caplog.records)
-
-    def test_write_worker_template_force_skips_system_exit(self, mocker, tmp_path, caplog):
-        """write_worker_template(force=True) should complete when env file is missing."""
-        import logging
-
-        mocker.patch("rots.quadlet.systemd.daemon_reload")
-        from rots import quadlet
-        from rots.config import Config
-
-        cfg = Config(
-            worker_template_path=tmp_path / "onetime-worker@.container",
-            var_dir=tmp_path / "var",
-        )
-
-        with caplog.at_level(logging.WARNING):
-            quadlet.write_worker_template(
-                cfg, env_file_path=tmp_path / "nonexistent.env", force=True
-            )
-
-        assert cfg.worker_template_path.exists()
-        assert any(rec.levelno == logging.WARNING for rec in caplog.records)
-
-    def test_write_scheduler_template_force_skips_system_exit(self, mocker, tmp_path, caplog):
-        """write_scheduler_template(force=True) should complete when env file is missing."""
-        import logging
-
-        mocker.patch("rots.quadlet.systemd.daemon_reload")
-        from rots import quadlet
-        from rots.config import Config
-
-        cfg = Config(
-            scheduler_template_path=tmp_path / "onetime-scheduler@.container",
-            var_dir=tmp_path / "var",
-        )
-
-        with caplog.at_level(logging.WARNING):
-            quadlet.write_scheduler_template(
-                cfg, env_file_path=tmp_path / "nonexistent.env", force=True
-            )
-
-        assert cfg.scheduler_template_path.exists()
-        assert any(rec.levelno == logging.WARNING for rec in caplog.records)
-
-    def test_write_web_template_no_force_raises_system_exit(self, mocker, tmp_path):
-        """write_web_template() without force=True raises SystemExit(3) for missing env."""
-        mocker.patch("rots.quadlet.systemd.daemon_reload")
-        from rots import quadlet
-        from rots.config import Config
-
-        cfg = Config(
-            web_template_path=tmp_path / "onetime-web@.container",
-            var_dir=tmp_path / "var",
-        )
-
-        with pytest.raises(SystemExit) as exc_info:
-            quadlet.write_web_template(cfg, env_file_path=tmp_path / "nonexistent.env")
-
-        assert exc_info.value.code == 3
-
-    def test_write_worker_template_no_force_raises_system_exit(self, mocker, tmp_path):
-        """write_worker_template() without force=True raises SystemExit(3) for missing env."""
-        mocker.patch("rots.quadlet.systemd.daemon_reload")
-        from rots import quadlet
-        from rots.config import Config
-
-        cfg = Config(
-            worker_template_path=tmp_path / "onetime-worker@.container",
-            var_dir=tmp_path / "var",
-        )
-
-        with pytest.raises(SystemExit) as exc_info:
-            quadlet.write_worker_template(cfg, env_file_path=tmp_path / "nonexistent.env")
-
-        assert exc_info.value.code == 3
-
-    def test_write_scheduler_template_no_force_raises_system_exit(self, mocker, tmp_path):
-        """write_scheduler_template() without force=True raises SystemExit(3) for missing env."""
-        mocker.patch("rots.quadlet.systemd.daemon_reload")
-        from rots import quadlet
-        from rots.config import Config
-
-        cfg = Config(
-            scheduler_template_path=tmp_path / "onetime-scheduler@.container",
-            var_dir=tmp_path / "var",
-        )
-
-        with pytest.raises(SystemExit) as exc_info:
-            quadlet.write_scheduler_template(cfg, env_file_path=tmp_path / "nonexistent.env")
-
-        assert exc_info.value.code == 3
+        result = get_secrets_section()
+        assert "Secrets loaded via environment drop-in directory" in result
 
 
 class TestGetResourceLimitsSection:
@@ -1448,41 +1124,6 @@ class TestWriteTemplateRemote:
 
         # Should call daemon_reload with executor
         mock_reload.assert_called_once_with(executor=mock_ex)
-
-
-class TestGetSecretsSectionRemote:
-    """Test get_secrets_section() with remote executor."""
-
-    def test_checks_env_file_existence_remotely(self, mocker):
-        from rots.quadlet import get_secrets_section
-
-        mock_ex = _make_ssh_executor(mocker)
-        # test -f returns false (env file not found)
-        mock_ex.run.return_value = _make_remote_result(returncode=1)
-
-        with pytest.raises(SystemExit):
-            get_secrets_section(executor=mock_ex)
-
-        mock_ex.run.assert_called_once_with(["test", "-f", "/etc/default/onetimesecret"])
-
-    def test_passes_executor_to_get_secrets_from_env_file(self, mocker):
-        from rots.quadlet import get_secrets_section
-
-        mock_ex = _make_ssh_executor(mocker)
-        # env file exists
-        mock_ex.run.return_value = _make_remote_result(returncode=0)
-
-        mock_get_secrets = mocker.patch(
-            "rots.quadlet.get_secrets_from_env_file",
-            return_value=[],
-        )
-
-        # Will raise SystemExit due to no secrets + no force
-        with pytest.raises(SystemExit):
-            get_secrets_section(executor=mock_ex)
-
-        mock_get_secrets.assert_called_once()
-        assert mock_get_secrets.call_args[1]["executor"] is mock_ex
 
 
 class TestGetConfigVolumesSectionRemote:

--- a/tests/test_quadlet.py
+++ b/tests/test_quadlet.py
@@ -141,7 +141,7 @@ class TestContainerTemplate:
         assert "Volume=static_assets:/app/public:ro" in content
 
     def test_write_web_template_secrets_section_comment(self, mocker, tmp_path):
-        """Container quadlet should include drop-in directory comment for secrets."""
+        """Container quadlet should include EnvironmentFile layered pattern comment for secrets."""
         mocker.patch("rots.quadlet.systemd.daemon_reload")
         from rots import quadlet
         from rots.config import Config
@@ -154,8 +154,8 @@ class TestContainerTemplate:
         quadlet.write_web_template(cfg, force=True)
 
         content = cfg.web_template_path.read_text()
-        # Secrets are now loaded via environment drop-in directory
-        assert "Secrets loaded via environment drop-in directory" in content
+        # Secrets are now loaded via EnvironmentFile layered pattern
+        assert "Secrets loaded via EnvironmentFile layered pattern" in content
 
     def test_write_web_template_includes_systemd_dependencies(self, mocker, tmp_path):
         """Container quadlet should have proper systemd dependencies."""
@@ -510,7 +510,7 @@ class TestWorkerTemplate:
         assert f"Volume={config_dir}/logging.yaml:/app/etc/logging.yaml:ro" in content
 
     def test_write_worker_template_secrets_section_comment(self, mocker, tmp_path):
-        """Worker quadlet should include drop-in directory comment for secrets."""
+        """Worker quadlet should include EnvironmentFile layered pattern comment for secrets."""
         mocker.patch("rots.quadlet.systemd.daemon_reload")
         from rots import quadlet
         from rots.config import Config
@@ -523,7 +523,7 @@ class TestWorkerTemplate:
         quadlet.write_worker_template(cfg, force=True)
 
         content = cfg.worker_template_path.read_text()
-        assert "Secrets loaded via environment drop-in directory" in content
+        assert "Secrets loaded via EnvironmentFile layered pattern" in content
 
     def test_write_worker_template_reloads_daemon(self, mocker, tmp_path):
         """write_worker_template should reload systemd daemon after writing."""
@@ -770,7 +770,7 @@ class TestSchedulerTemplate:
         assert f"Volume={config_dir}/logging.yaml:/app/etc/logging.yaml:ro" in content
 
     def test_write_scheduler_template_secrets_section_comment(self, mocker, tmp_path):
-        """Scheduler quadlet should include drop-in directory comment for secrets."""
+        """Scheduler quadlet should include EnvironmentFile layered pattern comment for secrets."""
         mocker.patch("rots.quadlet.systemd.daemon_reload")
         from rots import quadlet
         from rots.config import Config
@@ -783,7 +783,7 @@ class TestSchedulerTemplate:
         quadlet.write_scheduler_template(cfg, force=True)
 
         content = cfg.scheduler_template_path.read_text()
-        assert "Secrets loaded via environment drop-in directory" in content
+        assert "Secrets loaded via EnvironmentFile layered pattern" in content
 
     def test_write_scheduler_template_creates_parent_dirs(self, mocker, tmp_path):
         """write_scheduler_template should create parent directories if needed."""
@@ -898,14 +898,14 @@ class TestGetConfigVolumesSection:
 
 
 class TestGetSecretsSection:
-    """Test get_secrets_section returns drop-in directory comment."""
+    """Test get_secrets_section returns EnvironmentFile layered pattern comment."""
 
     def test_returns_drop_in_comment(self):
-        """get_secrets_section should return drop-in directory comment."""
+        """get_secrets_section should return EnvironmentFile layered pattern comment."""
         from rots.quadlet import get_secrets_section
 
         result = get_secrets_section()
-        assert "Secrets loaded via environment drop-in directory" in result
+        assert "Secrets loaded via EnvironmentFile layered pattern" in result
 
 
 class TestGetResourceLimitsSection:

--- a/tests/test_quadlet_render.py
+++ b/tests/test_quadlet_render.py
@@ -165,12 +165,12 @@ class TestRenderWorkerTemplate:
         assert "bin/ots worker" in result
 
     def test_secrets_section_shows_drop_in_comment(self, mocker, tmp_path):
-        """render_worker_template should show drop-in directory comment for secrets."""
+        """render_worker_template should show EnvironmentFile pattern comment."""
         from rots import quadlet
 
         cfg = _make_cfg(mocker, tmp_path)
         result = quadlet.render_worker_template(cfg, force=True)
-        assert "Secrets loaded via environment drop-in directory" in result
+        assert "Secrets loaded via EnvironmentFile layered pattern" in result
 
 
 class TestRenderSchedulerTemplate:
@@ -223,12 +223,12 @@ class TestRenderSchedulerTemplate:
         assert "bin/ots scheduler" in result
 
     def test_secrets_section_shows_drop_in_comment(self, mocker, tmp_path):
-        """render_scheduler_template should show drop-in directory comment for secrets."""
+        """render_scheduler_template should show EnvironmentFile pattern comment."""
         from rots import quadlet
 
         cfg = _make_cfg(mocker, tmp_path)
         result = quadlet.render_scheduler_template(cfg, force=True)
-        assert "Secrets loaded via environment drop-in directory" in result
+        assert "Secrets loaded via EnvironmentFile layered pattern" in result
 
 
 class TestBuildFmtVars:
@@ -651,7 +651,7 @@ class TestRenderTemplatesWithConfigSource:
     def test_no_secret_lines_in_rendered_output(self, mocker, tmp_path):
         """Rendered templates should not contain Secret= lines.
 
-        Secrets are now loaded via environment drop-in directory instead of
+        Secrets are now loaded via EnvironmentFile layered pattern instead of
         being enumerated as Secret= directives in the quadlet file.
         """
         from rots import quadlet
@@ -675,5 +675,5 @@ class TestRenderTemplatesWithConfigSource:
         assert "Secret=" not in result_web
         assert "Secret=" not in result_worker
         assert "Secret=" not in result_scheduler
-        # Verify the drop-in comment is present
-        assert "Secrets loaded via environment drop-in directory" in result_web
+        # Verify the EnvironmentFile layered pattern comment is present
+        assert "Secrets loaded via EnvironmentFile layered pattern" in result_web

--- a/tests/test_quadlet_render.py
+++ b/tests/test_quadlet_render.py
@@ -164,14 +164,13 @@ class TestRenderWorkerTemplate:
         result = quadlet.render_worker_template(cfg, force=True)
         assert "bin/ots worker" in result
 
-    def test_force_true_without_env_file(self, mocker, tmp_path):
-        """render_worker_template with force=True should not exit even without env file."""
+    def test_secrets_section_shows_drop_in_comment(self, mocker, tmp_path):
+        """render_worker_template should show drop-in directory comment for secrets."""
         from rots import quadlet
 
         cfg = _make_cfg(mocker, tmp_path)
-        mocker.patch("rots.quadlet.DEFAULT_ENV_FILE", tmp_path / "noenv")
         result = quadlet.render_worker_template(cfg, force=True)
-        assert "No secrets configured" in result
+        assert "Secrets loaded via environment drop-in directory" in result
 
 
 class TestRenderSchedulerTemplate:
@@ -223,14 +222,13 @@ class TestRenderSchedulerTemplate:
         result = quadlet.render_scheduler_template(cfg, force=True)
         assert "bin/ots scheduler" in result
 
-    def test_force_true_without_env_file(self, mocker, tmp_path):
-        """render_scheduler_template with force=True should not exit without env file."""
+    def test_secrets_section_shows_drop_in_comment(self, mocker, tmp_path):
+        """render_scheduler_template should show drop-in directory comment for secrets."""
         from rots import quadlet
 
         cfg = _make_cfg(mocker, tmp_path)
-        mocker.patch("rots.quadlet.DEFAULT_ENV_FILE", tmp_path / "noenv")
         result = quadlet.render_scheduler_template(cfg, force=True)
-        assert "No secrets configured" in result
+        assert "Secrets loaded via environment drop-in directory" in result
 
 
 class TestBuildFmtVars:
@@ -650,39 +648,20 @@ class TestRenderTemplatesWithConfigSource:
         assert "Image=ghcr.io/test/image:v1.2.3" in result
         cfg.resolved_image_with_tag.assert_not_called()
 
-    def test_no_secret_lines_when_config_source_is_set(self, mocker, tmp_path):
-        """Render mode signal: no Secret= lines when config_source is set.
+    def test_no_secret_lines_in_rendered_output(self, mocker, tmp_path):
+        """Rendered templates should not contain Secret= lines.
 
-        This test deliberately makes secrets *visible* (returns specs, says they exist)
-        so a regression that re-enables secret emission under render would surface.
+        Secrets are now loaded via environment drop-in directory instead of
+        being enumerated as Secret= directives in the quadlet file.
         """
         from rots import quadlet
-        from rots.environment_file import SecretSpec
 
         cfg = _make_render_cfg(mocker, tmp_path)
-        # Force the secret-existence check to say "yes" — autouse fixture
-        # returns False, which alone would suppress Secret= lines.
-        mocker.patch("rots.quadlet.secret_exists", return_value=True)
-        # And make the env file probe return real-looking secrets.
-        mocker.patch(
-            "rots.quadlet.get_secrets_from_env_file",
-            return_value=[
-                SecretSpec(env_var_name="AUTH_SECRET", secret_name="ots_auth_secret"),
-                SecretSpec(env_var_name="API_KEY", secret_name="ots_api_key"),
-            ],
-        )
-        # Make the env file appear to exist so the secrets path is reachable
-        # in non-render mode.
-        env_file = tmp_path / "envfile"
-        env_file.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET,API_KEY\n")
-        mocker.patch("rots.quadlet.DEFAULT_ENV_FILE", env_file)
 
         src = tmp_path / "src"
         src.mkdir()
         (src / "config.yaml").touch()
 
-        # render_mode=True is the documented signal; pass it alongside config_source
-        # since the contract states no Secret= lines are emitted under --render.
         result_web = quadlet.render_web_template(
             cfg, force=True, config_source=src, render_mode=True
         )
@@ -696,3 +675,5 @@ class TestRenderTemplatesWithConfigSource:
         assert "Secret=" not in result_web
         assert "Secret=" not in result_worker
         assert "Secret=" not in result_scheduler
+        # Verify the drop-in comment is present
+        assert "Secrets loaded via environment drop-in directory" in result_web


### PR DESCRIPTION
## Summary

- Replace `EnvironmentFile=/etc/default/onetimesecret` with glob pattern `EnvironmentFile=/etc/default/onetimesecret.d/*.conf` in all quadlet templates
- Remove SECRET_VARIABLE_NAMES probing from `get_secrets_section()` — secrets now loaded via drop-in directory
- Update `DEFAULT_ENV_FILE` to point to `00-baseline.conf` with legacy path commented for reference

This enables layered configuration via OverlayFS where `00-baseline.conf` ships in baseline confext and `50-host.conf` ships in per-host confext. Lexical order determines precedence.

## Test plan

- [x] All 2103 tests pass
- [x] Lint and type checks clean
- [ ] Verify systemd glob behavior on target hosts (systemd 250+)