### PR TITLE
[#78] Split shell --volume into --data-volume and repeatable general -v mounts

### DIFF
--- a/changelog.d/20260719_split-shell-volume-flags.rst
+++ b/changelog.d/20260719_split-shell-volume-flags.rst
@@ -1,0 +1,28 @@
+Changed
+-------
+
+- Split ``rots instance shell``'s single ``--volume``/``-v`` flag into two
+  distinct flags (#78). ``--data-volume`` (long form only, no short alias)
+  keeps the previous behavior: bind-mount a host directory at the fixed
+  ``/app/data`` target as ``rw,U`` with auto-create of the host path.
+  ``--volume``/``-v`` is now a general-purpose, repeatable bind-mount flag
+  accepting Podman-style ``HOST:CONTAINER[:OPTS]`` specs.
+- **BREAKING:** the old bare form ``-v ./data`` (a value with no colon) is
+  no longer accepted and now errors immediately, suggesting ``--data-volume``.
+- General ``-v`` mounts require an **absolute** container target, reject
+  ``/app/data`` (always occupied by the managed data mount), and **fail loud**
+  when the host path does not exist (no directory is created). ``OPTS`` are
+  passed through **verbatim** — no implicit ``U`` or ``rw`` is added. Relative
+  host paths are still resolved to absolute for local execution.
+- Against a **remote** host, relative host paths for both ``--data-volume`` and
+  ``-v`` are now rejected (they cannot be resolved locally and Podman would
+  silently treat them as named volumes rather than bind mounts). ``-v`` specs
+  are also fully validated before any ``--data-volume`` directory is created, so
+  an invalid ``-v`` no longer leaves a stray directory behind.
+
+AI Assistance
+-------------
+
+- Flag split design, validation rules (fail-loud host existence, absolute
+  target enforcement, ``/app/data`` rejection), implementation, and remote/local
+  branch tests developed with AI assistance.

--- a/src/rots/commands/instance/app.py
+++ b/src/rots/commands/instance/app.py
@@ -2048,13 +2048,20 @@ def shell(
             help="Named volume for persistent data (survives exit)",
         ),
     ] = None,
-    volume: Annotated[
+    data_volume: Annotated[
         str | None,
         cyclopts.Parameter(
-            name=["--volume", "-v"],
+            name=["--data-volume"],
             help="Host path to bind-mount at /app/data (rw, user-mapped)",
         ),
     ] = None,
+    volume: Annotated[
+        tuple[str, ...],
+        cyclopts.Parameter(
+            name=["--volume", "-v"],
+            help="Bind-mount HOST:CONTAINER[:OPTS] (absolute target, repeatable)",
+        ),
+    ] = (),
     env: Annotated[
         tuple[str, ...],
         cyclopts.Parameter(
@@ -2076,16 +2083,19 @@ def shell(
 
     By default uses tmpfs at /app/data (data destroyed on exit).
     Use --persistent to create a named volume that survives exit.
-    Use --volume to bind-mount a host directory at /app/data.
-    Config is mounted read-only at /app/etc.
+    Use --data-volume to bind-mount a host directory at /app/data (rw,U).
+    Use --volume/-v to add general HOST:CONTAINER[:OPTS] bind mounts
+    (absolute container target, host path must exist, opts pass through
+    verbatim). Config is mounted read-only at /app/etc.
 
     Examples:
         ots instance shell                              # tmpfs, interactive bash
         ots instance shell --persistent upgrade-v024    # named volume survives exit
         ots instance shell -c "bin/ots migrate"         # run command and exit
         ots instance shell --tag v0.24.0                # specific image tag
-        ots instance shell -v ./data                    # bind-mount ./data at /app/data
-        ots instance shell -v ./data -e REDIS_URL=redis://10.0.0.5:6379/0  # with env
+        ots instance shell --data-volume ./data         # bind-mount ./data at /app/data (rw,U)
+        ots instance shell -v ./certs:/app/etc/tls:ro   # general read-only mount
+        ots instance shell -v ./a:/app/x -v ./b:/app/y  # repeatable
         ots instance shell -e FOO=bar -e BAZ=qux        # multiple env vars, tmpfs default
         ots instance shell ghcr.io/org/image:v0.24.0     # explicit image ref
     """
@@ -2093,8 +2103,8 @@ def shell(
 
     apply_quiet(quiet)
 
-    if persistent and volume:
-        logger.error("--persistent and --volume are mutually exclusive")
+    if persistent and data_volume:
+        logger.error("--persistent and --data-volume are mutually exclusive")
         raise SystemExit(1)
 
     cfg = Config()
@@ -2142,14 +2152,59 @@ def shell(
 
     cmd.extend(build_env_file_args(env_file, executor=ex))
 
+    # General-purpose bind mounts: HOST:CONTAINER[:OPTS] (fail-loud, no mkdir).
+    # Validate and collect every -v spec BEFORE the --data-volume mkdir side
+    # effect so that an invalid -v cannot leave a stray host/remote directory
+    # behind (validate-before-mutate).
+    volume_args: list[str] = []
+    for spec in volume:
+        parts = spec.split(":", 2)
+        if len(parts) < 2 or parts[0] == "" or parts[1] == "":
+            logger.error(
+                f"-v expects HOST:CONTAINER[:OPTS]; did you mean --data-volume? (got '{spec}')"
+            )
+            raise SystemExit(1)
+        host, container = parts[0], parts[1]
+        opts = parts[2] if len(parts) == 3 else None
+        if not container.startswith("/"):
+            logger.error(f"-v container target must be absolute: {container}")
+            raise SystemExit(1)
+        if container == "/app/data":
+            logger.error("-v cannot target /app/data; use --data-volume")
+            raise SystemExit(1)
+        if isinstance(ex, LocalExecutor):
+            host_path = Path(host).resolve()
+            if not host_path.exists():
+                logger.error(f"host path does not exist: {host_path}")
+                raise SystemExit(1)
+        else:
+            # A remote path cannot be resolved locally; a relative source would
+            # be silently treated by podman as a NAMED VOLUME, not a bind mount.
+            # Require an absolute host path and fail loud otherwise.
+            if not host.startswith("/"):
+                logger.error(f"-v host path must be absolute on remote: {host}")
+                raise SystemExit(1)
+            host_path = Path(host)
+            res = ex.run(["test", "-e", str(host_path)])
+            if not getattr(res, "ok", False):
+                logger.error(f"host path does not exist on remote: {host_path}")
+                raise SystemExit(1)
+        volume_args.extend(["-v", f"{host_path}:{container}" + (f":{opts}" if opts else "")])
+
     # Data volume: bind-mount, persistent named volume, or tmpfs (default)
-    if volume:
+    if data_volume:
         if not isinstance(ex, LocalExecutor):
+            # A remote path cannot be resolved locally; a relative source would
+            # be silently treated by podman as a NAMED VOLUME, not a bind mount.
+            # Require an absolute host path and fail loud before the remote mkdir.
+            if not data_volume.startswith("/"):
+                logger.error(f"--data-volume host path must be absolute on remote: {data_volume}")
+                raise SystemExit(1)
             # Remote: create directory on the remote host, use path as-is
-            host_path = Path(volume)
+            host_path = Path(data_volume)
             ex.run(["mkdir", "-p", str(host_path)])
         else:
-            host_path = Path(volume).resolve()
+            host_path = Path(data_volume).resolve()
             host_path.mkdir(parents=True, exist_ok=True)
         cmd.extend(["-v", f"{host_path}:/app/data:rw,U"])
     elif persistent:
@@ -2157,6 +2212,9 @@ def shell(
         cmd.extend(["-v", f"{volume_name}:/app/data"])
     else:
         cmd.extend(["--tmpfs", "/app/data"])
+
+    # Append the validated general-purpose mounts after the data mount.
+    cmd.extend(volume_args)
 
     # Ad-hoc environment variables
     for entry in env:

--- a/tests/commands/instance/test_shell.py
+++ b/tests/commands/instance/test_shell.py
@@ -81,6 +81,28 @@ def _setup_shell_mocks(mocker, tmp_path, **config_overrides):
     return cfg, mock_executor
 
 
+def _stub_run(mock_executor, host_exists=True, env_ok=False):
+    """Route executor.run() by command so tests are deterministic.
+
+    The mock executor is a plain MagicMock, so isinstance(ex, LocalExecutor)
+    is False and the shell command takes the REMOTE branch: env-file existence
+    uses ``test -f`` and general -v host existence uses ``test -e``. A single
+    shared return_value can't serve both an existing-host mount and a missing
+    env file, so route by the leading command tokens instead.
+    """
+    from types import SimpleNamespace
+
+    def _run(cmd_list, *args, **kwargs):
+        head = list(cmd_list[:2])
+        if head == ["test", "-f"]:
+            return SimpleNamespace(ok=env_ok)
+        if head == ["test", "-e"]:
+            return SimpleNamespace(ok=host_exists)
+        return SimpleNamespace(ok=True)
+
+    mock_executor.run.side_effect = _run
+
+
 def _get_cmd_from_executor(mock_executor, interactive=True):
     """Extract the command list from the executor mock's call args."""
     if interactive:
@@ -481,6 +503,157 @@ class TestShellPrivateRegistry:
         assert f"{DEFAULT_IMAGE}:edge" in cmd
 
 
+class TestShellVolumes:
+    """Test --data-volume and general -v/--volume handling.
+
+    NOTE: the mock executor is a plain MagicMock, so the shell command takes
+    the REMOTE branch (Path used verbatim, remote ``mkdir -p`` for
+    --data-volume, remote ``test -e`` for general -v host existence).
+    """
+
+    def test_data_volume_mounts_app_data_and_mkdirs(self, mocker, tmp_path):
+        """--data-volume bind-mounts at /app/data (rw,U) and mkdirs on remote."""
+        _mock_config, mock_executor = _setup_shell_mocks(mocker, tmp_path)
+
+        instance.shell(data_volume="/host/data", quiet=True)
+
+        cmd = _get_cmd_from_executor(mock_executor, interactive=True)
+        assert "/host/data:/app/data:rw,U" in cmd
+        assert "--tmpfs" not in cmd
+        # Remote branch creates the host directory
+        mock_executor.run.assert_any_call(["mkdir", "-p", "/host/data"])
+
+    def test_general_volume_passes_through_verbatim(self, mocker, tmp_path):
+        """-v HOST:CONTAINER[:OPTS] is passed through verbatim (incl :ro)."""
+        _mock_config, mock_executor = _setup_shell_mocks(mocker, tmp_path)
+        _stub_run(mock_executor, host_exists=True)
+
+        instance.shell(volume=("/host/certs:/app/etc/tls:ro",), quiet=True)
+
+        cmd = _get_cmd_from_executor(mock_executor, interactive=True)
+        assert "/host/certs:/app/etc/tls:ro" in cmd
+        # No implicit U or rw added
+        assert not any("/app/etc/tls:rw" in part for part in cmd)
+
+    def test_general_volume_repeatable(self, mocker, tmp_path):
+        """Repeatable -v yields one mount arg per spec."""
+        _mock_config, mock_executor = _setup_shell_mocks(mocker, tmp_path)
+        _stub_run(mock_executor, host_exists=True)
+
+        instance.shell(volume=("/host/a:/app/x", "/host/b:/app/y"), quiet=True)
+
+        cmd = _get_cmd_from_executor(mock_executor, interactive=True)
+        assert "/host/a:/app/x" in cmd
+        assert "/host/b:/app/y" in cmd
+        # tmpfs default (no -v for data), config none => exactly two -v
+        assert cmd.count("-v") == 2
+
+    def test_general_volume_rejects_relative_target(self, mocker, tmp_path, capsys):
+        """Non-absolute container target is rejected."""
+        _mock_config, _mock_executor = _setup_shell_mocks(mocker, tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            instance.shell(volume=("/host/certs:relative/path",), quiet=True)
+
+        assert exc_info.value.code == 1
+        assert "must be absolute" in capsys.readouterr().err
+
+    def test_general_volume_rejects_bare_form(self, mocker, tmp_path, capsys):
+        """Bare -v ./data (no colon) is rejected with a --data-volume hint."""
+        _mock_config, _mock_executor = _setup_shell_mocks(mocker, tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            instance.shell(volume=("./data",), quiet=True)
+
+        assert exc_info.value.code == 1
+        assert "--data-volume" in capsys.readouterr().err
+
+    def test_general_volume_rejects_app_data_target(self, mocker, tmp_path, capsys):
+        """-v targeting /app/data is rejected in favor of --data-volume."""
+        _mock_config, _mock_executor = _setup_shell_mocks(mocker, tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            instance.shell(volume=("/host/data:/app/data",), quiet=True)
+
+        assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "/app/data" in err
+        assert "--data-volume" in err
+
+    def test_general_volume_missing_host_fails_loud(self, mocker, tmp_path, capsys):
+        """Missing host path fails loud (no mkdir)."""
+        _mock_config, mock_executor = _setup_shell_mocks(mocker, tmp_path)
+        _stub_run(mock_executor, host_exists=False)
+
+        with pytest.raises(SystemExit) as exc_info:
+            instance.shell(volume=("/host/missing:/app/x",), quiet=True)
+
+        assert exc_info.value.code == 1
+        assert "does not exist" in capsys.readouterr().err
+
+    def test_general_volume_rejects_relative_host_on_remote(self, mocker, tmp_path, capsys):
+        """Relative -v host is rejected on remote (would become a named volume)."""
+        _mock_config, mock_executor = _setup_shell_mocks(mocker, tmp_path)
+        _stub_run(mock_executor, host_exists=True)
+
+        with pytest.raises(SystemExit) as exc_info:
+            instance.shell(volume=("./certs:/app/etc/tls:ro",), quiet=True)
+
+        assert exc_info.value.code == 1
+        assert "must be absolute on remote" in capsys.readouterr().err
+
+    def test_data_volume_rejects_relative_host_on_remote(self, mocker, tmp_path, capsys):
+        """Relative --data-volume host is rejected on remote (no mkdir)."""
+        _mock_config, mock_executor = _setup_shell_mocks(mocker, tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            instance.shell(data_volume="./data", quiet=True)
+
+        assert exc_info.value.code == 1
+        assert "must be absolute on remote" in capsys.readouterr().err
+        # Rejection happens before the remote mkdir side effect
+        mkdir_calls = [
+            c for c in mock_executor.run.call_args_list if list(c.args[0][:2]) == ["mkdir", "-p"]
+        ]
+        assert mkdir_calls == []
+
+    def test_invalid_general_volume_aborts_before_data_volume_mkdir(self, mocker, tmp_path):
+        """An invalid -v aborts before the --data-volume mkdir (validate-before-mutate)."""
+        _mock_config, mock_executor = _setup_shell_mocks(mocker, tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            instance.shell(data_volume="/host/data", volume=("/bad",), quiet=True)
+
+        assert exc_info.value.code == 1
+        # No mkdir side effect for --data-volume should have run
+        mkdir_calls = [
+            c for c in mock_executor.run.call_args_list if list(c.args[0][:2]) == ["mkdir", "-p"]
+        ]
+        assert mkdir_calls == []
+
+    def test_persistent_and_data_volume_mutually_exclusive(self, mocker, tmp_path, capsys):
+        """--persistent and --data-volume both target /app/data and cannot combine."""
+        _mock_config, _mock_executor = _setup_shell_mocks(mocker, tmp_path)
+
+        with pytest.raises(SystemExit) as exc_info:
+            instance.shell(persistent="upgrade-v024", data_volume="/host/data", quiet=True)
+
+        assert exc_info.value.code == 1
+        assert "mutually exclusive" in capsys.readouterr().err
+
+    def test_persistent_allows_general_volume(self, mocker, tmp_path):
+        """--persistent is NOT mutually exclusive with the general -v flag."""
+        _mock_config, mock_executor = _setup_shell_mocks(mocker, tmp_path)
+        _stub_run(mock_executor, host_exists=True)
+
+        instance.shell(persistent="upgrade-v024", volume=("/host/x:/app/x",), quiet=True)
+
+        cmd = _get_cmd_from_executor(mock_executor, interactive=True)
+        joined = " ".join(cmd)
+        assert "ots-migration-upgrade-v024:/app/data" in joined
+        assert "/host/x:/app/x" in joined
+
+
 class TestShellHelp:
     """Test shell command help output."""
 
@@ -492,8 +665,11 @@ class TestShellHelp:
             app(["instance", "shell", "--help"])
         assert exc_info.value.code == 0
         captured = capsys.readouterr()
-        assert "persistent" in captured.out.lower()
-        assert "tmpfs" in captured.out.lower() or "ephemeral" in captured.out.lower()
+        out = captured.out.lower()
+        assert "persistent" in out
+        assert "tmpfs" in out or "ephemeral" in out
+        assert "data-volume" in out
+        assert "host:container" in out
 
 
 class TestBuildEnvFileArgs:


### PR DESCRIPTION
## Summary

Splits `rots instance shell`'s single `--volume`/`-v` flag into two distinct flags (#78):

- **`--data-volume`** (long form only, no short alias) keeps the previous behavior: bind-mount a host directory at the fixed `/app/data` target as `rw,U`, auto-creating the host path.
- **`--volume`/`-v`** becomes a general-purpose, **repeatable** bind-mount flag taking Podman-style `HOST:CONTAINER[:OPTS]` specs.

## Behavior & guardrails

General `-v` mounts:
- require an **absolute** container target;
- reject `/app/data` (always occupied by the managed data mount);
- **fail loud** when the host path does not exist — no directory is created;
- pass `OPTS` through **verbatim** (no implicit `U` or `rw`);
- resolve relative host paths to absolute for local execution.

Against a **remote** host, relative host paths for both `--data-volume` and `-v` are rejected (Podman would silently treat them as named volumes rather than bind mounts). All `-v` specs are fully validated **before** any `--data-volume` directory is created (validate-before-mutate), so an invalid `-v` no longer leaves a stray directory behind.

`--persistent` remains mutually exclusive with `--data-volume` (both target `/app/data`) but is allowed alongside general `-v` mounts.

## ⚠️ Breaking change

The old bare form `-v ./data` (a value with no colon) is no longer accepted; it now errors immediately and suggests `--data-volume`.

## Tests

Adds `TestShellVolumes` covering data-volume mounting/remote mkdir, verbatim pass-through, repeatability, absolute-target enforcement, bare-form and `/app/data` rejection, fail-loud missing host, remote relative-host rejection, validate-before-mutate ordering, and `--persistent` exclusivity. Full `test_shell.py` suite: 45 passing.

Rebased on latest `main` (includes #76/#77 secret-injection work).