### PR TITLE
Fix authfile handling for login/pull commands

### DIFF
--- a/src/rots/commands/image/app.py
+++ b/src/rots/commands/image/app.py
@@ -148,13 +148,13 @@ def pull(
     logger.info(f"Pulling {full_image}...")
 
     try:
-        # Use auth file for authenticated registries
-        pull_kwargs = {
-            "authfile": str(cfg.registry_auth_file),
+        # Use auth file only when explicitly configured or file exists
+        pull_kwargs: dict[str, object] = {
             "check": True,
             "capture_output": True,
             "text": True,
         }
+        pull_kwargs.update(cfg.podman_auth_kwargs(executor=ex))
         if platform:
             pull_kwargs["platform"] = platform
 
@@ -345,13 +345,11 @@ def list_remote(
         resolved_image,
         reg,
     )
-    cmd = [
-        "skopeo",
-        "list-tags",
-        "--authfile",
-        str(cfg.registry_auth_file),
-        image_ref,
-    ]
+    cmd = ["skopeo", "list-tags"]
+    auth_kwargs = cfg.podman_auth_kwargs()
+    if "authfile" in auth_kwargs:
+        cmd.extend(["--authfile", auth_kwargs["authfile"]])
+    cmd.append(image_ref)
 
     logger.info(f"$ {' '.join(cmd)}")
 
@@ -753,16 +751,19 @@ def login(
     logger.info(f"Logging in to {reg}...")
 
     try:
-        p.login(
-            reg,
-            username=user,
-            password_stdin=True,
-            authfile=str(cfg.registry_auth_file),
-            input=pw,
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        login_kwargs = {
+            "username": user,
+            "password_stdin": True,
+            "input": pw,
+            "check": True,
+            "capture_output": True,
+            "text": True,
+        }
+        # For login, pass authfile only if explicitly configured (env var or override).
+        # This allows podman to create the file in its default location on first login.
+        if cfg._registry_auth_file or os.environ.get("REGISTRY_AUTH_FILE"):
+            login_kwargs["authfile"] = str(cfg.registry_auth_file)
+        p.login(reg, **login_kwargs)
         logger.info(f"Login successful: {reg}")
     except Exception as e:
         logger.error(f"Login failed: {e}")
@@ -847,13 +848,13 @@ def push(
 
     # Push to registry
     try:
-        p.push(
-            target_full,
-            authfile=str(cfg.registry_auth_file),
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        push_kwargs: dict[str, object] = {
+            "check": True,
+            "capture_output": True,
+            "text": True,
+        }
+        push_kwargs.update(cfg.podman_auth_kwargs(executor=ex))
+        p.push(target_full, **push_kwargs)
         logger.info(f"Successfully pushed {target_full}")
     except Exception as e:
         logger.error(f"Failed to push {target_full}: {e}")
@@ -899,13 +900,13 @@ def logout(
     logger.info(f"Logging out from {reg}...")
 
     try:
-        p.logout(
-            reg,
-            authfile=str(cfg.registry_auth_file),
-            check=True,
-            capture_output=True,
-            text=True,
-        )
+        logout_kwargs: dict[str, object] = {
+            "check": True,
+            "capture_output": True,
+            "text": True,
+        }
+        logout_kwargs.update(cfg.podman_auth_kwargs(executor=ex))
+        p.logout(reg, **logout_kwargs)
         logger.info(f"Logged out from {reg}")
     except Exception as e:
         logger.error(f"Logout failed: {e}")
@@ -1677,13 +1678,13 @@ def _push_images(
         logger.info(f"Pushing {target_image}...")
 
         try:
-            p.push(
-                target_image,
-                authfile=str(cfg.registry_auth_file),
-                check=True,
-                capture_output=quiet,
-                text=True,
-            )
+            push_kwargs: dict[str, object] = {
+                "check": True,
+                "capture_output": quiet,
+                "text": True,
+            }
+            push_kwargs.update(cfg.podman_auth_kwargs())
+            p.push(target_image, **push_kwargs)
             logger.info(f"Successfully pushed {target_image}")
         except Exception as e:
             logger.error(f"Failed to push {target_image}: {e}")

--- a/src/rots/commands/image/app.py
+++ b/src/rots/commands/image/app.py
@@ -759,9 +759,9 @@ def login(
             "capture_output": True,
             "text": True,
         }
-        # For login, pass authfile only if explicitly configured (env var or override).
+        # For login, pass authfile only if explicitly configured.
         # This allows podman to create the file in its default location on first login.
-        if cfg._registry_auth_file or os.environ.get("REGISTRY_AUTH_FILE"):
+        if cfg.has_explicit_auth_config:
             login_kwargs["authfile"] = str(cfg.registry_auth_file)
         p.login(reg, **login_kwargs)
         logger.info(f"Login successful: {reg}")

--- a/src/rots/config.py
+++ b/src/rots/config.py
@@ -304,18 +304,33 @@ class Config:
         # System path (root on Linux only)
         return Path("/etc/containers/auth.json")
 
-    def get_registry_auth_file(self, executor: Executor | None = None) -> Path:
+    @property
+    def has_explicit_auth_config(self) -> bool:
+        """True when auth file was explicitly configured (override or env var)."""
+        return bool(self._registry_auth_file or os.environ.get("REGISTRY_AUTH_FILE"))
+
+    def get_registry_auth_file(
+        self, executor: Executor | None = None, *, exists_only: bool = False
+    ) -> Path | None:
         """Remote-aware registry auth file resolution.
 
         When *executor* is None or a LocalExecutor, delegates to the
         :attr:`registry_auth_file` property (local filesystem probing).
         For remote executors, probes the remote filesystem and uses
         remote-appropriate defaults (always Linux, always root on production).
+
+        Args:
+            executor: Optional executor for remote filesystem probing.
+            exists_only: When True, return None if no auth file exists
+                (instead of returning a fallback path that may not exist).
         """
         from ots_shared.ssh import is_remote
 
         if not is_remote(executor):
-            return self.registry_auth_file
+            path = self.registry_auth_file
+            if exists_only and not path.exists():
+                return None
+            return path
 
         # Explicit override
         if self._registry_auth_file:
@@ -335,6 +350,9 @@ class Config:
             result = executor.run(["test", "-f", str(candidate)])
             if result.ok:
                 return candidate
+
+        if exists_only:
+            return None
 
         # Default to system path (root on Linux production)
         return Path("/etc/containers/auth.json")
@@ -646,30 +664,13 @@ class Config:
         Use this for pull/push/logout operations where passing a non-existent authfile
         causes podman to fail with exit 125.
         """
-        from ots_shared.ssh import is_remote
+        # Explicit config always wins (no existence check needed)
+        if self.has_explicit_auth_config:
+            return {"authfile": str(self.get_registry_auth_file(executor=executor))}
 
-        # Explicit override always wins
-        if self._registry_auth_file:
-            return {"authfile": str(self._registry_auth_file)}
-
-        # Environment variable always wins
-        env_path = os.environ.get("REGISTRY_AUTH_FILE")
-        if env_path:
-            return {"authfile": env_path}
-
-        # For remote execution, probe remote filesystem
-        if is_remote(executor):
-            auth_path = self.get_registry_auth_file(executor=executor)
-            # get_registry_auth_file already probed; if it returned a path, it exists
-            # (or is the fallback /etc/containers/auth.json which may not exist)
-            result = executor.run(["test", "-f", str(auth_path)])
-            if result.ok:
-                return {"authfile": str(auth_path)}
-            return {}
-
-        # Local: check if the resolved auth file exists
-        auth_path = self.registry_auth_file
-        if auth_path.exists():
+        # Otherwise, only return authfile if it actually exists
+        auth_path = self.get_registry_auth_file(executor=executor, exists_only=True)
+        if auth_path:
             return {"authfile": str(auth_path)}
 
         return {}

--- a/src/rots/config.py
+++ b/src/rots/config.py
@@ -635,3 +635,41 @@ class Config:
         if not self.registry:
             return []
         return ["--authfile", str(self.get_registry_auth_file(executor=executor))]
+
+    def podman_auth_kwargs(self, *, executor: Executor | None = None) -> dict[str, str]:
+        """Return ``authfile`` kwarg dict when auth file is explicitly configured or exists.
+
+        Returns an empty dict when no explicit auth config is set and the default
+        auth file does not exist. This allows podman to use its default auth location
+        and create the file on first login.
+
+        Use this for pull/push/logout operations where passing a non-existent authfile
+        causes podman to fail with exit 125.
+        """
+        from ots_shared.ssh import is_remote
+
+        # Explicit override always wins
+        if self._registry_auth_file:
+            return {"authfile": str(self._registry_auth_file)}
+
+        # Environment variable always wins
+        env_path = os.environ.get("REGISTRY_AUTH_FILE")
+        if env_path:
+            return {"authfile": env_path}
+
+        # For remote execution, probe remote filesystem
+        if is_remote(executor):
+            auth_path = self.get_registry_auth_file(executor=executor)
+            # get_registry_auth_file already probed; if it returned a path, it exists
+            # (or is the fallback /etc/containers/auth.json which may not exist)
+            result = executor.run(["test", "-f", str(auth_path)])
+            if result.ok:
+                return {"authfile": str(auth_path)}
+            return {}
+
+        # Local: check if the resolved auth file exists
+        auth_path = self.registry_auth_file
+        if auth_path.exists():
+            return {"authfile": str(auth_path)}
+
+        return {}

--- a/tests/commands/image/test_build.py
+++ b/tests/commands/image/test_build.py
@@ -49,6 +49,7 @@ class TestBuildVersionDetection:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -97,6 +98,7 @@ class TestBuildVersionDetection:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -182,6 +184,7 @@ class TestBuildPodmanInvocation:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -227,6 +230,7 @@ class TestBuildPodmanInvocation:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,  # No registry configured
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -266,6 +270,7 @@ class TestBuildPodmanInvocation:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry="registry.example.com",
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -306,6 +311,7 @@ class TestBuildPodmanInvocation:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -349,6 +355,7 @@ class TestBuildPodmanInvocation:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -400,6 +407,7 @@ class TestBuildDefaultBehavior:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -438,6 +446,7 @@ class TestBuildDefaultBehavior:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -482,6 +491,7 @@ class TestBuildDefaultBehavior:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -525,6 +535,7 @@ class TestBuildErrorHandling:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -601,6 +612,7 @@ class TestBuildVariants:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -655,6 +667,7 @@ class TestBuildVariants:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -725,6 +738,7 @@ class TestBuildVariants:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry="registry.example.com",
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )
@@ -780,6 +794,7 @@ def _mock_build_env(mocker, tmp_path):
             image="ghcr.io/onetimesecret/onetimesecret",
             registry=None,
             registry_auth_file=tmp_path / "auth.json",
+            podman_auth_kwargs=lambda executor=None: {},
             get_executor=lambda host=None: None,
         ),
     )
@@ -1074,6 +1089,7 @@ class TestBuildBaseCleanup:
                 image="ghcr.io/onetimesecret/onetimesecret",
                 registry=None,
                 registry_auth_file=tmp_path / "auth.json",
+                podman_auth_kwargs=lambda executor=None: {},
                 get_executor=lambda host=None: None,
             ),
         )


### PR DESCRIPTION
## Summary
- Only pass `--authfile` to podman when explicitly configured or file exists
- Allows first-time `rots image login` to work without pre-existing auth file
- Podman creates the file in its default location on first login

## Test plan
- [x] 121 image command tests pass
- [x] 37 auth-related tests pass
- [ ] Manual test: `rots image login ghcr.io` on fresh system without `/etc/containers/auth.json`
- [ ] Manual test: `rots image pull` after successful login

Fixes #82