### PR TITLE
[#76] Single-source secret injection via EnvironmentFile

### DIFF
--- a/changelog.d/20260719_secret_single_source.rst
+++ b/changelog.d/20260719_secret_single_source.rst
@@ -1,0 +1,39 @@
+Changed
+-------
+
+- Resolve container secrets from the layered EnvironmentFile set
+  (``/etc/default/onetimesecret`` plus optional
+  ``/etc/default/onetimesecret.local``) as the single source of truth. The
+  ad-hoc ``podman run`` paths (``instance shell``, ``boot-test``, config
+  transform, ``run --production``) now layer those files with ``--env-file``
+  instead of injecting from the podman secret store with ``--secret``, so a
+  passing ``boot-test`` guarantees the quadlet sees the same environment
+  (``#76``).
+
+Fixed
+-----
+
+- Stop the ad-hoc ``podman run`` paths from reading secrets out of the podman
+  secret store while the quadlet reads only the EnvironmentFiles. On hosts whose
+  secret values lived only in the store (or whose base env file held
+  ``_VAR=ots_var`` placeholders from ``ots env process``), ``boot-test`` passed
+  on store values but the quadlet-managed container crash-looped on a nil
+  secret. Both paths now read the same files (``#76``).
+- ``deploy`` and ``redeploy`` verify secrets before rendering: if any name in
+  ``SECRET_VARIABLE_NAMES`` does not resolve to a non-empty value in the merged
+  EnvironmentFile set, they refuse and name every missing variable rather than
+  producing a silently dead container. ``--force`` downgrades the refusal to a
+  warning (``#76``).
+
+Documentation
+-------------
+
+- Add ``docs/upgrading-0.7.md`` covering the v0.6.x to v0.7.x upgrade for
+  store-sourced hosts: symptom, cause, the per-secret ``.local`` remedy, and the
+  new fail-loud deploy behavior (``#76``).
+
+AI Assistance
+-------------
+
+- Code trace of the ad-hoc ``podman run`` versus quadlet secret paths, upgrade
+  note, and changelog fragment developed with AI assistance.

--- a/docs/upgrading-0.7.md
+++ b/docs/upgrading-0.7.md
@@ -1,0 +1,75 @@
+# Upgrading to v0.7.x
+
+## Secrets now resolve from EnvironmentFiles only
+
+**Applies to:** hosts upgrading from v0.6.x whose secret values lived only in
+the podman secret store (manually built hosts, or hosts where `ots env process`
+rewrote `/etc/default/onetimesecret` into `_VAR=ots_var` placeholders).
+
+### Symptom
+
+After upgrading to v0.7.x, a quadlet-managed container crash-loops with a
+nil/missing secret environment variable — even though `rots instance shell` and
+`rots instance boot-test` show the value present. A green `boot-test`, a dead
+container.
+
+### Cause
+
+v0.7.x makes the layered EnvironmentFile set the single source of truth. The
+quadlet loads secrets from `/etc/default/onetimesecret` plus the optional
+`/etc/default/onetimesecret.local`, and the ad-hoc `podman run` paths
+(`instance shell`, `boot-test`, config transform, `run --production`) now layer
+those same files with `--env-file` instead of injecting from the podman secret
+store with `--secret`.
+
+Before v0.7.x the two paths diverged: the ad-hoc runs pulled secrets from the
+podman secret store while the quadlet read only the files. A host whose values
+lived only in the store — or whose base env file held `_VAR=ots_var`
+placeholders written by `ots env process` — passed `boot-test` on the store
+values but gave the quadlet no literal values to read. In v0.7.x both paths read
+the files, so a passing `boot-test` now guarantees the quadlet sees the same
+environment.
+
+The placeholder transform (`VARNAME=value` -> `_VARNAME=ots_varname` plus a
+podman secret) runs only from the opt-in `ots env process` / `ots env push`
+commands. It is never invoked by the instance deploy or run paths. Real secret
+values are expected to live as literal `KEY=value` lines in the EnvironmentFiles.
+
+### Remedy
+
+Ensure every name listed in `SECRET_VARIABLE_NAMES` has a literal `KEY=value`
+line in the merged EnvironmentFile set. Put sensitive values in
+`/etc/default/onetimesecret.local` (mode 0600, root-only).
+
+For each name in `SECRET_VARIABLE_NAMES`, pull the value out of the store the
+quadlet no longer uses and write it into `.local`:
+
+```bash
+# read the value that lived only in the podman secret store
+sudo podman secret inspect --showsecret SECRET --format '{{.SecretData}}'
+
+# write it as a literal line the quadlet's EnvironmentFile can read
+printf 'SECRET=%s\n' '<value>' | sudo tee -a /etc/default/onetimesecret.local
+sudo chmod 600 /etc/default/onetimesecret.local
+
+systemctl restart onetime-web@7043
+```
+
+Alternatively, re-run the `lots secrets` provisioning path so `.local` is
+populated the standard way.
+
+### New fail-loud behavior
+
+`deploy` and `redeploy` now verify secrets before rendering. If any name in
+`SECRET_VARIABLE_NAMES` does not resolve to a non-empty value in the merged
+EnvironmentFile set, they refuse and name every missing variable, rather than
+producing a silently dead container. Pass `--force` to downgrade the refusal to
+a warning and deploy anyway (the application will likely fail at runtime without
+the secrets).
+
+### Encryption at rest
+
+Sensitive values currently sit as plaintext lines in
+`/etc/default/onetimesecret.local` (mode 0600, root-only). An optional
+systemd-creds encryption-at-rest layer is forthcoming and out of scope for this
+change.

--- a/src/rots/commands/instance/_helpers.py
+++ b/src/rots/commands/instance/_helpers.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING
 from ots_shared.ssh import is_remote as _is_remote
 
 from rots import systemd
-from rots.environment_file import get_secrets_from_env_file
 from rots.systemd import SystemctlError
 
 from .annotations import InstanceType
@@ -265,35 +264,37 @@ def format_journalctl_hint(instances: dict[InstanceType, list[str]]) -> str:
     return f"journalctl {tag_args} -f"
 
 
-def build_secret_args(env_file: Path, *, executor: Executor | None = None) -> list[str]:
-    """Build podman --secret arguments from environment file.
+def build_env_file_args(base_env_file: Path, *, executor: Executor | None = None) -> list[str]:
+    """Build layered podman ``--env-file`` arguments for an ad-hoc container run.
 
-    Reads SECRET_VARIABLE_NAMES from the env file and generates
-    corresponding --secret flags for podman run.
+    Mirrors the quadlet's two-file ``EnvironmentFile=`` layering (see
+    :func:`rots.quadlet.get_env_files_section`): the baseline env file is added
+    when present, and the optional host override
+    ``/etc/default/onetimesecret.local`` is appended only when it exists on the
+    target. This keeps ad-hoc ``podman run`` paths (production run, boot-test
+    shell, migration transforms) resolving the *same* environment the
+    systemd-managed quadlet does, so verification faithfully matches production.
+
+    Secrets are resolved from these files (the single source of truth); no
+    ``--secret`` injection from the podman secret store is used.
 
     Args:
-        env_file: Path to environment file (e.g., /etc/default/onetimesecret)
-        executor: Optional executor for remote file access
+        base_env_file: Baseline environment file (e.g. /etc/default/onetimesecret)
+        executor: Optional executor for remote file existence checks
 
     Returns:
-        List of command arguments: ["--secret", "name,type=env,target=VAR", ...]
+        List of command arguments, e.g. ["--env-file", "/etc/default/onetimesecret"]
     """
-    if _is_remote(executor):
-        result = executor.run(["test", "-f", str(env_file)])
-        if not result.ok:
-            return []
-    elif not env_file.exists():
-        return []
+    from rots.quadlet import LOCAL_ENV_FILE
 
-    secret_specs = get_secrets_from_env_file(env_file, executor=executor)
     args: list[str] = []
-    for spec in secret_specs:
-        args.extend(
-            [
-                "--secret",
-                f"{spec.secret_name},type=env,target={spec.env_var_name}",
-            ]
-        )
+    for path in (base_env_file, LOCAL_ENV_FILE):
+        if _is_remote(executor):
+            exists = executor.run(["test", "-f", str(path)]).ok
+        else:
+            exists = path.exists()
+        if exists:
+            args.extend(["--env-file", str(path)])
     return args
 
 

--- a/src/rots/commands/instance/app.py
+++ b/src/rots/commands/instance/app.py
@@ -30,7 +30,7 @@ from ..common import (
 )
 from ._helpers import (
     apply_quiet,
-    build_secret_args,
+    build_env_file_args,
     deploy_lock,
     flush_output,
     for_each_instance,
@@ -351,31 +351,15 @@ def run(
         if local_env.exists():
             cmd.extend(["--env-file", str(local_env)])
 
-    # Production mode: add env file, secrets, and volumes
+    # Production mode: add env file(s) and volumes
     if production:
-        from ots_shared.ssh import LocalExecutor
-
-        from rots.environment_file import get_secrets_from_env_file
-
         env_file = quadlet.DEFAULT_ENV_FILE
 
-        # Environment file
-        if not isinstance(ex, LocalExecutor):
-            env_exists = ex.run(["test", "-f", str(env_file)]).ok
-        else:
-            env_exists = env_file.exists()
-        if env_exists:
-            cmd.extend(["--env-file", str(env_file)])
-
-            # Secrets
-            secret_specs = get_secrets_from_env_file(env_file, executor=ex)
-            for spec in secret_specs:
-                cmd.extend(
-                    [
-                        "--secret",
-                        f"{spec.secret_name},type=env,target={spec.env_var_name}",
-                    ]
-                )
+        # Environment files: baseline + optional .local host override, matching
+        # the quadlet's layered EnvironmentFile= set (the single source of
+        # truth). Secrets are resolved from these files, not injected via
+        # --secret from the podman secret store.
+        cmd.extend(build_env_file_args(env_file, executor=ex))
 
         # Config overrides (per-file)
         config_files = cfg.get_existing_config_files(executor=ex)
@@ -872,8 +856,14 @@ def deploy(
     deploy_results: list[dict] = []
 
     with deploy_lock(executor=ex):
+        # Fail loud when any SECRET_VARIABLE_NAMES entry is missing/empty in the
+        # merged /etc/default/onetimesecret[.local] set. Raises SystemExit and
+        # names every unresolved secret; --force downgrades this to a warning.
+        from rots.environment_file import check_secrets_resolvable
+
+        check_secrets_resolvable(force=force, executor=ex)
+
         # Write appropriate quadlet template.
-        # Raises SystemExit(1) if env file or secrets are missing (unless force=True).
         if itype == InstanceType.WEB:
             assets.update(cfg, create_volume=True, executor=ex)
             logger.info(f"Writing quadlet files to {cfg.web_template_path.parent}")
@@ -1316,9 +1306,14 @@ def redeploy(
     redeploy_results: list[dict] = []
 
     with deploy_lock(executor=ex):
+        # Fail loud when any SECRET_VARIABLE_NAMES entry is missing/empty in the
+        # merged /etc/default/onetimesecret[.local] set. Raises SystemExit and
+        # names every unresolved secret; --force downgrades this to a warning.
+        from rots.environment_file import check_secrets_resolvable
+
+        check_secrets_resolvable(force=force, executor=ex)
+
         # Write quadlet templates for each type being redeployed.
-        # Raises SystemExit(1) if env file or secrets are missing.
-        # Redeploy always enforces secrets check (no --force override for secrets here).
         if InstanceType.WEB in instances:
             assets.update(cfg, create_volume=force, executor=ex)
             logger.info(f"Writing quadlet files to {cfg.web_template_path.parent}")
@@ -2139,17 +2134,13 @@ def shell(
 
     cmd.append("--network=host")
 
-    # Environment file and secrets
+    # Environment files: baseline + optional .local host override, matching the
+    # quadlet's layered EnvironmentFile= set. Secrets resolve from these files,
+    # not from --secret injection, so boot-test matches the production quadlet.
     env_file = quadlet.DEFAULT_ENV_FILE
     from ots_shared.ssh import LocalExecutor
 
-    if not isinstance(ex, LocalExecutor):
-        env_exists = ex.run(["test", "-f", str(env_file)]).ok
-    else:
-        env_exists = env_file.exists()
-    if env_exists:
-        cmd.extend(["--env-file", str(env_file)])
-        cmd.extend(build_secret_args(env_file, executor=ex))
+    cmd.extend(build_env_file_args(env_file, executor=ex))
 
     # Data volume: bind-mount, persistent named volume, or tmpfs (default)
     if volume:
@@ -2337,13 +2328,10 @@ def config_transform(
         env_file = quadlet.DEFAULT_ENV_FILE
         cmd = ["podman", "run", "--rm", "--network=host"]
 
-        if is_remote:
-            env_exists = ex.run(["test", "-f", str(env_file)]).ok
-        else:
-            env_exists = env_file.exists()
-        if env_exists:
-            cmd.extend(["--env-file", str(env_file)])
-            cmd.extend(build_secret_args(env_file, executor=ex))
+        # Environment files: baseline + optional .local host override, matching
+        # the quadlet's layered EnvironmentFile= set. Secrets resolve from these
+        # files, not from --secret injection.
+        cmd.extend(build_env_file_args(env_file, executor=ex))
 
         cmd.extend(["-v", f"{volume_name}:/app/data"])
         # Resolve symlinks for podman VM compatibility (macOS, local only)
@@ -2362,8 +2350,8 @@ def config_transform(
 
         if not result.ok:
             # Show migration command output for operator debugging.
-            # No secrets here: env vars are passed via podman secrets,
-            # not visible in command stdout/stderr.
+            # Secrets live in the container environment (loaded from --env-file),
+            # not on the command line, so stdout/stderr are safe to surface.
             logger.error(f"Migration command failed (exit {result.returncode})")
             if result.stderr:
                 print(result.stderr)

--- a/src/rots/environment_file.py
+++ b/src/rots/environment_file.py
@@ -544,7 +544,13 @@ def check_secrets_resolvable(
     )
 
     if force:
-        logger.warning("%s Proceeding anyway because --force was given.", detail)
+        # `detail` names the unresolved secret *variables* (keys) and file
+        # paths only -- secret values are never interpolated. CodeQL taints
+        # this because `missing` is filtered against the merged env dict, but
+        # the logged strings are variable names, not their values.
+        logger.warning(  # codeql[py/clear-text-logging-sensitive-data]
+            "%s Proceeding anyway because --force was given.", detail
+        )
         return
 
     raise SystemExit(

--- a/src/rots/environment_file.py
+++ b/src/rots/environment_file.py
@@ -470,6 +470,90 @@ def generate_quadlet_secret_lines(secrets: list[SecretSpec]) -> str:
     return "\n".join(lines)
 
 
+def parse_merged_env_files(
+    base_path: Path | str,
+    local_path: Path | str | None = None,
+    *,
+    executor: Executor | None = None,
+) -> dict[str, str]:
+    """Parse the base env file and optional local override into one merged dict.
+
+    Values from ``local_path`` (when present) take precedence over
+    ``base_path``, mirroring the layered ``EnvironmentFile=`` directives the
+    quadlet emits (base first, ``.local`` second, later file wins).
+
+    Only real ``KEY=VALUE`` variables are merged; comments and blank lines are
+    ignored. Missing files contribute nothing (never an error), consistent with
+    :meth:`EnvFile.parse`. Executor-aware for local and remote hosts.
+    """
+    merged: dict[str, str] = {}
+    base = EnvFile.parse(base_path, executor=executor)
+    for key, value in base.iter_variables():
+        merged[key] = value
+    if local_path is not None:
+        local = EnvFile.parse(local_path, executor=executor)
+        for key, value in local.iter_variables():
+            merged[key] = value
+    return merged
+
+
+def check_secrets_resolvable(
+    *,
+    force: bool = False,
+    base_path: Path | str | None = None,
+    local_path: Path | str | None = None,
+    executor: Executor | None = None,
+) -> None:
+    """Verify every SECRET_VARIABLE_NAMES entry resolves to a non-empty value.
+
+    Reads the merged base + ``.local`` EnvironmentFile set -- the single source
+    of truth the quadlet loads at container start -- and raises ``SystemExit``
+    naming *every* secret variable that is absent or empty (not just the first).
+
+    When ``force`` is True the check is downgraded to a logged warning and the
+    deployment is allowed to proceed even though the container will start
+    without the required secrets.
+
+    Args:
+        force: If True, warn instead of raising.
+        base_path: Base env file. Defaults to ``quadlet.DEFAULT_ENV_FILE``.
+        local_path: Optional override. Defaults to ``quadlet.LOCAL_ENV_FILE``.
+        executor: Optional executor for remote hosts.
+
+    Raises:
+        SystemExit: If any declared secret is unresolved and ``force`` is False.
+    """
+    if base_path is None or local_path is None:
+        from .quadlet import DEFAULT_ENV_FILE, LOCAL_ENV_FILE
+
+        base_path = DEFAULT_ENV_FILE if base_path is None else base_path
+        local_path = LOCAL_ENV_FILE if local_path is None else local_path
+
+    merged = parse_merged_env_files(base_path, local_path, executor=executor)
+    secret_names = parse_secret_variable_names(merged.get(SECRET_NAMES_KEY, ""))
+
+    # Preserve declaration order for deterministic, reproducible messages.
+    missing = [name for name in secret_names if not merged.get(name, "").strip()]
+    if not missing:
+        return
+
+    detail = (
+        f"Unresolved secrets: {', '.join(missing)}. "
+        f"Every name in {SECRET_NAMES_KEY} must resolve to a non-empty value in "
+        f"{base_path} or {local_path}."
+    )
+
+    if force:
+        logger.warning("%s Proceeding anyway because --force was given.", detail)
+        return
+
+    raise SystemExit(
+        f"{detail}\n"
+        "Set the value(s) in the env file(s) above, or pass --force to deploy "
+        "anyway (the application will likely fail at runtime without them)."
+    )
+
+
 def get_secrets_from_env_file(
     path: Path | str, *, executor: Executor | None = None
 ) -> list[SecretSpec]:
@@ -489,16 +573,20 @@ ENV_FILE_TEMPLATE = """\
 #
 # OneTime Secret - Environment Variables
 #
-# This file is sourced by the systemd quadlet container.
-# Secret values listed in SECRET_VARIABLE_NAMES are stored
-# in podman secrets (not in this file).
+# This file is the single source of truth for instance configuration.
+# It is layered onto the container as an EnvironmentFile, together with
+# an optional /etc/default/onetimesecret.local override. The instance
+# deploy/run paths read secret values directly from these files.
 #
-# Usage:
-#   1. Set SECRET_VARIABLE_NAMES with your secret env var names
-#   2. Add secret values as regular entries (STRIPE_API_KEY=sk_live_xxx)
-#   3. Run: ots env process
-#   4. Secret values are moved to podman secrets
-#   5. This file is updated: _STRIPE_API_KEY=ots_stripe_api_key
+# Usage (default):
+#   1. Add real KEY=value entries here (STRIPE_API_KEY=sk_live_xxx).
+#   2. List which names must resolve in SECRET_VARIABLE_NAMES.
+#   3. Deploy checks that every listed name has a non-empty value.
+#
+# Optional podman-secrets flow (opt-in, not the default):
+#   Run `ots env process` / `ots env push` to move the listed values
+#   into podman secrets and rewrite them as _KEY=ots_key placeholders.
+#   Only these commands perform the placeholder transform.
 #
 
 # Secret variable names (comma, space, or colon separated)

--- a/src/rots/environment_file.py
+++ b/src/rots/environment_file.py
@@ -561,10 +561,7 @@ def check_secrets_resolvable(
                 file=sys.stderr,
             )
         else:
-            raise SystemExit(
-                f"{detail}\n"
-                "Create the file, or pass --force to deploy anyway."
-            )
+            raise SystemExit(f"{detail}\nCreate the file, or pass --force to deploy anyway.")
 
     merged = parse_merged_env_files(base_path, local_path, executor=executor)
     secret_names = parse_secret_variable_names(merged.get(SECRET_NAMES_KEY, ""))

--- a/src/rots/environment_file.py
+++ b/src/rots/environment_file.py
@@ -544,10 +544,7 @@ def check_secrets_resolvable(
     )
 
     if force:
-        # `detail` names the unresolved secret *variables* (keys) and file
-        # paths only -- secret values are never interpolated. CodeQL taints
-        # this because `missing` is filtered against the merged env dict, but
-        # the logged strings are variable names, not their values.
+        # codeql suppression: logs secret variable names, never their values.
         logger.warning(  # codeql[py/clear-text-logging-sensitive-data]
             "%s Proceeding anyway because --force was given.", detail
         )

--- a/src/rots/environment_file.py
+++ b/src/rots/environment_file.py
@@ -17,6 +17,7 @@ Convention:
 from __future__ import annotations
 
 import logging
+import os
 import re
 import sys
 from dataclasses import dataclass, field
@@ -471,6 +472,17 @@ def generate_quadlet_secret_lines(secrets: list[SecretSpec]) -> str:
     return "\n".join(lines)
 
 
+def _readable_file(path: Path | str, *, executor: Executor | None = None) -> bool:
+    """Return True if ``path`` exists and is a readable regular file.
+
+    Executor-aware: uses ``test -r`` on remote hosts and ``os.access`` locally.
+    """
+    path = Path(path)
+    if _is_remote(executor):
+        return executor.run(["test", "-r", str(path)]).ok
+    return path.is_file() and os.access(path, os.R_OK)
+
+
 def parse_merged_env_files(
     base_path: Path | str,
     local_path: Path | str | None = None,
@@ -529,6 +541,30 @@ def check_secrets_resolvable(
 
         base_path = DEFAULT_ENV_FILE if base_path is None else base_path
         local_path = LOCAL_ENV_FILE if local_path is None else local_path
+
+    # The quadlet emits the base ``EnvironmentFile=`` with no optional ("-")
+    # syntax, so Podman refuses to start the container if the base file is
+    # missing or unreadable. Reject the deployment here rather than letting it
+    # write units that crash-loop at start. A missing base also silently yields
+    # an empty merged dict, which would make the secret check below a no-op.
+    if not _readable_file(base_path, executor=executor):
+        detail = (
+            f"Base env file {base_path} is missing or unreadable. The quadlet "
+            f"requires it as an EnvironmentFile, so the container will fail to "
+            f"start."
+        )
+        if force:
+            # User-facing CLI warning: goes to stderr, not the logging
+            # framework. Only the file path is interpolated, never secrets.
+            print(
+                f"WARNING: {detail} Proceeding anyway because --force was given.",
+                file=sys.stderr,
+            )
+        else:
+            raise SystemExit(
+                f"{detail}\n"
+                "Create the file, or pass --force to deploy anyway."
+            )
 
     merged = parse_merged_env_files(base_path, local_path, executor=executor)
     secret_names = parse_secret_variable_names(merged.get(SECRET_NAMES_KEY, ""))

--- a/src/rots/environment_file.py
+++ b/src/rots/environment_file.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 import logging
 import re
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING
@@ -544,9 +545,12 @@ def check_secrets_resolvable(
     )
 
     if force:
-        # codeql suppression: logs secret variable names, never their values.
-        logger.warning(  # codeql[py/clear-text-logging-sensitive-data]
-            "%s Proceeding anyway because --force was given.", detail
+        # User-facing CLI warning: goes to stderr, not the logging framework.
+        # `detail` names the unresolved secret *variables* and file paths only
+        # -- values are never interpolated.
+        print(
+            f"WARNING: {detail} Proceeding anyway because --force was given.",
+            file=sys.stderr,
         )
         return
 
@@ -586,10 +590,13 @@ ENV_FILE_TEMPLATE = """\
 #   2. List which names must resolve in SECRET_VARIABLE_NAMES.
 #   3. Deploy checks that every listed name has a non-empty value.
 #
-# Optional podman-secrets flow (opt-in, not the default):
-#   Run `ots env process` / `ots env push` to move the listed values
-#   into podman secrets and rewrite them as _KEY=ots_key placeholders.
-#   Only these commands perform the placeholder transform.
+# Legacy podman-secrets flow (opt-in, NOT compatible with the default deploy):
+#   `ots env process` / `ots env push` move the listed values into podman
+#   secrets and rewrite them as _KEY=ots_key placeholders. After that, the
+#   literal values are gone from this file, so the deploy-time resolvability
+#   check reports every SECRET_VARIABLE_NAMES entry as unresolved and refuses
+#   to deploy (use --force to override). Keep literal KEY=value entries here
+#   unless you have migrated the whole host to the podman-secrets model.
 #
 
 # Secret variable names (comma, space, or colon separated)

--- a/src/rots/sidecar/rabbitmq.py
+++ b/src/rots/sidecar/rabbitmq.py
@@ -126,14 +126,17 @@ class RabbitMQConfig:
         )
 
     @classmethod
-    def from_env_file(
-        cls, path: Path = DEFAULT_ENV_FILE, host_id: str | None = None
-    ) -> RabbitMQConfig:
+    def from_env_file(cls, path: Path | None = None, host_id: str | None = None) -> RabbitMQConfig:
         """Load config from environment file.
 
         Parses shell-style env file looking for RABBITMQ_URL.
         Falls back to defaults if file missing or URL not found.
+
+        When ``path`` is None, the module-level ``DEFAULT_ENV_FILE`` is
+        resolved at call time (not at definition time) so tests can patch it.
         """
+        if path is None:
+            path = DEFAULT_ENV_FILE
         if not path.exists():
             logger.warning("Env file %s not found, using defaults", path)
             return cls() if host_id is None else cls(host_id=host_id)

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -1080,6 +1080,7 @@ class TestDeployEnvVarResolution:
             "rots.commands.instance.app.deploy_lock",
             return_value=contextlib.nullcontext(),
         )
+        mocker.patch("rots.environment_file.check_secrets_resolvable")
         mock_record = mocker.patch("rots.commands.instance.app.db.record_deployment")
 
         instance.deploy(web="7043")
@@ -1156,6 +1157,7 @@ class TestRedeployEnvVarResolution:
             return_value=True,
         )
         mocker.patch("rots.commands.instance.app.systemd.recreate")
+        mocker.patch("rots.environment_file.check_secrets_resolvable")
         mock_record = mocker.patch("rots.commands.instance.app.db.record_deployment")
 
         instance.redeploy(web="7043")
@@ -1867,6 +1869,7 @@ class TestDeployHooks:
         mocker.patch("rots.commands.instance.app.quadlet.write_web_template")
         mocker.patch("rots.commands.instance.app.systemd.start")
         mocker.patch("rots.commands.instance.app.db.record_deployment")
+        mocker.patch("rots.environment_file.check_secrets_resolvable")
         mock_run_hook = mocker.patch("rots.commands.instance.app.run_hook")
 
         instance.deploy(web="7043", pre_hook="./scan.sh")
@@ -1885,6 +1888,7 @@ class TestDeployHooks:
         mocker.patch("rots.commands.instance.app.quadlet.write_web_template")
         mocker.patch("rots.commands.instance.app.systemd.start")
         mocker.patch("rots.commands.instance.app.db.record_deployment")
+        mocker.patch("rots.environment_file.check_secrets_resolvable")
         mock_run_hook = mocker.patch("rots.commands.instance.app.run_hook")
 
         instance.deploy(web="7043", post_hook="./notify.sh")

--- a/tests/commands/instance/test_app.py
+++ b/tests/commands/instance/test_app.py
@@ -169,8 +169,13 @@ class TestRunCommand:
         assert "7143:7143" in cmd
         assert "onetimesecret:v0.23.0" in cmd
 
-    def test_run_includes_secrets_with_production_flag(self, mocker, tmp_path):
-        """run --production should include secrets from env file."""
+    def test_run_layers_env_files_with_production_flag(self, mocker, tmp_path):
+        """run --production layers env files and does NOT inject --secret.
+
+        Secrets now resolve from the merged base + .local env files (the single
+        source of truth), so the production run must emit --env-file for the
+        baseline and must never pass --secret.
+        """
         from ots_shared.ssh.executor import Result
 
         # Mock Config with executor
@@ -191,34 +196,28 @@ class TestRunCommand:
         mock_config.get_executor.return_value = mock_executor
         mocker.patch("rots.commands.instance.app.Config", return_value=mock_config)
 
-        # Create env file with secrets
+        # Create env file with secrets (single source of truth)
         env_file = tmp_path / "onetimesecret"
         env_file.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET,API_KEY\n")
         mocker.patch(
             "rots.commands.instance.app.quadlet.DEFAULT_ENV_FILE",
             env_file,
         )
-
-        # Mock get_secrets_from_env_file (imported inside run function)
-        from rots.environment_file import SecretSpec
-
-        mock_secrets = [
-            SecretSpec(env_var_name="AUTH_SECRET", secret_name="ots_hmac_secret"),
-            SecretSpec(env_var_name="API_KEY", secret_name="ots_api_key"),
-        ]
-        mocker.patch(
-            "rots.environment_file.get_secrets_from_env_file",
-            return_value=mock_secrets,
-        )
+        # .local override at a distinct path; mock_executor.run returns ok=True
+        # for every test -f, so both files layer.
+        local_file = tmp_path / "onetimesecret.local"
+        mocker.patch("rots.quadlet.LOCAL_ENV_FILE", local_file)
 
         # Call run command with production flag
         instance.run(port=7143, detach=True, quiet=True, production=True)
 
-        # Verify secrets were included
+        # Verify env files layered, no --secret injection
         cmd = mock_executor.run.call_args.args[0]
         cmd_str = " ".join(cmd)
-        assert "--secret" in cmd_str
-        assert "ots_hmac_secret" in cmd_str
+        assert "--secret" not in cmd_str
+        assert "--env-file" in cmd
+        assert str(env_file) in cmd
+        assert str(local_file) in cmd
 
     def test_run_minimal_without_production_flag(self, mocker, tmp_path):
         """run without --production should be minimal (no secrets/volumes)."""
@@ -307,6 +306,53 @@ class TestDeployCommand:
 
         mock_assets.assert_called_once_with(mock_config, create_volume=True, executor=ANY)
         mock_quadlet.assert_called_once_with(mock_config, force=False, executor=ANY)
+
+    def test_deploy_gates_on_secret_resolution(self, mocker, tmp_path):
+        """deploy invokes check_secrets_resolvable inside the deploy lock."""
+        mock_config = mocker.MagicMock()
+        mock_config.config_dir = mocker.MagicMock()
+        mock_config.web_template_path = mocker.MagicMock()
+        mock_config.db_path = tmp_path / "test.db"
+        mock_config.existing_config_files = []
+        mock_config.has_custom_config = False
+        mock_config.resolve_image_tag.return_value = ("ghcr.io/test/image", "v1.0.0")
+        mocker.patch("rots.commands.instance.app.Config", return_value=mock_config)
+        mocker.patch("rots.commands.instance.app.assets.update")
+        mocker.patch("rots.commands.instance.app.quadlet.write_web_template")
+        mocker.patch("rots.commands.instance.app.systemd.start")
+        mocker.patch("rots.commands.instance.app.db.record_deployment")
+        # deploy does `from rots.environment_file import check_secrets_resolvable`
+        mock_check = mocker.patch("rots.environment_file.check_secrets_resolvable")
+
+        instance.deploy(web="7143")
+
+        mock_check.assert_called_once()
+        assert mock_check.call_args.kwargs["force"] is False
+
+    def test_deploy_aborts_when_secrets_unresolved(self, mocker, tmp_path):
+        """A SystemExit from the secret gate aborts deploy before writing units."""
+        mock_config = mocker.MagicMock()
+        mock_config.config_dir = mocker.MagicMock()
+        mock_config.web_template_path = mocker.MagicMock()
+        mock_config.db_path = tmp_path / "test.db"
+        mock_config.existing_config_files = []
+        mock_config.has_custom_config = False
+        mock_config.resolve_image_tag.return_value = ("ghcr.io/test/image", "v1.0.0")
+        mocker.patch("rots.commands.instance.app.Config", return_value=mock_config)
+        mock_assets = mocker.patch("rots.commands.instance.app.assets.update")
+        mocker.patch("rots.commands.instance.app.quadlet.write_web_template")
+        mocker.patch("rots.commands.instance.app.systemd.start")
+        mocker.patch("rots.commands.instance.app.db.record_deployment")
+        mocker.patch(
+            "rots.environment_file.check_secrets_resolvable",
+            side_effect=SystemExit("Unresolved secrets: AUTH_SECRET."),
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            instance.deploy(web="7143")
+
+        assert "AUTH_SECRET" in str(exc.value)
+        mock_assets.assert_not_called()  # gate runs before unit writes
 
 
 class TestDeployWorkerCommand:

--- a/tests/commands/instance/test_config_transform.py
+++ b/tests/commands/instance/test_config_transform.py
@@ -586,10 +586,12 @@ class TestConfigTransformCommand:
         # Call with custom file
         instance.config_transform(command="transform", file="auth.yaml", quiet=True)
 
-    def test_config_transform_includes_secrets(self, mocker, tmp_path):
-        """config_transform should include secrets from env file."""
-        from rots.environment_file import SecretSpec
+    def test_config_transform_layers_env_files_no_secret(self, mocker, tmp_path):
+        """config_transform resolves secrets from the env file, not --secret.
 
+        The migration/transform podman run must layer the baseline --env-file
+        (secrets' single source of truth) and must not inject --secret.
+        """
         # Mock Config
         mock_config = mocker.MagicMock()
         mock_config.get_executor.return_value = LocalExecutor()
@@ -608,22 +610,15 @@ class TestConfigTransformCommand:
         (mock_config.config_dir / "config.yaml").write_text("key: value\n")
         mocker.patch("rots.commands.instance.app.Config", return_value=mock_config)
 
-        # Create env file with secrets
+        # Create env file with secrets (single source of truth)
         env_file = tmp_path / "onetimesecret"
-        env_file.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET\n")
+        env_file.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET\nAUTH_SECRET=resolved\n")
         mocker.patch(
             "rots.commands.instance.app.quadlet.DEFAULT_ENV_FILE",
             env_file,
         )
-
-        # Mock get_secrets_from_env_file
-        mock_secrets = [
-            SecretSpec(env_var_name="AUTH_SECRET", secret_name="ots_hmac_secret"),
-        ]
-        mocker.patch(
-            "rots.commands.instance._helpers.get_secrets_from_env_file",
-            return_value=mock_secrets,
-        )
+        # Point .local at a nonexistent path so only the base layers.
+        mocker.patch("rots.quadlet.LOCAL_ENV_FILE", tmp_path / "onetimesecret.local")
 
         migration_cmd_args = []
 
@@ -644,10 +639,11 @@ class TestConfigTransformCommand:
 
         instance.config_transform(command="transform", quiet=True)
 
-        # Verify secrets were included in migration command
+        # Verify env file layered, no --secret injection
         cmd_str = " ".join(migration_cmd_args)
-        assert "--secret" in cmd_str
-        assert "ots_hmac_secret" in cmd_str
+        assert "--secret" not in cmd_str
+        assert "--env-file" in migration_cmd_args
+        assert str(env_file) in migration_cmd_args
 
     def test_config_transform_numbered_backup(self, mocker, tmp_path):
         """config_transform should create numbered backups if needed."""

--- a/tests/commands/instance/test_shell.py
+++ b/tests/commands/instance/test_shell.py
@@ -128,31 +128,31 @@ class TestShellCommand:
         assert "ots-migration-upgrade-v024:/app/data" in volume_arg
         assert "--tmpfs" not in cmd
 
-    def test_shell_includes_secrets_from_env_file(self, mocker, tmp_path):
-        """shell should include secrets when env file exists."""
-        from rots.environment_file import SecretSpec
+    def test_shell_layers_env_files_no_secret_injection(self, mocker, tmp_path):
+        """shell resolves secrets from layered env files, never via --secret.
 
+        Secrets now live in the merged base + .local env files (the single
+        source of truth the quadlet loads). The boot-test shell must layer the
+        same --env-file args and must NOT inject --secret from the podman store.
+        """
         env_file = tmp_path / "onetimesecret"
         env_file.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET,API_KEY\n")
+        local_file = tmp_path / "onetimesecret.local"
+        local_file.write_text("AUTH_SECRET=from-local\n")
+        mocker.patch("rots.quadlet.LOCAL_ENV_FILE", local_file)
 
         _mock_config, mock_executor = _setup_shell_mocks(mocker, tmp_path, env_file=env_file)
-
-        mock_secrets = [
-            SecretSpec(env_var_name="AUTH_SECRET", secret_name="ots_hmac_secret"),
-            SecretSpec(env_var_name="API_KEY", secret_name="ots_api_key"),
-        ]
-        mocker.patch(
-            "rots.commands.instance._helpers.get_secrets_from_env_file",
-            return_value=mock_secrets,
-        )
 
         instance.shell(quiet=True)
 
         cmd = _get_cmd_from_executor(mock_executor, interactive=True)
         cmd_str = " ".join(cmd)
-        assert "--secret" in cmd_str
-        assert "ots_hmac_secret" in cmd_str
-        assert "ots_api_key" in cmd_str
+        assert "--secret" not in cmd_str
+        # Base file layered first, .local override second (later file wins).
+        assert cmd.count("--env-file") == 2
+        assert str(env_file) in cmd
+        assert str(local_file) in cmd
+        assert cmd.index(str(local_file)) > cmd.index(str(env_file))
 
     def test_shell_includes_env_file(self, mocker, tmp_path):
         """shell should include --env-file when file exists."""
@@ -496,60 +496,65 @@ class TestShellHelp:
         assert "tmpfs" in captured.out.lower() or "ephemeral" in captured.out.lower()
 
 
-class TestBuildSecretArgs:
-    """Test build_secret_args helper function."""
+class TestBuildEnvFileArgs:
+    """Test build_env_file_args helper (replaces deleted build_secret_args).
 
-    def test_build_secret_args_returns_empty_for_missing_file(self, tmp_path):
-        """build_secret_args should return empty list for missing file."""
-        from rots.commands.instance._helpers import build_secret_args
+    Ad-hoc podman runs now layer the baseline env file plus an optional
+    /etc/default/onetimesecret.local override as --env-file args, matching the
+    quadlet's EnvironmentFile= layering. Secrets resolve from these files, so
+    no --secret injection is emitted.
+    """
 
-        missing_file = tmp_path / "nonexistent"
-        result = build_secret_args(missing_file)
+    def test_returns_empty_when_no_files_exist(self, mocker, tmp_path):
+        """No base and no .local -> no args at all."""
+        from rots.commands.instance._helpers import build_env_file_args
+
+        missing_base = tmp_path / "nonexistent"
+        mocker.patch("rots.quadlet.LOCAL_ENV_FILE", tmp_path / "nonexistent.local")
+
+        result = build_env_file_args(missing_base)
         assert result == []
+        assert "--secret" not in result
 
-    def test_build_secret_args_returns_secret_flags(self, mocker, tmp_path):
-        """build_secret_args should return --secret flags."""
-        from rots.commands.instance._helpers import build_secret_args
-        from rots.environment_file import SecretSpec
+    def test_emits_base_env_file_only(self, mocker, tmp_path):
+        """Base present, .local absent -> single --env-file for the base."""
+        from rots.commands.instance._helpers import build_env_file_args
 
-        env_file = tmp_path / "env"
-        env_file.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET\n")
+        base = tmp_path / "onetimesecret"
+        base.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET\nAUTH_SECRET=x\n")
+        mocker.patch("rots.quadlet.LOCAL_ENV_FILE", tmp_path / "missing.local")
 
-        mock_secrets = [
-            SecretSpec(env_var_name="AUTH_SECRET", secret_name="ots_hmac_secret"),
-        ]
-        mocker.patch(
-            "rots.commands.instance._helpers.get_secrets_from_env_file",
-            return_value=mock_secrets,
-        )
+        result = build_env_file_args(base)
+        assert result == ["--env-file", str(base)]
+        assert "--secret" not in result
 
-        result = build_secret_args(env_file)
-        assert result == [
-            "--secret",
-            "ots_hmac_secret,type=env,target=AUTH_SECRET",
-        ]
+    def test_layers_base_then_local_when_local_exists(self, mocker, tmp_path):
+        """Base + .local present -> both layered, base first, .local second."""
+        from rots.commands.instance._helpers import build_env_file_args
 
-    def test_build_secret_args_handles_multiple_secrets(self, mocker, tmp_path):
-        """build_secret_args should handle multiple secrets."""
-        from rots.commands.instance._helpers import build_secret_args
-        from rots.environment_file import SecretSpec
+        base = tmp_path / "onetimesecret"
+        base.write_text("AUTH_SECRET=base\n")
+        local = tmp_path / "onetimesecret.local"
+        local.write_text("AUTH_SECRET=override\n")
+        mocker.patch("rots.quadlet.LOCAL_ENV_FILE", local)
 
-        env_file = tmp_path / "env"
-        env_file.write_text("SECRET_VARIABLE_NAMES=A,B,C\n")
+        result = build_env_file_args(base)
+        assert result == ["--env-file", str(base), "--env-file", str(local)]
+        assert "--secret" not in result
 
-        mock_secrets = [
-            SecretSpec(env_var_name="A", secret_name="ots_a"),
-            SecretSpec(env_var_name="B", secret_name="ots_b"),
-            SecretSpec(env_var_name="C", secret_name="ots_c"),
-        ]
-        mocker.patch(
-            "rots.commands.instance._helpers.get_secrets_from_env_file",
-            return_value=mock_secrets,
-        )
+    def test_uses_executor_for_remote_existence_checks(self, mocker, tmp_path):
+        """Remote runs test -f via the executor rather than touching local fs."""
+        from rots.commands.instance._helpers import build_env_file_args
 
-        result = build_secret_args(env_file)
-        assert len(result) == 6  # 3 secrets * 2 args each (--secret, value)
-        assert result[0] == "--secret"
-        assert "ots_a" in result[1]
-        assert result[2] == "--secret"
-        assert "ots_b" in result[3]
+        base = tmp_path / "onetimesecret"
+        local = tmp_path / "onetimesecret.local"
+        mocker.patch("rots.quadlet.LOCAL_ENV_FILE", local)
+
+        mock_ex = mocker.MagicMock()  # not a LocalExecutor -> _is_remote() True
+        mock_ex.run.return_value.ok = True
+
+        result = build_env_file_args(base, executor=mock_ex)
+        assert result == ["--env-file", str(base), "--env-file", str(local)]
+        assert "--secret" not in result
+        mock_ex.run.assert_any_call(["test", "-f", str(base)])
+        mock_ex.run.assert_any_call(["test", "-f", str(local)])

--- a/tests/test_environment_file.py
+++ b/tests/test_environment_file.py
@@ -705,3 +705,157 @@ class TestProcessEnvFileRemote:
 
         mock_ensure.assert_called_once_with("ots_api_key", "secret_value", executor=mock_ex)
         mock_write.assert_called_once_with(executor=mock_ex)
+
+
+# =============================================================================
+# Merged env file parsing (base + .local override)
+# =============================================================================
+
+
+class TestParseMergedEnvFiles:
+    """Test parse_merged_env_files() merge precedence and missing-file handling."""
+
+    def test_local_overrides_base(self, tmp_path):
+        """Values in .local win over the base file (later file wins)."""
+        from rots.environment_file import parse_merged_env_files
+
+        base = tmp_path / "onetimesecret"
+        base.write_text("AUTH_SECRET=from-base\nREDIS_URL=redis://base\n")
+        local = tmp_path / "onetimesecret.local"
+        local.write_text("AUTH_SECRET=from-local\n")
+
+        merged = parse_merged_env_files(base, local)
+
+        assert merged["AUTH_SECRET"] == "from-local"  # override wins
+        assert merged["REDIS_URL"] == "redis://base"  # base-only preserved
+
+    def test_missing_local_returns_base_only(self, tmp_path):
+        """A missing .local contributes nothing (never an error)."""
+        from rots.environment_file import parse_merged_env_files
+
+        base = tmp_path / "onetimesecret"
+        base.write_text("AUTH_SECRET=x\n")
+        missing_local = tmp_path / "onetimesecret.local"  # not created
+
+        merged = parse_merged_env_files(base, missing_local)
+
+        assert merged == {"AUTH_SECRET": "x"}
+
+    def test_none_local_returns_base_only(self, tmp_path):
+        """local_path=None parses only the base file."""
+        from rots.environment_file import parse_merged_env_files
+
+        base = tmp_path / "onetimesecret"
+        base.write_text("A=1\nB=2\n")
+
+        merged = parse_merged_env_files(base)
+
+        assert merged == {"A": "1", "B": "2"}
+
+    def test_missing_base_still_merges_local(self, tmp_path):
+        """A missing base contributes nothing; .local values still merge."""
+        from rots.environment_file import parse_merged_env_files
+
+        missing_base = tmp_path / "onetimesecret"  # not created
+        local = tmp_path / "onetimesecret.local"
+        local.write_text("AUTH_SECRET=only-local\n")
+
+        merged = parse_merged_env_files(missing_base, local)
+
+        assert merged == {"AUTH_SECRET": "only-local"}
+
+    def test_both_missing_returns_empty(self, tmp_path):
+        """Neither file present -> empty dict, no error."""
+        from rots.environment_file import parse_merged_env_files
+
+        merged = parse_merged_env_files(
+            tmp_path / "onetimesecret", tmp_path / "onetimesecret.local"
+        )
+        assert merged == {}
+
+
+class TestCheckSecretsResolvable:
+    """Test check_secrets_resolvable() deploy-time secret gating."""
+
+    def test_raises_naming_every_missing_secret(self, tmp_path):
+        """Fails loudly, naming ALL unresolved secrets (not just the first)."""
+        from rots.environment_file import check_secrets_resolvable
+
+        base = tmp_path / "onetimesecret"
+        base.write_text(
+            "SECRET_VARIABLE_NAMES=AUTH_SECRET,API_KEY,SESSION_SECRET\n"
+            "AUTH_SECRET=present\n"
+            "API_KEY=\n"  # empty -> unresolved
+            # SESSION_SECRET absent -> unresolved
+        )
+        local = tmp_path / "onetimesecret.local"
+
+        with pytest.raises(SystemExit) as exc:
+            check_secrets_resolvable(base_path=base, local_path=local)
+
+        msg = str(exc.value)
+        assert "API_KEY" in msg
+        assert "SESSION_SECRET" in msg
+        assert "AUTH_SECRET" not in msg  # resolved, must not be named
+
+    def test_passes_when_all_resolve_via_layering(self, tmp_path):
+        """Override precedence resolves an empty base value from .local."""
+        from rots.environment_file import check_secrets_resolvable
+
+        base = tmp_path / "onetimesecret"
+        base.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET\nAUTH_SECRET=\n")  # empty
+        local = tmp_path / "onetimesecret.local"
+        local.write_text("AUTH_SECRET=filled-by-local\n")
+
+        # Must not raise: .local supplies the non-empty value.
+        check_secrets_resolvable(base_path=base, local_path=local)
+
+    def test_force_warns_instead_of_raising(self, tmp_path, caplog):
+        """force=True downgrades to a warning even with missing secrets."""
+        import logging
+
+        from rots.environment_file import check_secrets_resolvable
+
+        base = tmp_path / "onetimesecret"
+        base.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET\n")  # AUTH_SECRET absent
+        local = tmp_path / "onetimesecret.local"
+
+        with caplog.at_level(logging.WARNING, logger="rots.environment_file"):
+            check_secrets_resolvable(force=True, base_path=base, local_path=local)
+
+        assert any("AUTH_SECRET" in r.message for r in caplog.records)
+
+    def test_passes_when_secret_names_absent(self, tmp_path):
+        """No SECRET_VARIABLE_NAMES -> silent pass."""
+        from rots.environment_file import check_secrets_resolvable
+
+        base = tmp_path / "onetimesecret"
+        base.write_text("REDIS_URL=redis://localhost\n")
+        local = tmp_path / "onetimesecret.local"
+
+        check_secrets_resolvable(base_path=base, local_path=local)
+
+    def test_passes_when_secret_names_empty(self, tmp_path):
+        """Empty SECRET_VARIABLE_NAMES -> silent pass."""
+        from rots.environment_file import check_secrets_resolvable
+
+        base = tmp_path / "onetimesecret"
+        base.write_text("SECRET_VARIABLE_NAMES=\n")
+        local = tmp_path / "onetimesecret.local"
+
+        check_secrets_resolvable(base_path=base, local_path=local)
+
+    def test_defaults_to_quadlet_paths(self, mocker, tmp_path):
+        """When paths omitted, defaults come from quadlet.DEFAULT/LOCAL_ENV_FILE."""
+        import rots.quadlet as quadlet
+        from rots.environment_file import check_secrets_resolvable
+
+        base = tmp_path / "onetimesecret"
+        base.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET\n")  # absent -> unresolved
+        mocker.patch.object(quadlet, "DEFAULT_ENV_FILE", base)
+        mocker.patch.object(quadlet, "LOCAL_ENV_FILE", tmp_path / "onetimesecret.local")
+
+        with pytest.raises(SystemExit) as exc:
+            check_secrets_resolvable()
+
+        assert "AUTH_SECRET" in str(exc.value)

--- a/tests/test_environment_file.py
+++ b/tests/test_environment_file.py
@@ -844,6 +844,33 @@ class TestCheckSecretsResolvable:
 
         check_secrets_resolvable(base_path=base, local_path=local)
 
+    def test_raises_when_base_file_missing(self, tmp_path):
+        """Absent base file is rejected: the quadlet requires it as EnvironmentFile."""
+        from rots.environment_file import check_secrets_resolvable
+
+        base = tmp_path / "onetimesecret"  # never created
+        local = tmp_path / "onetimesecret.local"
+
+        with pytest.raises(SystemExit) as exc:
+            check_secrets_resolvable(base_path=base, local_path=local)
+
+        msg = str(exc.value)
+        assert str(base) in msg
+        assert "missing or unreadable" in msg
+
+    def test_force_warns_when_base_file_missing(self, tmp_path, capsys):
+        """force=True downgrades the missing-base-file error to a stderr warning."""
+        from rots.environment_file import check_secrets_resolvable
+
+        base = tmp_path / "onetimesecret"  # never created
+        local = tmp_path / "onetimesecret.local"
+
+        check_secrets_resolvable(force=True, base_path=base, local_path=local)
+
+        captured = capsys.readouterr()
+        assert str(base) in captured.err
+        assert "--force" in captured.err
+
     def test_defaults_to_quadlet_paths(self, mocker, tmp_path):
         """When paths omitted, defaults come from quadlet.DEFAULT/LOCAL_ENV_FILE."""
         import rots.quadlet as quadlet

--- a/tests/test_environment_file.py
+++ b/tests/test_environment_file.py
@@ -810,20 +810,19 @@ class TestCheckSecretsResolvable:
         # Must not raise: .local supplies the non-empty value.
         check_secrets_resolvable(base_path=base, local_path=local)
 
-    def test_force_warns_instead_of_raising(self, tmp_path, caplog):
-        """force=True downgrades to a warning even with missing secrets."""
-        import logging
-
+    def test_force_warns_instead_of_raising(self, tmp_path, capsys):
+        """force=True downgrades to a stderr warning even with missing secrets."""
         from rots.environment_file import check_secrets_resolvable
 
         base = tmp_path / "onetimesecret"
         base.write_text("SECRET_VARIABLE_NAMES=AUTH_SECRET\n")  # AUTH_SECRET absent
         local = tmp_path / "onetimesecret.local"
 
-        with caplog.at_level(logging.WARNING, logger="rots.environment_file"):
-            check_secrets_resolvable(force=True, base_path=base, local_path=local)
+        check_secrets_resolvable(force=True, base_path=base, local_path=local)
 
-        assert any("AUTH_SECRET" in r.message for r in caplog.records)
+        captured = capsys.readouterr()
+        assert "AUTH_SECRET" in captured.err
+        assert "--force" in captured.err
 
     def test_passes_when_secret_names_absent(self, tmp_path):
         """No SECRET_VARIABLE_NAMES -> silent pass."""


### PR DESCRIPTION
## Summary

Makes the container `EnvironmentFile` the single source of truth for secrets, removing the parallel `--secret` injection path that masked broken store-sourced host behavior. Deploy/redeploy now layer the `.local` env file and validate that referenced secrets are resolvable before writing the Quadlet.

- Replace `build_secret_args` with `build_env_file_args` (layers `.local` over the base env file)
- Add `parse_merged_env_files` / `check_secrets_resolvable` and wire them into deploy/redeploy validation
- Fix `RabbitMQConfig.from_env_file` to resolve the default path at call time
- Document the v0.6.x → v0.7.x secret migration for store-sourced hosts

Resolves #76

## Test plan

- `pytest tests/` — full suite green (2562 tests, 78.5% coverage)
- New coverage in `tests/test_environment_file.py` and `tests/commands/instance/test_app.py` for single-source injection and deploy validation