### PR TITLE
Fix Quadlet EnvironmentFile= crash-loop (podman exit 125); release 0.7.5

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,29 @@ Versioning <https://semver.org/spec/v2.0.0.html>`__.
 
    <!--scriv-insert-here-->
 
+.. _changelog-0.7.5:
+
+0.7.5 — 2026-06-29
+==================
+
+Fixed
+-----
+
+- Stop emitting an invalid ``EnvironmentFile=-/etc/default/onetimesecret.local``
+  line in generated Quadlet ``[Container]`` units. Quadlet does not honor
+  systemd's ``-`` ("optional") prefix and passed it to ``podman --env-file``
+  verbatim, which resolved to a non-existent relative path and crashed the
+  container with exit 125 (restart loop). The optional ``.local`` host override
+  is now emitted only when the file exists on the target host. Regression from
+  v0.7.4.
+
+AI Assistance
+-------------
+
+- Root-cause diagnosis (podman exit 125 from the unsupported ``-`` prefix),
+  fix design mirroring ``get_config_volumes_section``, and regression tests
+  developed with AI assistance.
+
 .. _changelog-0.7.4:
 
 0.7.4 — 2026-05-04

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@
 
 [project]
 name = "rots"
-version = "0.7.4"
+version = "0.7.5"
 description = "Service orchestration for OneTimeSecret: Podman Quadlets and systemd service management"
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/rots/quadlet.py
+++ b/src/rots/quadlet.py
@@ -6,7 +6,8 @@ Quadlet template generation for OneTimeSecret containers.
 The quadlet template is a systemd unit file that defines how to run
 the container. Environment variables are loaded via a two-file layered
 pattern: /etc/default/onetimesecret (baseline, required) plus
-/etc/default/onetimesecret.local (host overrides, optional).
+/etc/default/onetimesecret.local (host overrides, included only when the
+file exists on the target host).
 """
 
 from __future__ import annotations
@@ -27,10 +28,17 @@ logger = logging.getLogger(__name__)
 
 
 # Environment files use a two-file layered pattern:
-#   EnvironmentFile=/etc/default/onetimesecret        (baseline, confext)
-#   EnvironmentFile=-/etc/default/onetimesecret.local (optional host overrides)
-# The "-" prefix makes .local optional — missing file is not an error.
+#   EnvironmentFile=/etc/default/onetimesecret       (baseline, confext)
+#   EnvironmentFile=/etc/default/onetimesecret.local (host overrides, when present)
+#
+# NOTE: Quadlet's [Container] EnvironmentFile= forwards its value verbatim to
+# `podman run --env-file` and, unlike systemd's [Service] EnvironmentFile=,
+# does NOT support the leading "-" ("ignore if missing") prefix. A "-" is taken
+# as a literal relative path, joined to the quadlet directory, and fails the
+# unit (podman exit 125). So the optional override is emitted only when it
+# actually exists on the host -- see get_env_files_section().
 DEFAULT_ENV_FILE = Path("/etc/default/onetimesecret")
+LOCAL_ENV_FILE = Path("/etc/default/onetimesecret.local")
 
 # Quadlet template with {secrets_section} placeholder for dynamic generation
 WEB_TEMPLATE = """\
@@ -86,9 +94,11 @@ PodmanArgs=--log-opt tag=onetime-web-%i
 # Port is derived from instance name: onetime-web@7043 -> PORT=7043
 Environment=PORT=%i
 
-# Infrastructure config: baseline (confext) + optional host overrides
-EnvironmentFile=/etc/default/onetimesecret
-EnvironmentFile=-/etc/default/onetimesecret.local
+# Infrastructure config: baseline (confext) + optional host overrides.
+# Quadlet [Container] EnvironmentFile= has no "-" optional syntax, so the
+# .local override is emitted only when it exists on the host (see
+# get_env_files_section); the baseline is created via confext.
+{env_files_section}
 
 {secrets_section}
 
@@ -132,6 +142,51 @@ def get_secrets_section(
         A comment string indicating secrets are loaded via EnvironmentFile.
     """
     return "# Secrets loaded via EnvironmentFile layered pattern"
+
+
+def get_env_files_section(
+    cfg: Config,  # noqa: ARG001
+    *,
+    executor: Executor | None = None,
+    render_mode: bool = False,
+) -> str:
+    """Generate EnvironmentFile= directives for the [Container] section.
+
+    Quadlet's [Container] EnvironmentFile= forwards its value verbatim to
+    ``podman run --env-file``. Unlike systemd's [Service] EnvironmentFile=, it
+    does NOT support the leading ``-`` ("ignore if missing") prefix: a ``-`` is
+    treated as a literal relative path, joined to the quadlet directory, and
+    fails the unit (podman exit 125). So the optional host-override file must be
+    emitted only when it actually exists.
+
+    Always emits the baseline ``/etc/default/onetimesecret`` (created via
+    confext). Adds ``/etc/default/onetimesecret.local`` only when that file
+    exists on the target host.
+
+    In render mode there is no host to probe (the no-host-I/O contract of
+    ``--render``), so only the baseline is emitted and the override -- being
+    host-specific state -- is resolved at deploy time. This mirrors how
+    :func:`get_config_volumes_section` defers host probing.
+    """
+    lines = [f"EnvironmentFile={DEFAULT_ENV_FILE}"]
+
+    if render_mode:
+        lines.append(
+            "# Host override (/etc/default/onetimesecret.local) is added at "
+            "deploy time when present"
+        )
+        return "\n".join(lines)
+
+    from ots_shared.ssh import is_remote
+
+    if is_remote(executor):
+        exists = executor.run(["test", "-f", str(LOCAL_ENV_FILE)]).ok
+    else:
+        exists = LOCAL_ENV_FILE.exists()
+
+    if exists:
+        lines.append(f"EnvironmentFile={LOCAL_ENV_FILE}")
+    return "\n".join(lines)
 
 
 def get_config_volumes_section(
@@ -268,6 +323,7 @@ def _build_fmt_vars(
     config_volumes_section = get_config_volumes_section(
         cfg, executor=executor, config_source=config_source
     )
+    env_files_section = get_env_files_section(cfg, executor=executor, render_mode=render_mode)
 
     if cfg.registry:
         image = "onetime.image"
@@ -294,6 +350,7 @@ def _build_fmt_vars(
         "config_dir": cfg.config_dir,
         "secrets_section": secrets_section,
         "config_volumes_section": config_volumes_section,
+        "env_files_section": env_files_section,
         "resource_limits_section": get_resource_limits_section(cfg),
     }
     if extra_vars:
@@ -493,9 +550,11 @@ PodmanArgs=--log-opt tag=onetime-worker-%i
 # Worker ID is derived from instance name: onetime-worker@1 -> WORKER_ID=1
 Environment=WORKER_ID=%i
 
-# Infrastructure config: baseline (confext) + optional host overrides
-EnvironmentFile=/etc/default/onetimesecret
-EnvironmentFile=-/etc/default/onetimesecret.local
+# Infrastructure config: baseline (confext) + optional host overrides.
+# Quadlet [Container] EnvironmentFile= has no "-" optional syntax, so the
+# .local override is emitted only when it exists on the host (see
+# get_env_files_section); the baseline is created via confext.
+{env_files_section}
 
 {secrets_section}
 
@@ -597,9 +656,11 @@ PodmanArgs=--log-opt tag=onetime-scheduler-%i
 # Scheduler ID is derived from instance name: onetime-scheduler@main -> SCHEDULER_ID=main
 Environment=SCHEDULER_ID=%i
 
-# Infrastructure config: baseline (confext) + optional host overrides
-EnvironmentFile=/etc/default/onetimesecret
-EnvironmentFile=-/etc/default/onetimesecret.local
+# Infrastructure config: baseline (confext) + optional host overrides.
+# Quadlet [Container] EnvironmentFile= has no "-" optional syntax, so the
+# .local override is emitted only when it exists on the host (see
+# get_env_files_section); the baseline is created via confext.
+{env_files_section}
 
 {secrets_section}
 

--- a/tests/test_quadlet.py
+++ b/tests/test_quadlet.py
@@ -94,7 +94,11 @@ class TestContainerTemplate:
         content = cfg.web_template_path.read_text()
         # Uses fixed path for infrastructure config (not per-instance)
         assert "EnvironmentFile=/etc/default/onetimesecret" in content
-        assert "EnvironmentFile=-/etc/default/onetimesecret.local" in content
+        # Regression guard: Quadlet [Container] EnvironmentFile= has no "-"
+        # optional syntax; a dash is taken as a literal path and fails the
+        # unit (podman exit 125). The .local override must never be emitted
+        # with a leading dash.
+        assert "EnvironmentFile=-" not in content
 
     def test_write_web_template_includes_syslog_tag(self, mocker, tmp_path):
         """Container quadlet should include syslog tag for unified log filtering."""
@@ -482,7 +486,11 @@ class TestWorkerTemplate:
 
         content = cfg.worker_template_path.read_text()
         assert "EnvironmentFile=/etc/default/onetimesecret" in content
-        assert "EnvironmentFile=-/etc/default/onetimesecret.local" in content
+        # Regression guard: Quadlet [Container] EnvironmentFile= has no "-"
+        # optional syntax; a dash is taken as a literal path and fails the
+        # unit (podman exit 125). The .local override must never be emitted
+        # with a leading dash.
+        assert "EnvironmentFile=-" not in content
 
     def test_write_worker_template_includes_config_volume(self, mocker, tmp_path):
         """Worker quadlet should mount per-file config volumes."""
@@ -742,7 +750,11 @@ class TestSchedulerTemplate:
 
         content = cfg.scheduler_template_path.read_text()
         assert "EnvironmentFile=/etc/default/onetimesecret" in content
-        assert "EnvironmentFile=-/etc/default/onetimesecret.local" in content
+        # Regression guard: Quadlet [Container] EnvironmentFile= has no "-"
+        # optional syntax; a dash is taken as a literal path and fails the
+        # unit (podman exit 125). The .local override must never be emitted
+        # with a leading dash.
+        assert "EnvironmentFile=-" not in content
 
     def test_write_scheduler_template_includes_config_volume(self, mocker, tmp_path):
         """Scheduler quadlet should mount per-file config volumes."""
@@ -895,6 +907,58 @@ class TestGetConfigVolumesSection:
         assert f"Volume={config_dir}/config.yaml:/app/etc/config.yaml:ro" in result
         assert f"Volume={config_dir}/auth.yaml:/app/etc/auth.yaml:ro" in result
         assert "logging.yaml" not in result
+
+
+class TestGetEnvFilesSection:
+    """Tests for get_env_files_section() -- the [Container] EnvironmentFile= lines.
+
+    Regression coverage for the podman exit-125 bug: Quadlet [Container]
+    EnvironmentFile= does not honor systemd's "-" optional prefix, so the
+    optional .local override must be emitted only when it exists, never with a
+    leading dash.
+    """
+
+    def test_baseline_always_emitted_no_dash(self, tmp_path, mocker):
+        """Baseline is always present; no entry ever carries a leading dash."""
+        from rots import quadlet
+        from rots.config import Config
+
+        # Force the override to be absent regardless of the host machine.
+        mocker.patch.object(quadlet, "LOCAL_ENV_FILE", tmp_path / "absent.local")
+
+        result = quadlet.get_env_files_section(Config())
+        assert "EnvironmentFile=/etc/default/onetimesecret" in result
+        assert "EnvironmentFile=-" not in result
+        assert "onetimesecret.local" not in result
+
+    def test_override_emitted_without_dash_when_present(self, tmp_path, mocker):
+        """When .local exists on the host, it is added as a plain (dash-free) entry."""
+        from rots import quadlet
+        from rots.config import Config
+
+        local = tmp_path / "onetimesecret.local"
+        local.write_text("FOO=bar\n")
+        mocker.patch.object(quadlet, "LOCAL_ENV_FILE", local)
+
+        result = quadlet.get_env_files_section(Config())
+        assert "EnvironmentFile=/etc/default/onetimesecret" in result
+        assert f"EnvironmentFile={local}" in result
+        assert "EnvironmentFile=-" not in result
+
+    def test_render_mode_emits_baseline_only(self, tmp_path, mocker):
+        """Render mode (no host I/O) emits baseline only, never probing the override."""
+        from rots import quadlet
+        from rots.config import Config
+
+        # Even if a like-named file exists locally, render mode must not probe it.
+        local = tmp_path / "onetimesecret.local"
+        local.write_text("FOO=bar\n")
+        mocker.patch.object(quadlet, "LOCAL_ENV_FILE", local)
+
+        result = quadlet.get_env_files_section(Config(), render_mode=True)
+        assert "EnvironmentFile=/etc/default/onetimesecret" in result
+        assert f"EnvironmentFile={local}" not in result
+        assert "EnvironmentFile=-" not in result
 
 
 class TestGetSecretsSection:

--- a/uv.lock
+++ b/uv.lock
@@ -1085,7 +1085,7 @@ wheels = [
 
 [[package]]
 name = "rots"
-version = "0.7.4"
+version = "0.7.5"
 source = { editable = "." }
 dependencies = [
     { name = "cyclopts" },


### PR DESCRIPTION
## What & why

`rots instance deploy` put containers into a restart loop (podman exit 125) on any host whose quadlet was regenerated by v0.7.4+. The generated `[Container]` section emitted `EnvironmentFile=-/etc/default/onetimesecret.local`. Quadlet does **not** honor systemd's `-` ("optional") prefix — unlike a `[Service]` unit — and forwarded the value verbatim to `podman run --env-file`. Podman read the leading `-` as a relative path, joined it to the quadlet dir (`/etc/containers/systemd/-/etc/default/onetimesecret.local`), failed to open it, and exited 125.

Regression from a7f854e ("Use two-file layered EnvironmentFile pattern"), shipped in v0.7.4: the `-` was valid while the directive briefly lived in `[Service]` (7047b91) but became invalid when it moved to `[Container]`.

## Fix

Replace the hardcoded two-line `EnvironmentFile=` block in all three templates (web/worker/scheduler) with `get_env_files_section()`, mirroring `get_config_volumes_section`:

- Baseline `/etc/default/onetimesecret` always emitted (created via confext).
- `.local` host override emitted **only when it exists** on the target host (remote-aware probe), **never with a dash**.
- Render mode emits baseline only, honoring the `--render` no-host-I/O contract.
- Regression guards assert no `EnvironmentFile=` entry ever carries a leading `-`.

Bumps to **0.7.5** (changelog collected, lockfile refreshed) — hotfix for the production blocker.

## Tests

121 quadlet/render tests + full suite green (2548 passed with podman up). The one unrelated rabbitmq failure is a pre-existing test-isolation bug, present at v0.7.4.

Related to a7f854e.